### PR TITLE
Detect same-prefix conflicts within complementary groups

### DIFF
--- a/src/rules/no-conflicting-classes.ts
+++ b/src/rules/no-conflicting-classes.ts
@@ -62,10 +62,14 @@ export const noConflictingClasses = defineRule({
           // Most composition is detected automatically via CSS custom properties
           // (see isCompositionViaCssVars below). These groups cover cases where
           // the heuristic fails: shared intermediate vars or missing custom props.
+          // A capture group marks the utility prefix: same-prefix pairs (e.g.
+          // duration-300 / duration-500) fall through to the overlap check so
+          // they still conflict, only cross-prefix pairs compose. No capture
+          // group means "always compose within group" (e.g. prose).
           const COMPLEMENTARY_GROUPS = [
-            /^(?:from|via|to)-/, // gradient stops (share --tw-gradient-stops)
-            /^(?:transition|duration|ease|delay)(?:-|$)/, // transition composition (transition-all has no custom vars)
-            /^-?(?:translate|scale|rotate|skew)-/, // transform axis composition (overlap not in cssProps)
+            /^(from|via|to)-/, // gradient stops (share --tw-gradient-stops)
+            /^(transition|duration|ease|delay)(?:-|$)/, // transition composition (transition-all has no custom vars)
+            /^-?(translate|scale|rotate|skew)-/, // transform axis composition (overlap not in cssProps)
             /^prose(?:-|$)/, // prose + prose-sm/lg/xl modifiers
           ]
           // Pairs where one utility sets defaults and the other overrides a specific property
@@ -104,7 +108,13 @@ export const noConflictingClasses = defineRule({
             else if (ub.endsWith('!')) ub = ub.slice(0, -1)
             // Complementary utilities within the same group
             for (const re of COMPLEMENTARY_GROUPS) {
-              if (re.test(ua) && re.test(ub)) return true
+              const ma = ua.match(re)
+              const mb = ub.match(re)
+              if (!ma || !mb) continue
+              // No capture group: always compose within group
+              if (ma[1] === undefined) return true
+              // Different prefix: compose; same prefix: fall through to overlap check
+              if (ma[1] !== mb[1]) return true
             }
             // Composition pairs where one sets defaults and the other overrides
             for (const [reA, reB] of COMPOSITION_PAIRS) {

--- a/tests/rules/no-conflicting-classes.test.ts
+++ b/tests/rules/no-conflicting-classes.test.ts
@@ -131,6 +131,81 @@ ruleTester.run('no-conflicting-classes', noConflictingClasses, {
       filename: 'test.tsx',
       errors: [{ messageId: 'conflict' }],
     },
+    {
+      code: '<div className="duration-300 duration-500" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="from-red-500 from-blue-500" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="translate-x-1 translate-x-2" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="transition-all transition-colors" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="hover:duration-300 hover:duration-500" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="!duration-300 !duration-500" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="duration-300! duration-500!" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="translate-x-1 -translate-x-2" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="ease-in ease-out" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="delay-100 delay-200" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="via-red-500 via-blue-500" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="to-red-500 to-blue-500" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="scale-50 scale-75" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="rotate-45 rotate-90" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      code: '<div className="skew-x-1 skew-x-2" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
   ],
 })
 


### PR DESCRIPTION
## Summary
`COMPLEMENTARY_GROUPS` in `no-conflicting-classes` was treating any pair of
classes matching the same group regex as composition, including pairs that
share a prefix and genuinely conflict. `isCompositionViaCssVars` does not
catch these because the two classes set the same custom property.
Examples that were silently passing:
- `duration-300 duration-500`
- `from-red-500 from-blue-500`
- `translate-x-1 translate-x-2`
- `ease-in ease-out`, `delay-100 delay-200`
- `scale-50 scale-75`, `rotate-45 rotate-90`, `skew-x-1 skew-x-2`
## Fix
Add a capture group to each cross-prefix group regex so `shouldSkipPair` can
compare the captured prefixes: different prefix → composition (skip), same
prefix → fall through to the overlap check and report the conflict.
The `prose` group keeps its no-capture form (`/^prose(?:-|$)/`) to preserve
the existing "always compose within group" behavior for `prose-sm` / `-lg` /
`-xl` modifiers. The non-capturing `-?` on the transform regex is
intentional: negative variants flip value sign but target the same axis, so
they share the captured prefix and conflict (`translate-x-1` vs
`-translate-x-2`).
## Test coverage
13 new invalid cases covering:
- Every same-prefix variant in each affected group
- Variant-scoped (`hover:duration-300 hover:duration-500`)
- Both important forms (`!duration-*` and `duration-*!`)
- Negative same-axis transforms
All cases validated against Tailwind v4 docs as genuine conflicts. Existing
valid composition cases (`from-X to-Y`, `transition-all duration-N`,
`translate-x-N -translate-y-N`, `scale-x-N scale-y-N`, `prose prose-sm`) are
preserved.
## Verification
- `pnpm test` — 867/867 pass
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm format` — applied