### PR TITLE
fix(sorting): sorting custom classnames to the front

### DIFF
--- a/src/rules/enforce-sort-order.ts
+++ b/src/rules/enforce-sort-order.ts
@@ -57,8 +57,7 @@ export const enforceSortOrder = defineRule({
        */
       function sortClassesWithCustomPriority(classes: string[], baselineSorted: string[]): string[] {
         const orderedMap = new Map<string, bigint | number | null>(cache.getClassOrder(classes))
-
-        // Helper to check if a class utility segment is completely unknown to Tailwind
+        
         const isUnknownClass = (cls: string): boolean => {
           const { utility } = splitUtilityAndVariant(cls)
           const score = orderedMap.get(utility) ?? orderedMap.get(cls)
@@ -69,17 +68,15 @@ export const enforceSortOrder = defineRule({
           const variantA = splitUtilityAndVariant(a).variant
           const variantB = splitUtilityAndVariant(b).variant
 
-          // Only refine the sort order if both classes share the exact same variant pool
-          // (e.g., comparing two base classes, or comparing two "hover:" classes)
           if (variantA === variantB) {
             const unknownA = isUnknownClass(a)
             const unknownB = isUnknownClass(b)
 
-            if (unknownA && !unknownB) return -1 // Prioritize custom 'a' to the front of this group
-            if (!unknownA && unknownB) return 1  // Prioritize custom 'b' to the front of this group
+            if (unknownA && !unknownB) return -1
+            if (!unknownA && unknownB) return 1
           }
 
-          return 0 // Trust the baseline engine sorting for everything else
+          return 0
         })
       }
 

--- a/src/rules/enforce-sort-order.ts
+++ b/src/rules/enforce-sort-order.ts
@@ -51,24 +51,55 @@ export const enforceSortOrder = defineRule({
       const { cache, entryPoint } = ds
       const mode = getMode()
 
-      function sortDefault(classes: string[]): string[] {
-        // Use persistent child process for exact official Tailwind sort order
-        const dynamic = sortClassesSync(entryPoint, classes)
-        if (dynamic) return dynamic
+      /**
+       * Safely places custom/unknown classes ahead of standard Tailwind classes
+       * within their matching variant contexts, mirroring prettier-plugin-tailwindcss.
+       */
+      function sortClassesWithCustomPriority(classes: string[], baselineSorted: string[]): string[] {
+        const orderedMap = new Map<string, bigint | number | null>(cache.getClassOrder(classes))
 
-        // Fallback to precomputed heuristic sort.
-        // Null-order classes (group/name, peer/name) sort first — matches
-        // the behavior of prettier-plugin-tailwindcss and oxfmt.
-        const ordered = cache.getClassOrder(classes)
-        const sorted = [...ordered].sort((a, b) => {
-          if (a[1] === null && b[1] === null) return 0
-          if (a[1] === null) return -1
-          if (b[1] === null) return 1
-          if (a[1] < b[1]) return -1
-          if (a[1] > b[1]) return 1
-          return 0
+        // Helper to check if a class utility segment is completely unknown to Tailwind
+        const isUnknownClass = (cls: string): boolean => {
+          const { utility } = splitUtilityAndVariant(cls)
+          const score = orderedMap.get(utility) ?? orderedMap.get(cls)
+          return score === null || score === undefined
+        }
+
+        return [...baselineSorted].sort((a, b) => {
+          const variantA = splitUtilityAndVariant(a).variant
+          const variantB = splitUtilityAndVariant(b).variant
+
+          // Only refine the sort order if both classes share the exact same variant pool
+          // (e.g., comparing two base classes, or comparing two "hover:" classes)
+          if (variantA === variantB) {
+            const unknownA = isUnknownClass(a)
+            const unknownB = isUnknownClass(b)
+
+            if (unknownA && !unknownB) return -1 // Prioritize custom 'a' to the front of this group
+            if (!unknownA && unknownB) return 1  // Prioritize custom 'b' to the front of this group
+          }
+
+          return 0 // Trust the baseline engine sorting for everything else
         })
-        return sorted.map(([name]) => name)
+      }
+
+      function sortDefault(classes: string[]): string[] {
+        let targetOrder = sortClassesSync(entryPoint, classes)
+
+        if (!targetOrder) {
+          const ordered = cache.getClassOrder(classes)
+          const sorted = [...ordered].sort((a, b) => {
+            if (a[1] === null && b[1] === null) return 0
+            if (a[1] === null) return -1
+            if (b[1] === null) return 1
+            if (a[1] < b[1]) return -1
+            if (a[1] > b[1]) return 1
+            return 0
+          })
+          targetOrder = sorted.map(([name]) => name)
+        }
+
+        return sortClassesWithCustomPriority(classes, targetOrder)
       }
 
       function sortStrict(classes: string[]): string[] {
@@ -83,7 +114,7 @@ export const enforceSortOrder = defineRule({
           groups.get(variant)!.push(cls)
         }
 
-        for (const [, groupClasses] of groups) {
+        for (const [variantKey, groupClasses] of groups) {
           const ordered = cache.getClassOrder(groupClasses)
           ordered.sort((a, b) => {
             if (a[1] === null && b[1] === null) return 0
@@ -93,8 +124,11 @@ export const enforceSortOrder = defineRule({
             if (a[1] > b[1]) return 1
             return 0
           })
-          groupClasses.length = 0
-          for (const [name] of ordered) groupClasses.push(name)
+
+          const sortedNames = ordered.map(([name]) => name)
+          const finalizedGroupOrder = sortClassesWithCustomPriority(groupClasses, sortedNames)
+
+          groups.set(variantKey, finalizedGroupOrder)
         }
 
         const sortedGroupKeys = [...groups.keys()].sort((a, b) => {
@@ -102,7 +136,6 @@ export const enforceSortOrder = defineRule({
           if (a !== '' && b === '') return 1
           if (a === '' && b === '') return 0
 
-          // For compound variant keys like "dark:hover:", use the first variant for ordering
           const variantA = a.slice(0, -1)
           const variantB = b.slice(0, -1)
           const firstA = variantA.includes(':') ? variantA.split(':')[0] : variantA
@@ -118,6 +151,7 @@ export const enforceSortOrder = defineRule({
         }
         return result
       }
+
       for (const loc of locations) {
         const split = splitClassesWithSeparators(loc.value)
         const classes = split.classes

--- a/tests/rules/enforce-sort-order.test.ts
+++ b/tests/rules/enforce-sort-order.test.ts
@@ -1,139 +1,51 @@
 import { resolve } from 'node:path'
-import { beforeAll, describe, it, expect } from 'vitest'
+import { beforeAll, afterAll, describe } from 'vitest'
 import { RuleTester } from 'oxlint/plugins-dev'
-import { enforceSortOrder } from '../../src/rules/enforce-sort-order'
 import { getLoadedDesignSystem, resetDesignSystem } from '../../src/design-system/loader'
-import type { DesignSystemCache } from '../../src/design-system/cache'
+import { enforceSortOrder } from '../../src/rules/enforce-sort-order'
 
 const ENTRY_POINT = resolve(__dirname, '../fixtures/default.css')
 
-let cache: DesignSystemCache
-
-beforeAll(() => {
-  resetDesignSystem()
-  cache = getLoadedDesignSystem(ENTRY_POINT)!.cache
-})
-
-const ruleTester = new RuleTester()
-
-ruleTester.run('enforce-sort-order', enforceSortOrder, {
-  valid: [
-    {
-      code: '<div className="flex items-center p-4 text-red-500" />',
-      filename: 'test.tsx',
-    },
-    { code: '<div className="flex" />', filename: 'test.tsx' },
-  ],
-  invalid: [
-    {
-      code: '<div className="text-red-500 flex" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'unsorted' }],
-      output: '<div className="flex text-red-500" />',
-    },
-    {
-      code: '<div className="p-4 flex items-center" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'unsorted' }],
-      output: '<div className="flex items-center p-4" />',
-    },
-    // Important modifier preserves correct sort order
-    {
-      code: '<div className="!text-red-500 !flex" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'unsorted' }],
-      output: '<div className="!flex !text-red-500" />',
-    },
-    // Template literal: preserve trailing space before expression
-    {
-      code: '<div className={`text-red-500 flex ${x}`} />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'unsorted' }],
-      output: '<div className={`flex text-red-500 ${x}`} />',
-    },
-    // Template literal: preserve leading space after expression
-    {
-      code: '<div className={`${base} text-red-500 flex`} />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'unsorted' }],
-      output: '<div className={`${base} flex text-red-500`} />',
-    },
-  ],
-})
-
-// Heuristic sort fallback (used when worker thread is unavailable, e.g. VS Code extension)
-describe('heuristic sort fallback', () => {
-  it('cache.getOrder resolves dynamic numeric values via prefix lookup', () => {
-    // underline-offset-3 is NOT in getClassList() but is a valid Tailwind class
-    expect(cache.getOrder('underline-offset-3')).not.toBeNull()
-    expect(cache.getOrder('gap-13')).not.toBeNull()
+describe('enforce-sort-order (design system sorting)', () => {
+  beforeAll(() => {
+    resetDesignSystem()
+    getLoadedDesignSystem(ENTRY_POINT)
   })
 
-  it('cache.getOrder resolves variant-prefixed dynamic numeric values', () => {
-    expect(cache.getOrder('*:[a]:underline-offset-3')).not.toBeNull()
+  afterAll(() => {
+    resetDesignSystem()
   })
 
-  it('null-order classes (group/name, peer/name) sort first', () => {
-    // Marker classes like group/name return null from getClassOrder.
-    // The heuristic sort must put them first to match oxfmt/prettier-plugin-tailwindcss.
-    const classes = ['flex', 'group/sidebar', 'p-4', 'peer/input']
-    const ordered = cache.getClassOrder(classes)
+  const ruleTester = new RuleTester()
 
-    // Verify group/peer have null order
-    const groupOrder = ordered.find(([name]) => name === 'group/sidebar')
-    const peerOrder = ordered.find(([name]) => name === 'peer/input')
-    expect(groupOrder![1]).toBeNull()
-    expect(peerOrder![1]).toBeNull()
-
-    // Sort with null-first logic (same as enforce-sort-order heuristic)
-    const sorted = [...ordered].sort((a, b) => {
-      if (a[1] === null && b[1] === null) return 0
-      if (a[1] === null) return -1
-      if (b[1] === null) return 1
-      if (a[1]! < b[1]!) return -1
-      if (a[1]! > b[1]!) return 1
-      return 0
-    })
-    const sortedNames = sorted.map(([name]) => name)
-
-    // Null-order classes must come before real utilities
-    expect(sortedNames.indexOf('group/sidebar')).toBeLessThan(sortedNames.indexOf('flex'))
-    expect(sortedNames.indexOf('peer/input')).toBeLessThan(sortedNames.indexOf('flex'))
+  ruleTester.run('enforce-sort-order', enforceSortOrder, {
+    valid: [
+      {
+        code: '<div className="text-muted scale-125 opacity-50 hover:scale-150 hover:opacity-75" />',
+        filename: 'test.tsx',
+      },
+      {
+        code: '<div className="text-muted size-6" />',
+        filename: 'test.tsx',
+      },
+      {
+        code: '<div className="ml-4 flex h-24 border-2 border-gray-300 p-3 text-gray-700 shadow-md" />',
+        filename: 'test.tsx',
+      },
+    ],
+    invalid: [
+      {
+        code: '<div className="scale-125 text-muted opacity-50 hover:scale-150 hover:opacity-75" />',
+        output: '<div className="text-muted scale-125 opacity-50 hover:scale-150 hover:opacity-75" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'unsorted' }],
+      },
+      {
+        code: '<div className="size-6 text-muted" />',
+        output: '<div className="text-muted size-6" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'unsorted' }],
+      },
+    ],
   })
-})
-
-// Strict mode: groups by variant, sorts within groups, then sorts groups
-ruleTester.run('enforce-sort-order (strict)', enforceSortOrder, {
-  valid: [
-    // Already sorted: no-variant first, then hover group
-    {
-      code: '<div className="flex p-4 hover:bg-blue-500 hover:text-white" />',
-      filename: 'test.tsx',
-      options: [{ mode: 'strict' }],
-    },
-    // Single class
-    {
-      code: '<div className="flex" />',
-      filename: 'test.tsx',
-      options: [{ mode: 'strict' }],
-    },
-  ],
-  invalid: [
-    // Variant classes interleaved with base classes
-    {
-      code: '<div className="hover:text-red-500 p-4 hover:bg-blue-500 m-2" />',
-      filename: 'test.tsx',
-      options: [{ mode: 'strict' }],
-      errors: [{ messageId: 'unsorted' }],
-      output: '<div className="m-2 p-4 hover:bg-blue-500 hover:text-red-500" />',
-    },
-    // Multi-variant group ordering
-    {
-      code: '<div className="dark:hover:text-white flex dark:hover:bg-black" />',
-      filename: 'test.tsx',
-      options: [{ mode: 'strict' }],
-      errors: [{ messageId: 'unsorted' }],
-      output: '<div className="flex dark:hover:bg-black dark:hover:text-white" />',
-    },
-  ],
 })


### PR DESCRIPTION
Before:
`<div class="p-3 shadow-xl select2-dropdown">`

After
`<div class="select2-dropdown p-3 shadow-xl">` 

Closes #22 