### PR TITLE
feat(enforce-shorthand): variant-aware merges and px+py → p

### DIFF
--- a/packages/docs/rules/enforce-shorthand.md
+++ b/packages/docs/rules/enforce-shorthand.md
@@ -39,6 +39,8 @@ is more a job for the upstream Tailwind project.
 // Two-axis (vertical, horizontal)
 <div className="mt-2 mb-2" />  →  my-2
 <div className="ml-2 mr-2" />  →  mx-2
+<div className="px-4 py-4" />  →  p-4
+<div className="mx-2 my-2" />  →  m-2
 
 // Width + height with the same value
 <div className="w-full h-full" />
@@ -64,8 +66,9 @@ is more a job for the upstream Tailwind project.
 // Partial coverage — needs all four sides for m-*
 <div className="mt-2 mr-2" />
 
-// Different variants — rule doesn't merge across variant chains
+// Different variants on each part — no merge (same variant prefix required)
 <div className="hover:mt-2 focus:mb-2" />
+<div className="sm:px-4 md:py-4" />
 ```
 
 ## Interactions with other rules

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -522,6 +522,8 @@ Suggests shorthand classes when all axes have the same value.
 "pt-4 pr-4 pb-4 pl-4"  → "p-4"
 "pt-4 pb-4"             → "py-4"
 "pl-4 pr-4"             → "px-4"
+"px-4 py-4"             → "p-4"
+"mx-2 my-2"             → "m-2"
 "w-full h-full"         → "size-full"
 "rounded-tl-lg rounded-tr-lg rounded-br-lg rounded-bl-lg" → "rounded-lg"
 ```

--- a/packages/oxlint-tailwindcss/src/rules/enforce-shorthand.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-shorthand.ts
@@ -1,9 +1,10 @@
 import { defineRule } from '@oxlint/plugins'
 import { createExtractorVisitors, preserveSpaces, type ClassLocation } from '../utils/extractors'
 import { rebuildClassString, splitClassesWithSeparators } from '../utils/class-splitter'
-import { splitImportant } from '../utils/class-parser'
+import { splitImportant, splitUtilityAndVariant } from '../utils/class-parser'
 
-const VALUE_RE = /^(?:m[trbl]|p[trbl]|[wh]|rounded-t[lr]|rounded-b[lr]|min-[wh]|max-[wh])-(.+)$/
+const VALUE_RE =
+  /^(?:m[trbl]|mx|my|p[trbl]|px|py|[wh]|rounded-t[lr]|rounded-b[lr]|min-[wh]|max-[wh])-(.+)$/
 
 // Values where w-X + h-X should NOT merge to size-X (different CSS units per axis)
 const INVALID_SIZE_VALUES = new Set(['screen', 'dvw', 'dvh', 'svw', 'svh', 'lvw', 'lvh'])
@@ -32,6 +33,10 @@ function createShorthandRules(value: string): ShorthandRule[] {
       replacement: `mx-${value}`,
     },
     {
+      parts: [`mx-${value}`, `my-${value}`],
+      replacement: `m-${value}`,
+    },
+    {
       parts: [`pt-${value}`, `pr-${value}`, `pb-${value}`, `pl-${value}`],
       replacement: `p-${value}`,
     },
@@ -42,6 +47,10 @@ function createShorthandRules(value: string): ShorthandRule[] {
     {
       parts: [`pl-${value}`, `pr-${value}`],
       replacement: `px-${value}`,
+    },
+    {
+      parts: [`px-${value}`, `py-${value}`],
+      replacement: `p-${value}`,
     },
     // w-* + h-* → size-* only when both produce the same CSS value
     // Exclude viewport units where w/h use different axes (vw vs vh)
@@ -81,37 +90,45 @@ export const enforceShorthand = defineRule({
 
         const classSet = new Set(classes)
 
-        // Extract all unique values used in the classes (strip ! for matching).
-        const values = new Set<string>()
+        // Extract unique (variant prefix, value) pairs — variants must match across parts.
+        const variantValues = new Set<string>()
         for (const cls of classes) {
-          const match = VALUE_RE.exec(splitImportant(cls).bare)
-          if (match) values.add(match[1])
+          const { utility, variant } = splitUtilityAndVariant(cls)
+          const match = VALUE_RE.exec(splitImportant(utility).bare)
+          if (match) variantValues.add(`${variant}\0${match[1]}`)
         }
 
-        for (const value of values) {
+        for (const variantValue of variantValues) {
+          const nul = variantValue.indexOf('\0')
+          const variant = variantValue.slice(0, nul)
+          const value = variantValue.slice(nul + 1)
           const rules = createShorthandRules(value)
 
           for (const rule of rules) {
+            const withVariant = (p: string) => `${variant}${p}`
             // Check with ! modifier: all parts must share the same modifier
-            const hasImportantPrefix = rule.parts.every((p) => classSet.has(`!${p}`))
+            const hasImportantPrefix = rule.parts.every((p) => classSet.has(withVariant(`!${p}`)))
             const hasImportantSuffix =
-              !hasImportantPrefix && rule.parts.every((p) => classSet.has(`${p}!`))
-            const hasPlain = rule.parts.every((p) => classSet.has(p))
+              !hasImportantPrefix &&
+              rule.parts.every((p) => classSet.has(withVariant(`${p}!`)))
+            const hasPlain = rule.parts.every((p) => classSet.has(withVariant(p)))
 
             if (!hasImportantPrefix && !hasImportantSuffix && !hasPlain) continue
 
             const importantStart = hasImportantPrefix ? '!' : ''
             const importantEnd = hasImportantSuffix ? '!' : ''
-            const matchParts = rule.parts.map((p) => `${importantStart}${p}${importantEnd}`)
+            const matchParts = rule.parts.map((p) =>
+              withVariant(`${importantStart}${p}${importantEnd}`),
+            )
             const remaining = classes.filter((c) => !matchParts.includes(c))
-            remaining.push(`${importantStart}${rule.replacement}${importantEnd}`)
+            remaining.push(withVariant(`${importantStart}${rule.replacement}${importantEnd}`))
 
             context.report({
               node: loc.node,
               messageId: 'shorthand',
               data: {
                 parts: matchParts.map((p) => `"${p}"`).join(', '),
-                replacement: `${importantStart}${rule.replacement}${importantEnd}`,
+                replacement: withVariant(`${importantStart}${rule.replacement}${importantEnd}`),
               },
               fix(fixer) {
                 return fixer.replaceTextRange(

--- a/packages/oxlint-tailwindcss/tests/rules/enforce-shorthand.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/enforce-shorthand.test.ts
@@ -13,13 +13,20 @@ ruleTester.run('enforce-shorthand', enforceShorthand, {
     { code: '<div className="w-screen h-screen" />', filename: 'test.tsx' },
     // Shorthand with different variants should NOT be merged
     { code: '<div className="hover:mt-2 focus:mb-2" />', filename: 'test.tsx' },
+    { code: '<div className="sm:h-4 md:w-4" />', filename: 'test.tsx' },
     // Partial axes with different values
     { code: '<div className="mt-2 mb-4" />', filename: 'test.tsx' },
-    // Same variant on all axes — rule does not handle variants, so this is valid
-    {
-      code: '<div className="hover:mt-2 hover:mr-2 hover:mb-2 hover:ml-2" />',
-      filename: 'test.tsx',
-    },
+    { code: '<div className="px-4 py-2" />', filename: 'test.tsx' },
+    { code: '<div className="mx-4 my-2" />', filename: 'test.tsx' },
+    { code: '<div className="px-4" />', filename: 'test.tsx' },
+    { code: '<div className="py-4" />', filename: 'test.tsx' },
+    { code: '<div className="p-4" />', filename: 'test.tsx' },
+    { code: '<div className="m-4" />', filename: 'test.tsx' },
+    // Axis shorthands with mismatched variants
+    { code: '<div className="sm:px-4 md:py-4" />', filename: 'test.tsx' },
+    { code: '<div className="hover:px-4 focus:py-4" />', filename: 'test.tsx' },
+    // Single axis pair without its partner — no px+py → p-*
+    { code: '<div className="px-4 pt-4" />', filename: 'test.tsx' },
   ],
   invalid: [
     {
@@ -46,11 +53,78 @@ ruleTester.run('enforce-shorthand', enforceShorthand, {
       errors: [{ messageId: 'shorthand' }, { messageId: 'shorthand' }, { messageId: 'shorthand' }],
       output: '<div className="p-4" />',
     },
+    // Axis pair shorthands → full shorthand (px+py, mx+my)
+    {
+      code: '<div className="px-4 py-4" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="p-4" />',
+    },
+    {
+      code: '<div className="py-4 px-4" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="p-4" />',
+    },
+    {
+      code: '<div className="mx-2 my-2" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="m-2" />',
+    },
+    {
+      code: '<div className="flex px-4 py-4 gap-2" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="flex gap-2 p-4" />',
+    },
+    {
+      code: '<div className="sm:px-4 sm:py-4" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="sm:p-4" />',
+    },
+    {
+      code: '<div className="hover:mx-4 hover:my-4" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="hover:m-4" />',
+    },
+    {
+      code: '<div className="!px-4 !py-4" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="!p-4" />',
+    },
+    {
+      code: '<div className="px-4! py-4!" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="p-4!" />',
+    },
+    {
+      code: '<div className={`px-4 py-4 ${extra}`} />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className={`p-4 ${extra}`} />',
+    },
     {
       code: '<div className="w-full h-full" />',
       filename: 'test.tsx',
       errors: [{ messageId: 'shorthand' }],
       output: '<div className="size-full" />',
+    },
+    {
+      code: '<div className="sm:h-4 sm:w-4" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }],
+      output: '<div className="sm:size-4" />',
+    },
+    {
+      code: '<div className="hover:mt-2 hover:mr-2 hover:mb-2 hover:ml-2" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'shorthand' }, { messageId: 'shorthand' }, { messageId: 'shorthand' }],
+      output: '<div className="hover:m-2" />',
     },
     // Template literal: preserve trailing space before expression
     {


### PR DESCRIPTION
## Summary

Closes #27.

- **Variant-aware shorthand** — parts must share the same variant prefix (`sm:h-4 sm:w-4` → `sm:size-4`; `hover:mt-2 focus:mb-2` still does not merge).
- **Axis pair → full shorthand** — `px-4 py-4` → `p-4`, `mx-2 my-2` → `m-2` (parity with [eslint-plugin-tailwindcss `enforces-shorthand`](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/enforces-shorthand.md)).
- Extended `VALUE_RE` so `px`/`py`/`mx`/`my` utilities participate in value discovery.

## Test plan

- [x] `pnpm -C packages/oxlint-tailwindcss exec vitest run tests/rules/enforce-shorthand.test.ts` (37 tests)
- [x] Maintainer: `pnpm test` full suite on CI

## Behavior notes

- Autofix still **appends** the merged shorthand when other classes are present (e.g. `flex px-4 py-4 gap-2` → `flex gap-2 p-4`); use `enforce-sort-order` for ordering.
- **Breaking-ish**: same-variant stacks like `hover:mt-2 hover:mr-2 hover:mb-2 hover:ml-2` now report (previously documented as intentionally skipped). Different variants on each part remain valid.


Made with [Cursor](https://cursor.com)