### PR TITLE
Fix CI on Windows (e2e shim + cold-compute timeout)

### DIFF
--- a/packages/oxlint-tailwindcss/tests/e2e/plugin-loading.test.ts
+++ b/packages/oxlint-tailwindcss/tests/e2e/plugin-loading.test.ts
@@ -5,16 +5,23 @@ import { existsSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs'
 
 const ROOT = resolve(__dirname, '../..')
 const DIST_CJS = resolve(ROOT, 'dist/index.cjs')
-const OXLINT = resolve(ROOT, 'node_modules/.bin/oxlint')
+// On Windows the npm bin shim is `oxlint.cmd`, and a `.cmd` can't be run via
+// execFileSync without a shell (Node refuses to spawn .cmd/.bat directly). Pick
+// the right shim per platform and only opt into the shell where it's needed.
+const IS_WINDOWS = process.platform === 'win32'
+const OXLINT = resolve(ROOT, 'node_modules/.bin', IS_WINDOWS ? 'oxlint.cmd' : 'oxlint')
 const E2E_DIR = resolve(__dirname, 'tmp')
 const FIXTURE_CSS = resolve(__dirname, '../fixtures/default.css')
 
 function runOxlint(configFile: string, targetFile: string): { stdout: string; exitCode: number } {
   try {
+    // configFile/targetFile are relative to cwd (E2E_DIR) so we don't pass
+    // absolute Windows paths (backslashes/spaces) through the shell.
     const stdout = execFileSync(OXLINT, ['-c', configFile, targetFile], {
       encoding: 'utf-8',
       cwd: E2E_DIR,
       timeout: 30_000,
+      shell: IS_WINDOWS,
     })
     return { stdout, exitCode: 0 }
   } catch (error: unknown) {
@@ -40,7 +47,9 @@ describe('E2E: oxlint plugin loading', () => {
       configPath,
       JSON.stringify(
         {
-          jsPlugins: [DIST_CJS],
+          // Forward slashes so the path survives JSON + oxlint resolution on
+          // Windows (backslashes would be JSON escape sequences).
+          jsPlugins: [DIST_CJS.split('\\').join('/')],
           rules: {
             'tailwindcss/no-duplicate-classes': 'error',
             'tailwindcss/no-unnecessary-whitespace': 'error',
@@ -85,7 +94,7 @@ describe('E2E: oxlint plugin loading', () => {
   })
 
   it('loads the plugin and detects errors', () => {
-    const { stdout, exitCode } = runOxlint(configPath, invalidFile)
+    const { stdout, exitCode } = runOxlint('.oxlintrc.json', 'invalid.tsx')
     expect(exitCode).not.toBe(0)
     expect(stdout).toContain('tailwindcss(no-duplicate-classes)')
     expect(stdout).toContain('tailwindcss(no-unnecessary-whitespace)')
@@ -93,7 +102,7 @@ describe('E2E: oxlint plugin loading', () => {
   })
 
   it('reports no errors on valid code', () => {
-    const { stdout } = runOxlint(configPath, validFile)
+    const { stdout } = runOxlint('.oxlintrc.json', 'valid.tsx')
     expect(stdout).not.toContain('tailwindcss(')
   })
 })

--- a/packages/oxlint-tailwindcss/tests/global-setup.ts
+++ b/packages/oxlint-tailwindcss/tests/global-setup.ts
@@ -1,16 +1,39 @@
 /**
- * Vitest global setup — pre-warms the design system disk cache.
+ * Vitest global setup — pre-warms the design system disk cache for every fixture
+ * entry point used across the suite.
  *
- * Without this, multiple test files running in parallel all attempt cold loads
- * simultaneously (~2.5s each), causing unnecessary contention. By loading once
- * here, all test files hit the disk cache (<20ms).
+ * Without this, each test file cold-loads its fixture on first use (~2.5s on
+ * Linux/macOS, much slower on Windows). Many files doing that in parallel
+ * saturates the runner and, on Windows, pushed `beforeAll` hooks past the
+ * hook timeout. Loading them ONCE here, sequentially, means every test file
+ * hits the warm disk cache (<500ms) and no per-file hook races a cold compute.
  */
 
 import { resolve } from 'node:path'
 import { loadDesignSystemSync } from '../src/design-system/sync-loader'
 
-const ENTRY_POINT = resolve(__dirname, 'fixtures/default.css')
+// Every fixture used as an entry point by the suite. Pre-warming a fixture that
+// isn't a valid entry point would throw, so each load is isolated — a failure
+// here must not block the rest (the test that owns it will surface it).
+const FIXTURES = [
+  'default.css',
+  'shadcn.css',
+  'with-components.css',
+  'with-typography.css',
+  'custom-theme.css',
+  'with-letter-spacing.css',
+  'with-prefix.css',
+  'with-prefix-components.css',
+  'with-tailwindcss-animate.css',
+  'with-tw-animate-css.css',
+]
 
 export function setup() {
-  loadDesignSystemSync(ENTRY_POINT)
+  for (const fixture of FIXTURES) {
+    try {
+      loadDesignSystemSync(resolve(__dirname, 'fixtures', fixture))
+    } catch {
+      // Leave it cold; the owning test will report the real failure.
+    }
+  }
 }

--- a/packages/oxlint-tailwindcss/vitest.config.ts
+++ b/packages/oxlint-tailwindcss/vitest.config.ts
@@ -4,8 +4,12 @@ export default defineConfig({
   test: {
     globals: true,
     globalSetup: './tests/global-setup.ts',
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
+    // Generous timeouts: Windows runners are markedly slower at the worker-thread
+    // design-system load / worker-service init, and the disk cache + sort/
+    // canonicalize workers aren't free to spin up. 60s guards against a hang
+    // without flaking on a slow-but-working cold path.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     // Benchmarks are slow and timing-sensitive — keep them out of the default
     // run so a bare `vitest run` (CI, IDE) doesn't pick them up (TST-M4). The
     // `bench` script overrides this to run them explicitly.


### PR DESCRIPTION
Makes the suite pass on Windows so the matrix is green on Linux, macOS and Windows alike.

## Two Windows-only failures (Linux/macOS were green)

1. **e2e/plugin-loading** — invoked `node_modules/.bin/oxlint`, but on Windows the npm shim is `oxlint.cmd`, which `execFileSync` refuses to spawn without a shell. It threw, stdout came back empty, and the assertion failed. **Test-harness bug, not a plugin bug** — the plugin loads fine via oxlint on Windows. Fix: `oxlint.cmd` + `shell:true` on Windows, config/target passed relative to cwd, jsPlugins path with forward slashes.
2. **prefix.test.ts hook timeout** — its `beforeAll` cold-loaded `with-prefix.css`; Windows cold-computes under parallel load exceed the 30s `hookTimeout`. Fix: pre-warm every fixture entry point once in `global-setup` (per-file hooks then read the warm disk cache), and raise test/hook timeouts to 60s.

Verified green locally on macOS (1119 tests). Letting CI confirm Windows.