### PR TITLE
release: v1.3.1 — fix no-unknown-classes false positives for valid v4 classes missing from getClassList (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,13 +258,30 @@ AST visitors: `JSXAttribute`, `CallExpression`, `TaggedTemplateExpression`, `Var
   in `no-conflicting-classes.ts` whitelist the `animate-in`/`animate-out` ↔ modifier pairs.
 - **`canonicalizeCandidates()`**: Deduplicates results — must be called one class at a time, NOT in
   batch.
-- **`getClassList()` gaps**: Some valid classes (`grow-1`, `border-1`, `underline-offset-3`) are
-  missing from the list. `cache.getOrder()` falls back to prefix lookup for dynamic numeric values.
-  Arbitrary values handled by heuristic.
-- **Legacy v3 spellings in the canonical map** (issue #16): the precompute step in `sync-loader.ts`
-  feeds a hardcoded seed list plus dynamic `start-*`/`end-*` derived from existing `inset-{s,e}-*`
-  utilities into `canonicalizeCandidates()` and adds the diffs to the canonical map. Legacy classes
-  are also pushed into `validClasses` so `no-unknown-classes` doesn't flag them.
+- **`getClassList()` gaps** (issue #37): some valid v4 classes never appear in `getClassList()`. The
+  precompute reconciles three kinds, each validated through `candidatesToCss()` — the source of
+  truth for "produces CSS" — so every addition self-prunes on a Tailwind version that doesn't emit
+  it:
+  1. **Dynamic numeric values** (`grow-1`, `border-1`, `underline-offset-3`): not seeded; recovered
+     at lookup time by the prefix-and-number heuristic in `cache.isValid`/`getOrder` (falls back to
+     prefix lookup). Arbitrary values handled by heuristic too.
+  2. **Special-cased compiler utilities** absent from `getClassList()` AND the utility registry
+     (`ds.utilities.keys('static')`): `@container-size`, `filter-none`, `backdrop-filter-none`,
+     `max-w-screen`. A curated `staticExtras` seed in `sync-loader.ts` validates + pushes them to
+     `validClasses` and captures their CSS so they get `cssProps` (so `@container @container-size`
+     conflicts like `@container @container-normal`, not silently accepted).
+  3. **Negative utilities** whose negative form `getClassList()` omits (`-col-N`, `-row-N`,
+     `-hue-rotate-N`, `-backdrop-hue-rotate-N`): auto-discovered by probing `-<prefix>-1` for every
+     known prefix; `candidatesToCss()` rejects non-negatable prefixes (`-p-1` → null), so only real
+     negative-capable prefixes land in `validClasses` (→ `knownPrefixes` picks up `-col`, etc.). To
+     re-audit after a Tailwind bump: `keys('static')`/`keys('functional')` (+ `getCompletions`
+     `supportsNegative`) vs `getClassList()`, filter by `candidatesToCss != null && !cache.isValid`.
+- **Legacy v3 spellings in the canonical map** (issues #16, #37): the precompute step in
+  `sync-loader.ts` feeds a hardcoded seed list (v3 renames like `break-words` / `bg-gradient-to-*`,
+  plus the v4-reordered position spellings `bg-left-top`→`bg-top-left` /
+  `object-{left,right}-{top,bottom}`) plus dynamic `start-*`/`end-*` derived from existing
+  `inset-{s,e}-*` utilities into `canonicalizeCandidates()` and adds the diffs to the canonical map.
+  Legacy classes are also pushed into `validClasses` so `no-unknown-classes` doesn't flag them.
 - **Floating point**: All rem/em/px operations go through `roundRemValue()`.
 - **Variant reordering barriers**: `consistent-variant-order` pulls pseudo-elements innermost
   (closest to the utility), but also treats selector-changing variants — `*`, `**`, `[&>svg]`, `*:…`

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 1.3.1 (2026-06-13)
+
+Fixes `no-unknown-classes` false positives on valid Tailwind v4 utilities that `getClassList()`
+doesn't enumerate ([#37](https://github.com/sergioazoc/oxlint-tailwindcss/issues/37)). The reported
+case was `@container-size`; a registry-vs-`getClassList()` audit then found and closed the rest of
+that family. Patch bumps to `tailwindcss` / `@tailwindcss/node` 4.3.1. Thanks to
+[@zorrodg](https://github.com/zorrodg) for the report.
+
+### Bug fixes
+
+- **`no-unknown-classes` no longer flags valid v4 classes missing from `getClassList()`.** Validity
+  is built by filtering `getClassList()` through `candidatesToCss()`, so any class Tailwind compiles
+  but doesn't enumerate was reported as a typo (`@container-size` → "Did you mean `contain-size`?").
+  The precompute now reconciles three kinds of gap, each validated through `candidatesToCss()` (the
+  source of truth — so every addition self-prunes on a Tailwind version that doesn't emit it):
+  - **Special-cased compiler utilities** absent from `getClassList()` _and_ the utility registry:
+    `@container-size` (`container-type: size`), `filter-none` / `backdrop-filter-none`, and
+    `max-w-screen`. Added as a curated seed, with their CSS properties captured so they participate
+    in `no-conflicting-classes` like their enumerated siblings.
+  - **Negative utilities** whose negative form `getClassList()` omits: `-col-N`, `-row-N`,
+    `-hue-rotate-N`, `-backdrop-hue-rotate-N`. Auto-discovered by probing `-<prefix>-1` for every
+    known prefix; `candidatesToCss()` rejects utilities that don't support negation (`-p-1`), so
+    only genuinely negative-capable prefixes are added.
+  - **v3 background/object-position spellings** reordered axis-first in v4 (`bg-left-top`,
+    `object-right-bottom`, and the six others) — fed through the existing legacy-canonicalize pass.
+
+### Behavior changes
+
+- **`enforce-canonical` now rewrites the v3 position spellings** to their v4 form (`bg-left-top` →
+  `bg-top-left`, `object-right-bottom` → `object-bottom-right`, and the six others). Autofix.
+- **`no-conflicting-classes` now flags two `container-type` markers together**
+  (`@container @container-size`), consistent with the already-detected
+  `@container @container-normal` — `@container-size` now carries its `container-type` property like
+  its siblings.
+
+### Dependencies
+
+- `tailwindcss` 4.3.1, `@tailwindcss/node` 4.3.1, `@types/node` 25.9.3 (all patch). The 0.8.0
+  cache-invalidation note claimed `@container-size` started working after a tailwindcss upgrade — it
+  never did (the `getClassList()` gap above); now it does, on any 4.x. Test suite at 1134 passing.
+
 ## 1.3.0 (2026-06-09)
 
 A correctness, robustness, and security pass from a full project audit. Two autofixes that could

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -930,10 +930,10 @@ The class parser correctly handles:
 
 - **`enforce-canonical`**: Named classes are canonicalized via the precomputed map (covers
   everything in `getClassList()` plus a curated list of legacy v3 spellings like `break-words`,
-  `flex-grow`, `start-N`, `bg-gradient-to-*`). Arbitrary/CSS-var forms (`p-[2px]`, `bg-(--c)`) are
-  canonicalized dynamically via the worker. Some valid v4 classes that don't appear in
-  `getClassList()` and have no canonical rewrite (e.g. `border-1` is valid as a dynamic numeric
-  value but isn't enumerated) are left untouched.
+  `flex-grow`, `start-N`, `bg-gradient-to-*`, `bg-left-top` → `bg-top-left`). Arbitrary/CSS-var
+  forms (`p-[2px]`, `bg-(--c)`) are canonicalized dynamically via the worker. Some valid v4 classes
+  that don't appear in `getClassList()` and have no canonical rewrite (e.g. `border-1` is valid as a
+  dynamic numeric value but isn't enumerated) are left untouched.
 - **`no-conflicting-classes`**: Uses exact CSS property name matching plus composition heuristics:
   CSS-var composition (`shadow` + `ring`), narrowing-override (later class is a strict subset of
   earlier — handles `size-4 h-6`, `rounded-t-lg rounded-tl-sm`, `truncate text-clip`), complementary

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",
@@ -51,13 +51,13 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "@tailwindcss/node": "^4.3.0",
-    "tailwindcss": "^4.3.0"
+    "@tailwindcss/node": "^4.3.1",
+    "tailwindcss": "^4.3.1"
   },
   "devDependencies": {
     "@oxlint/plugins": "catalog:",
     "@tailwindcss/typography": "^0.5.20",
-    "@types/node": "^25.9.2",
+    "@types/node": "^25.9.3",
     "@typescript/native-preview": "7.0.0-dev.20260608.1",
     "oxlint": "catalog:",
     "tailwindcss-animate": "^1.0.7",

--- a/packages/oxlint-tailwindcss/src/design-system/sync-loader.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/sync-loader.ts
@@ -201,6 +201,39 @@ async function main() {
     const dash = cls.lastIndexOf('-');
     if (dash > 0) knownPrefixes.add(cls.slice(0, dash));
   }
+  // Curated static utilities valid in v4 but absent from getClassList() (#37).
+  // These are special-cased in Tailwind's compiler, so they appear in neither
+  // getClassList() NOR the utility registry (\`utilities.keys('static')\`) — only
+  // an explicit probe surfaces them:
+  //   - \`@container-size\` (\`container-type: size\`) — sibling of the enumerated
+  //     \`@container\` / \`@container-normal\`; was flagged as a typo of \`contain-size\`.
+  //   - \`filter-none\` / \`backdrop-filter-none\` (\`filter: none\`) — the reset
+  //     utilities; their functional bases enumerate values but omit \`none\`.
+  //   - \`max-w-screen\` (\`max-width: 100vw\`).
+  // Validated via candidatesToCss (self-prunes on any Tailwind version that doesn't
+  // emit them) and their CSS is captured so the cssProps phase below treats them
+  // exactly like their getClassList siblings — otherwise no-conflicting-classes
+  // would flag \`@container @container-normal\` but silently accept
+  // \`@container @container-size\`. Named forms (\`@container-size/main\`) are covered
+  // by the slash-modifier path in cache.isValid once the base lands in validClasses.
+  const staticExtras = [
+    '@container-size',
+    'filter-none',
+    'backdrop-filter-none',
+    'max-w-screen',
+  ].filter((c) => !validSet.has(c));
+  const staticExtraCss = {};
+  if (staticExtras.length > 0) {
+    const staticResults = ds.candidatesToCss(staticExtras.map(pfx));
+    for (let i = 0; i < staticExtras.length; i++) {
+      if (staticResults[i] != null) {
+        validClasses.push(staticExtras[i]);
+        validSet.add(staticExtras[i]);
+        staticExtraCss[staticExtras[i]] = staticResults[i];
+      }
+    }
+  }
+
   const extraCandidates = [];
   const breakpoints = ['sm', 'md', 'lg', 'xl', '2xl'];
   for (const prefix of knownPrefixes) {
@@ -218,6 +251,27 @@ async function main() {
       if (extraResults[i] != null) {
         validClasses.push(extraCandidates[i]);
         validSet.add(extraCandidates[i]);
+      }
+    }
+  }
+
+  // Negative variants of utilities that support them (#37). getClassList()
+  // enumerates negatives for most (\`-m-4\`, \`-translate-x-2\`) but omits a few
+  // (\`-col-1\`, \`-row-1\`, \`-hue-rotate-45\`, \`-backdrop-hue-rotate-45\`). Probe
+  // \`-<prefix>-1\` for every known prefix lacking negative coverage; candidatesToCss
+  // self-prunes utilities that reject negatives (\`-p-1\` → null), so only genuinely
+  // negative-capable prefixes land in validClasses, giving isValid's / getOrder's
+  // numeric-prefix heuristic the \`-<prefix>\` it needs to accept any \`-<prefix>-<n>\`.
+  const negativeProbes = [];
+  for (const prefix of knownPrefixes) {
+    if (!knownPrefixes.has('-' + prefix)) negativeProbes.push('-' + prefix + '-1');
+  }
+  if (negativeProbes.length > 0) {
+    const negResults = ds.candidatesToCss(negativeProbes.map(pfx));
+    for (let i = 0; i < negativeProbes.length; i++) {
+      if (negResults[i] != null && !validSet.has(negativeProbes[i])) {
+        validClasses.push(negativeProbes[i]);
+        validSet.add(negativeProbes[i]);
       }
     }
   }
@@ -268,6 +322,11 @@ async function main() {
     'decoration-clone', 'decoration-slice',
     'bg-gradient-to-t', 'bg-gradient-to-tr', 'bg-gradient-to-r', 'bg-gradient-to-br',
     'bg-gradient-to-b', 'bg-gradient-to-bl', 'bg-gradient-to-l', 'bg-gradient-to-tl',
+    // v3 background/object-position spellings reordered in v4 (#37):
+    // \`bg-left-top\` -> \`bg-top-left\`. canonicalizeCandidates rewrites them, so
+    // enforce-canonical suggests the v4 form and no-unknown-classes accepts them.
+    'bg-left-top', 'bg-right-top', 'bg-left-bottom', 'bg-right-bottom',
+    'object-left-top', 'object-right-top', 'object-left-bottom', 'object-right-bottom',
   ];
   for (const cls of validClasses) {
     if (cls.startsWith('inset-s-')) legacyCandidates.push('start-' + cls.slice(8));
@@ -394,6 +453,14 @@ async function main() {
       const props = extractRootCssProps(cssResults[i], pfx(classNames[i]));
       if (props.length > 0) cssProps[classNames[i]] = props;
     }
+  }
+
+  // cssProps for the curated static extras (#37) so they participate in conflict
+  // detection exactly like their getClassList siblings (e.g. \`@container-size\` and
+  // \`@container\` both declaring \`container-type\`).
+  for (const name in staticExtraCss) {
+    const props = extractRootCssProps(staticExtraCss[name], pfx(name));
+    if (props.length > 0) cssProps[name] = props;
   }
 
   // Variant ordering from the design system

--- a/packages/oxlint-tailwindcss/tests/rules/enforce-canonical.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/enforce-canonical.test.ts
@@ -30,6 +30,20 @@ runWithFixture(ruleTester, 'enforce-canonical', enforceCanonical, ENTRY_POINT, {
       errors: [{ messageId: 'nonCanonical' }],
       output: '<div className="m-0" />',
     },
+    // v3 background/object-position spellings reordered in v4 (#37):
+    // axis order flipped to vertical-first.
+    {
+      code: '<div className="bg-left-top" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'nonCanonical' }],
+      output: '<div className="bg-top-left" />',
+    },
+    {
+      code: '<div className="object-right-bottom" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'nonCanonical' }],
+      output: '<div className="object-bottom-right" />',
+    },
     {
       code: '<div className="flex -mt-0" />',
       filename: 'test.tsx',

--- a/packages/oxlint-tailwindcss/tests/rules/no-conflicting-classes.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-conflicting-classes.test.ts
@@ -202,6 +202,14 @@ runWithFixture(ruleTester, 'no-conflicting-classes', noConflictingClasses, ENTRY
       filename: 'test.tsx',
       errors: [{ messageId: 'conflict' }],
     },
+    // Container-type marking utilities all set `container-type`, so combining
+    // two of them conflicts. @container-size is absent from getClassList() (#37)
+    // but must behave like its @container / @container-normal siblings.
+    {
+      code: '<div className="@container @container-size" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
   ],
 })
 

--- a/packages/oxlint-tailwindcss/tests/rules/no-unknown-classes.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-unknown-classes.test.ts
@@ -37,6 +37,29 @@ runWithFixture(ruleTester, 'no-unknown-classes', noUnknownClasses, ENTRY_POINT, 
     // Opacity modifiers
     { code: '<div className="bg-black/80" />', filename: 'test.tsx' },
     { code: '<div className="bg-blue-500/50 text-white/90" />', filename: 'test.tsx' },
+    // Container query marking utilities (#37). Tailwind's getClassList() omits
+    // @container-size (container-type: size), but it is a valid v4 utility.
+    { code: '<div className="@container" />', filename: 'test.tsx' },
+    { code: '<div className="@container-normal" />', filename: 'test.tsx' },
+    { code: '<div className="@container-size" />', filename: 'test.tsx' },
+    {
+      code: '<div className="@container-size pointer-events-none absolute inset-0" />',
+      filename: 'test.tsx',
+    },
+    // Named containers via the /name slash modifier
+    { code: '<div className="@container/main" />', filename: 'test.tsx' },
+    { code: '<div className="@container-size/main" />', filename: 'test.tsx' },
+    // Container query variants resolve through their base utility
+    { code: '<div className="@sm:flex @max-md:flex-row" />', filename: 'test.tsx' },
+    // Other utilities valid in v4 but missing from getClassList() (#37):
+    // special-cased compiler utilities (filter:none reset, max-width:100vw)…
+    { code: '<div className="filter-none backdrop-filter-none" />', filename: 'test.tsx' },
+    { code: '<div className="max-w-screen" />', filename: 'test.tsx' },
+    // …negative utilities whose negative form getClassList() omits…
+    { code: '<div className="-hue-rotate-45 -backdrop-hue-rotate-30" />', filename: 'test.tsx' },
+    { code: '<div className="-col-1 -row-2 -col-13" />', filename: 'test.tsx' },
+    // …and v3 position spellings (still valid CSS; enforce-canonical rewrites them)
+    { code: '<div className="bg-left-top object-right-bottom" />', filename: 'test.tsx' },
   ],
   invalid: [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,26 +34,26 @@ importers:
         version: link:../oxlint-tailwindcss
       vitepress:
         specifier: ^2.0.0-alpha.17
-        version: 2.0.0-alpha.17(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3)
+        version: 2.0.0-alpha.17(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3)
 
   packages/oxlint-tailwindcss:
     dependencies:
       '@tailwindcss/node':
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.3.1
+        version: 4.3.1
       tailwindcss:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.3.1
+        version: 4.3.1
     devDependencies:
       '@oxlint/plugins':
         specifier: 'catalog:'
         version: 1.69.0
       '@tailwindcss/typography':
         specifier: ^0.5.20
-        version: 0.5.20(tailwindcss@4.3.0)
+        version: 0.5.20(tailwindcss@4.3.1)
       '@types/node':
-        specifier: ^25.9.2
-        version: 25.9.2
+        specifier: ^25.9.3
+        version: 25.9.3
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260608.1
         version: 7.0.0-dev.20260608.1
@@ -62,7 +62,7 @@ importers:
         version: 1.69.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@4.3.0)
+        version: 1.0.7(tailwindcss@4.3.1)
       tsdown:
         specifier: ^0.22.2
         version: 0.22.2(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
@@ -74,7 +74,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.2)(vite@7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.1.8(@types/node@25.9.3)(vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
 
 packages:
 
@@ -852,8 +852,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tailwindcss/node@4.3.0':
-    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+  '@tailwindcss/node@4.3.1':
+    resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
 
   '@tailwindcss/typography@0.5.20':
     resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
@@ -893,8 +893,8 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
-  '@types/node@25.9.2':
-    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1479,8 +1479,8 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
 
-  tailwindcss@4.3.0:
-    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+  tailwindcss@4.3.1:
+    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -2177,7 +2177,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tailwindcss/node@4.3.0':
+  '@tailwindcss/node@4.3.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.21.6
@@ -2185,12 +2185,12 @@ snapshots:
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.3.0
+      tailwindcss: 4.3.1
 
-  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.0)':
+  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.1)':
     dependencies:
       postcss-selector-parser: 6.0.10
-      tailwindcss: 4.3.0
+      tailwindcss: 4.3.1
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -2227,7 +2227,7 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
-  '@types/node@25.9.2':
+  '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
 
@@ -2268,10 +2268,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0))(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
       vue: 3.5.34(typescript@6.0.3)
 
   '@vitest/expect@4.1.8':
@@ -2283,13 +2283,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -2820,11 +2820,11 @@ snapshots:
 
   tabbable@6.4.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@4.3.0):
+  tailwindcss-animate@1.0.7(tailwindcss@4.3.1):
     dependencies:
-      tailwindcss: 4.3.0
+      tailwindcss: 4.3.1
 
-  tailwindcss@4.3.0: {}
+  tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
 
@@ -2926,7 +2926,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0):
+  vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2935,12 +2935,12 @@ snapshots:
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
 
-  vitepress@2.0.0-alpha.17(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3):
+  vitepress@2.0.0-alpha.17(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/js': 4.6.3
@@ -2950,7 +2950,7 @@ snapshots:
       '@shikijs/transformers': 3.23.0
       '@shikijs/types': 3.23.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.7(vite@7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0))(vue@3.5.34(typescript@6.0.3))
+      '@vitejs/plugin-vue': 6.0.7(vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))(vue@3.5.34(typescript@6.0.3))
       '@vue/devtools-api': 8.1.2
       '@vue/shared': 3.5.34
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@6.0.3))
@@ -2959,7 +2959,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 3.23.0
-      vite: 7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
       vue: 3.5.34(typescript@6.0.3)
     optionalDependencies:
       postcss: 8.5.15
@@ -2988,10 +2988,10 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.8(@types/node@25.9.2)(vite@7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)):
+  vitest@4.1.8(@types/node@25.9.3)(vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -3008,10 +3008,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
Refs #37.

`no-unknown-classes` builds validity by filtering `getClassList()` through `candidatesToCss()`, so
valid Tailwind v4 utilities the compiler emits but `getClassList()` doesn't enumerate were reported
as typos (`@container-size` → "Did you mean `contain-size`?"). A registry-vs-`getClassList()` audit
found and closed the whole family; every addition is validated through `candidatesToCss()` (the
source of truth) so it self-prunes on any Tailwind version that doesn't emit it:

- **Special-cased compiler utilities**, absent from `getClassList()` _and_ the utility registry:
  `@container-size`, `filter-none`, `backdrop-filter-none`, `max-w-screen` — curated seed in
  `sync-loader.ts`, with their CSS captured so they get `cssProps`.
- **Negative utilities** whose negative form `getClassList()` omits: `-col-N`, `-row-N`,
  `-hue-rotate-N`, `-backdrop-hue-rotate-N` — auto-discovered by probing `-<prefix>-1` per known
  prefix; `candidatesToCss()` rejects non-negatable prefixes (`-p-1`).
- **v3 background/object-position spellings** reordered axis-first in v4 (`bg-left-top`,
  `object-right-bottom`, …) — fed through the legacy-canonicalize pass.

### Behavior changes

- `enforce-canonical` now rewrites the v3 position spellings (`bg-left-top` → `bg-top-left`, …).
  Autofix.
- `no-conflicting-classes` now flags `@container @container-size`, consistent with the
  already-detected `@container @container-normal`.

### Dependencies

- `tailwindcss` / `@tailwindcss/node` 4.3.1, `@types/node` 25.9.3 (all patch). Version bumped to
  **1.3.1**; CHANGELOG / CLAUDE.md / README updated.

### Verification

- Full suite **1134 passing**; `typecheck` / `lint` / `format:check` clean.
- Gap audit re-run on Tailwind 4.3.1 → **0 remaining false positives** (static and functional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
