### PR TITLE
fix: resolve relative entryPoint against config dir, not CWD (#39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,21 @@ AST visitors: `JSXAttribute`, `CallExpression`, `TaggedTemplateExpression`, `Var
     shape is removed; supplying it throws `DeprecatedEntryPointShapeError` with the migration
     snippet inline. If nothing resolves, `MissingEntryPointError` is thrown and the rule emits a
     `designSystemUnavailable` diagnostic.
+- **Relative string `entryPoint` anchoring (#39)**: a relative **string** entry (rule option or
+  settings string — NOT the mapping shape) is resolved by `resolveStringEntryPoint` in `loader.ts`,
+  NOT against `process.cwd()`. oxlint doesn't expose the config path to plugins, so the loader walks
+  up from the linted file to the nearest enclosing `.oxlintrc.json` (`nearestConfigDir`, early-exit,
+  memoized in `nearestConfigDirCache`) — the config oxlint applies under nested discovery — and
+  anchors there. Deterministic **two-step** `[nearest config dir → CWD]`: use the config-dir
+  candidate if it exists on disk, else the CWD candidate, else resolve against the nearest config
+  dir so the `Could not stat` error names the package-local path (fail-loud, never silently reach
+  past the nearest config into an unrelated ancestor — that masked-typo non-determinism is exactly
+  why the legacy `string[]` heuristic was removed). Absolute entries pass through `resolve()`
+  untouched; mapping arrays stay CWD-relative. This makes editor (CWD = workspace root) and CLI (CWD
+  = package) runs agree in Pattern-B monorepos. Limitation: under `oxlint -c <config>` /
+  `--disable-nested-config` oxlint suppresses nested discovery but the plugin still walks the FS, so
+  the nearest `.oxlintrc.json` may diverge from the config oxlint used — docs steer those setups to
+  absolute paths.
 - **Multi-DS cache**: `loader.ts` uses `dsCache: Map<string, { cache, mtime }>` to store multiple
   design systems simultaneously. Each unique resolved CSS gets its own entry. In monorepos with the
   mapping shape, distinct globs can map to distinct CSS files in the same lint run.

--- a/packages/docs/es/monorepo.md
+++ b/packages/docs/es/monorepo.md
@@ -70,6 +70,23 @@ my-monorepo/
 }
 ```
 
+Un `entryPoint` string **relativo** se resuelve respecto al directorio del `.oxlintrc.json` más
+cercano que lo contiene —es decir, el config que lo declara— y no respecto al working directory
+actual. Así `./src/styles.css` apunta a `packages/ui/src/styles.css` ya sea que oxlint corra desde
+el package (`cd packages/ui && oxlint`, como en la CLI) o desde la raíz del workspace (como hacen
+las extensiones de editor, p. ej. el plugin de oxlint para VS Code). Si el archivo no se encuentra
+ahí, la resolución cae de vuelta al CWD. Esto es lo que hace que los configs por package se
+comporten igual en la terminal y en el editor (issue #39).
+
+::: tip Configs explícitos con `-c` El anclaje usa el `.oxlintrc.json` más cercano porque ese es el
+config que oxlint aplica bajo su descubrimiento de configs anidados por defecto. Si en cambio pasas
+`oxlint -c <config>` (o deshabilitas los configs anidados), oxlint usa solo ese archivo — y el
+plugin no puede saber cuál config fue (oxlint le expone la ruta del archivo y el CWD, nunca la ruta
+del config). El fallback config-más-cercano + CWD igual resuelve bien para el layout habitual, pero
+si mezclas un config explícito `-c` con un `.oxlintrc.json` anidado no relacionado debajo del
+archivo lintado, prefiere un `entryPoint` **absoluto** (o la forma de mapping) para eliminar toda
+ambigüedad. :::
+
 Cuándo conviene:
 
 - Los packages divergen mucho en reglas, plugins o globals.

--- a/packages/docs/es/settings.md
+++ b/packages/docs/es/settings.md
@@ -28,10 +28,15 @@ Acepta dos formas:
 }
 ```
 
-Los globs se evalúan contra el path del archivo lintado relativo al directorio donde corre oxlint.
-Sintaxis soportada: `*` (cualquier caracter excepto `/`), `**` (cualquier profundidad), segmentos
-literales. El orden importa — el primer entry que matchea gana. Se recomienda agregar un fallback
-`"**"` para archivos fuera de los globs explícitos.
+Un `entryPoint` **string relativo** (la forma de proyecto simple) se resuelve respecto al directorio
+del `.oxlintrc.json` más cercano que lo contiene, cayendo de vuelta al directorio donde corre oxlint
+— así un config por package resuelve al mismo CSS ya sea que oxlint corra desde el package (CLI) o
+desde la raíz del workspace (editor). Ver [Monorepos](/es/monorepo).
+
+Los globs (la forma de mapping) se evalúan contra el path del archivo lintado relativo al directorio
+donde corre oxlint. Sintaxis soportada: `*` (cualquier caracter excepto `/`), `**` (cualquier
+profundidad), segmentos literales. El orden importa — el primer entry que matchea gana. Se
+recomienda agregar un fallback `"**"` para archivos fuera de los globs explícitos.
 
 `files` también acepta un arreglo de globs (`string[]`): el entry matchea si el archivo lintado
 coincide con cualquiera de ellos.

--- a/packages/docs/es/setup.md
+++ b/packages/docs/es/setup.md
@@ -103,8 +103,9 @@ oxlint debería marcar ambas clases con `no-unknown-classes`, y las sugerencias 
 
 Si en cambio ves un diagnóstico `designSystemUnavailable`, significa que `entryPoint` no está
 configurado o apunta a un archivo que el plugin no puede leer. El mensaje del diagnóstico te dice
-exactamente qué ruta intentó — copia esa en tu setting `entryPoint` (relativa al directorio donde
-corres `oxlint`).
+exactamente qué ruta intentó — copia esa en tu setting `entryPoint`. Un `entryPoint` relativo se
+resuelve respecto al directorio del `.oxlintrc.json` más cercano que lo contiene (el config que lo
+declara), cayendo de vuelta al directorio donde corres `oxlint`.
 
 ## 5. Setups de monorepo
 

--- a/packages/docs/monorepo.md
+++ b/packages/docs/monorepo.md
@@ -70,6 +70,21 @@ my-monorepo/
 }
 ```
 
+A **relative** string `entryPoint` is resolved against the directory of the nearest enclosing
+`.oxlintrc.json` — i.e. the config that declares it — not the current working directory. So
+`./src/styles.css` points at `packages/ui/src/styles.css` whether oxlint runs from the package
+(`cd packages/ui && oxlint`, as on the CLI) or from the workspace root (as editor extensions like
+the VS Code oxlint plugin do). If the file isn't found there, resolution falls back to the CWD. This
+is what makes per-package configs behave the same in the terminal and the editor (issue #39).
+
+::: tip Explicit `-c` configs Anchoring uses the nearest `.oxlintrc.json` because that's the config
+oxlint applies under its default nested-config discovery. If you instead pass `oxlint -c <config>`
+(or disable nested configs), oxlint uses only that one file — and the plugin can't see which config
+that was (oxlint exposes the file path and CWD to plugins, never the config path). The
+nearest-config + CWD fallback still resolves correctly for the usual layout, but if you mix an
+explicit `-c` config with an unrelated nested `.oxlintrc.json` below the linted file, prefer an
+**absolute** `entryPoint` (or the mapping shape) to remove all ambiguity. :::
+
 When to use this:
 
 - Packages diverge significantly in rules, plugins, or globals.

--- a/packages/docs/settings.md
+++ b/packages/docs/settings.md
@@ -27,9 +27,15 @@ Two shapes are supported:
 }
 ```
 
-Globs are evaluated against the linted file's path relative to the oxlint working directory.
-Supported syntax: `*` (any chars except `/`), `**` (any depth), literal segments. Order matters —
-the first matching entry wins. Add a `"**"` fallback to handle files outside the explicit globs.
+A **relative string** `entryPoint` (the single-project shape) is resolved against the directory of
+the nearest enclosing `.oxlintrc.json`, falling back to the oxlint working directory — so a
+per-package config resolves to the same CSS whether oxlint runs from the package (CLI) or the
+workspace root (editor). See [Monorepos](/monorepo).
+
+Globs (the mapping shape) are evaluated against the linted file's path relative to the oxlint
+working directory. Supported syntax: `*` (any chars except `/`), `**` (any depth), literal segments.
+Order matters — the first matching entry wins. Add a `"**"` fallback to handle files outside the
+explicit globs.
 
 `files` also accepts an array of globs (`string[]`): the entry matches if the linted file matches
 any of them.

--- a/packages/docs/setup.md
+++ b/packages/docs/setup.md
@@ -102,7 +102,9 @@ suggestions should appear in your editor.
 
 If you see a `designSystemUnavailable` diagnostic instead, the `entryPoint` setting is missing or
 points at a file the plugin can't read. The diagnostic message tells you exactly which path it tried
-— copy that into your `entryPoint` setting (relative to the directory where you run `oxlint`).
+— copy that into your `entryPoint` setting. A relative `entryPoint` is resolved against the
+directory of the nearest enclosing `.oxlintrc.json` (the config that declares it), falling back to
+the directory where you run `oxlint`.
 
 ## 5. Monorepo setups
 

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.3.2 (2026-06-14)
+
+Fixes a relative `entryPoint` resolving against the current working directory instead of the config
+file's location ([#39](https://github.com/sergioazoc/oxlint-tailwindcss/issues/39)). In a Pattern-B
+monorepo (one `.oxlintrc.json` per package), this made the plugin work from the CLI but fail in the
+editor — the same config resolved to different CSS depending on where oxlint was launched. Thanks to
+[@zorrodg](https://github.com/zorrodg) for the report.
+
+### Bug fixes
+
+- **A relative string `entryPoint` is now anchored to its config file's directory, not the CWD.**
+  oxlint doesn't expose the config path to plugins, so the plugin walks up from the linted file to
+  the nearest enclosing `.oxlintrc.json` (the config oxlint itself merges) and resolves the entry
+  there, falling back to the CWD if the file isn't found. The CLI (`cd packages/ui && oxlint`, CWD =
+  package) and editor extensions (CWD = workspace root) now load the same package-local CSS instead
+  of failing with `Could not stat CSS entry point`. Absolute `entryPoint`s and the
+  `EntryPointMapping[]` (glob) shape are unchanged — globs still match relative to the working
+  directory.
+
 ## 1.3.1 (2026-06-13)
 
 Fixes `no-unknown-classes` false positives on valid Tailwind v4 utilities that `getClassList()`

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -125,7 +125,9 @@ order:
 ```
 
 **Pattern B — one `.oxlintrc.json` per package**, each with its own string `entryPoint`. oxlint
-resolves the closest config to the file being linted.
+resolves the closest config to the file being linted, and a relative `entryPoint` is anchored to
+that config's directory (falling back to the working directory), so it resolves to the same CSS
+whether oxlint runs from the package (CLI) or the workspace root (editor).
 
 See the full [monorepo guide](https://oxlint-tailwindcss.pages.dev/monorepo) for examples of both.
 

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/design-system/loader.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/loader.ts
@@ -1,8 +1,8 @@
 import { DesignSystemCache } from './cache'
 import { loadDesignSystemSync } from './sync-loader'
 import { debugLog, isDebugEnabled, setDebugEnabled, resetDebug } from './debug'
-import { statSync } from 'node:fs'
-import { relative, resolve } from 'node:path'
+import { existsSync, statSync } from 'node:fs'
+import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import {
   DeprecatedEntryPointShapeError,
   DesignSystemLoadError,
@@ -10,7 +10,7 @@ import {
   MissingEntryPointError,
 } from '../utils/fatal'
 import type { EntryPointMapping } from '../types'
-import { safeFilename, safeOptions, safeSettings } from '../utils/context'
+import { safeCwd, safeFilename, safeOptions, safeSettings } from '../utils/context'
 
 export type { EntryPointMapping }
 
@@ -144,6 +144,90 @@ export function resolveByGlobMapping(
 }
 
 /**
+ * oxlint discovers nested configuration by walking up from each linted file
+ * looking for files with these names. We mirror that walk to find the config
+ * directory a relative `entryPoint` should be anchored to.
+ */
+const OXLINT_CONFIG_NAMES = ['.oxlintrc.json'] as const
+
+/** Memoizes the nearest-config walk per starting directory (cleared in tests). */
+const nearestConfigDirCache = new Map<string, string | null>()
+
+/**
+ * Find the directory of the **nearest** enclosing oxlint config, walking up
+ * from `filePath` toward the filesystem root. Returns `undefined` if none is
+ * found. This is the config oxlint applies to the file under its default
+ * nested-config discovery, so a relative `entryPoint` declared in it is meant
+ * to resolve relative to that directory — not the process CWD, which differs
+ * between the CLI (`cd package && oxlint`) and an editor (CWD = workspace
+ * root). See issue #39.
+ *
+ * Stops at the first match (early exit), so in the common case it touches only
+ * the file's package, not the whole path to root.
+ */
+function nearestConfigDir(filePath: string): string | undefined {
+  const start = dirname(resolve(filePath))
+  const cached = nearestConfigDirCache.get(start)
+  if (cached !== undefined) return cached ?? undefined
+
+  let dir = start
+  // Walk to the filesystem root; `dirname('/') === '/'` is the fixpoint.
+  for (;;) {
+    if (OXLINT_CONFIG_NAMES.some((name) => existsSync(resolve(dir, name)))) {
+      nearestConfigDirCache.set(start, dir)
+      return dir
+    }
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  nearestConfigDirCache.set(start, null)
+  return undefined
+}
+
+/**
+ * Resolve a string `entryPoint` (from `settings` or a rule option) to an
+ * absolute path.
+ *
+ * Absolute paths are returned normalized and untouched. A **relative** path is
+ * anchored to the directory of the nearest enclosing `.oxlintrc.json` (the
+ * config oxlint applies to the file), with the CWD as a single fallback:
+ *
+ *   1. nearest config dir — if its candidate file exists, use it;
+ *   2. CWD — if its candidate file exists, use it;
+ *   3. otherwise resolve against the nearest config dir (else CWD) so the
+ *      downstream "could not stat" diagnostic names the package-local path the
+ *      user most likely intended — i.e. fail loud rather than silently reach
+ *      past the nearest config into an unrelated ancestor.
+ *
+ * Deliberately a two-step [config dir → CWD] resolution, NOT a walk through
+ * every ancestor config: the v1 charter is deterministic + fail-loud, and a
+ * multi-ancestor existence probe would let a coincidentally same-named CSS in
+ * an unrelated parent silently shadow a genuine misconfiguration.
+ *
+ * This makes resolution independent of where oxlint is launched from: the
+ * editor (CWD = workspace root) and the CLI (CWD = package dir) now agree on
+ * the same CSS file in a Pattern-B monorepo (issue #39).
+ */
+export function resolveStringEntryPoint(
+  entry: string,
+  filePath: string | undefined,
+  cwd: string,
+): string {
+  if (isAbsolute(entry)) return resolve(entry)
+
+  const configDir = filePath ? nearestConfigDir(filePath) : undefined
+  const bases = configDir && configDir !== cwd ? [configDir, cwd] : [cwd]
+
+  for (const base of bases) {
+    const candidate = resolve(base, entry)
+    if (existsSync(candidate)) return candidate
+  }
+  // Nothing exists — resolve against the most-specific base for the error.
+  return resolve(bases[0], entry)
+}
+
+/**
  * Extract `rootFontSize` from `settings.tailwindcss` (default: 16).
  */
 export function rootFontSizeFromSettings(settings?: Readonly<Record<string, unknown>>): number {
@@ -186,7 +270,7 @@ export function getLoadedDesignSystem(
   } catch (cause) {
     throw new DesignSystemLoadError(
       `Could not stat CSS entry point: ${resolvedPath}`,
-      'Check that the file exists and is readable. The path is resolved relative to the oxlint working directory.',
+      'Check that the file exists and is readable. A relative `entryPoint` is resolved against the nearest `.oxlintrc.json` directory, falling back to the oxlint working directory.',
       { cause: cause instanceof Error ? cause : undefined },
     )
   }
@@ -223,6 +307,10 @@ export function getLoadedDesignSystem(
  *   3. `settings.tailwindcss.entryPoint` as an `EntryPointMapping[]` —
  *      first matching glob (relative to CWD) wins.
  *
+ * A relative string entry (1 or 2) is anchored to the nearest enclosing
+ * `.oxlintrc.json` directory rather than the CWD, so editor and CLI runs agree
+ * in Pattern-B monorepos (issue #39); see `resolveStringEntryPoint`.
+ *
  * If none of those produce an entry point for the current file, throws
  * `MissingEntryPointError`. If the resolved CSS fails to load, throws
  * `DesignSystemLoadError`. Both extend `OxlintTailwindError` and are
@@ -236,6 +324,7 @@ export function createLazyLoader(context: {
   options?: readonly unknown[]
   settings?: Readonly<Record<string, unknown>>
   filename?: string
+  cwd?: string
 }): () => LoadResult {
   let debugInitialized = false
   let lastFilePath: string | undefined
@@ -268,7 +357,12 @@ export function createLazyLoader(context: {
     lastError = undefined
     try {
       const settingsEntry = entryPointFromSettings(settings)
-      const cssPath = resolveEntryPointForFile(ruleOptionEntry, settingsEntry, filePath)
+      const cssPath = resolveEntryPointForFile(
+        ruleOptionEntry,
+        settingsEntry,
+        filePath,
+        safeCwd(context),
+      )
       lastResult = getLoadedDesignSystem(cssPath, settings)
     } catch (err) {
       if (isFatalError(err) && err instanceof Error) lastError = err
@@ -284,8 +378,11 @@ export function createLazyLoader(context: {
 }
 
 /**
- * Pure resolution from (rule option, settings entry, file path) to a CSS
- * entry-point path. Exported for testability.
+ * Pure resolution from (rule option, settings entry, file path, cwd) to an
+ * absolute CSS entry-point path. Exported for testability.
+ *
+ * Relative string entries are anchored via `resolveStringEntryPoint` (nearest
+ * `.oxlintrc.json` dir, then `cwd`); mapping arrays match relative to `cwd`.
  *
  * Throws `MissingEntryPointError` if nothing resolves. The error message
  * names the file so the user knows which one tripped the configuration.
@@ -294,9 +391,11 @@ export function resolveEntryPointForFile(
   ruleOptionEntry: string | undefined,
   settingsEntry: EntryPointSetting | undefined,
   filePath: string | undefined,
+  cwd: string = process.cwd(),
 ): string {
-  if (ruleOptionEntry) return ruleOptionEntry
-  if (typeof settingsEntry === 'string') return settingsEntry
+  if (ruleOptionEntry) return resolveStringEntryPoint(ruleOptionEntry, filePath, cwd)
+  if (typeof settingsEntry === 'string')
+    return resolveStringEntryPoint(settingsEntry, filePath, cwd)
   if (Array.isArray(settingsEntry)) {
     if (!filePath) {
       throw new MissingEntryPointError(
@@ -304,7 +403,7 @@ export function resolveEntryPointForFile(
         'This usually means the rule ran outside the linter context. Open an issue if you see this in a real lint run.',
       )
     }
-    const matched = resolveByGlobMapping(settingsEntry, filePath, process.cwd())
+    const matched = resolveByGlobMapping(settingsEntry, filePath, cwd)
     if (matched) return matched
     throw new MissingEntryPointError(
       `No \`entryPoint\` mapping matched \`${filePath}\`.`,
@@ -321,5 +420,6 @@ export function resolveEntryPointForFile(
 export function resetDesignSystem(): void {
   dsCache.clear()
   dsFailureCache.clear()
+  nearestConfigDirCache.clear()
   resetDebug()
 }

--- a/packages/oxlint-tailwindcss/src/utils/context.ts
+++ b/packages/oxlint-tailwindcss/src/utils/context.ts
@@ -16,6 +16,7 @@ interface ContextLike {
   options?: readonly unknown[]
   settings?: Readonly<Record<string, unknown>>
   filename?: string
+  cwd?: string
 }
 
 /**
@@ -48,6 +49,20 @@ export function safeFilename(context: ContextLike): string | undefined {
     return context.filename ?? undefined
   } catch {
     return undefined
+  }
+}
+
+/**
+ * Safely read `context.cwd`, falling back to `process.cwd()`. Same try/catch
+ * pattern as the other accessors (the getter throws in `createOnce` on older
+ * oxlint). The fallback keeps relative-path resolution working even when the
+ * linter never populates `cwd`.
+ */
+export function safeCwd(context: ContextLike): string {
+  try {
+    return context.cwd ?? process.cwd()
+  } catch {
+    return process.cwd()
   }
 }
 

--- a/packages/oxlint-tailwindcss/tests/design-system/loader.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/loader.test.ts
@@ -108,8 +108,11 @@ describe('resolveByGlobMapping', () => {
 
 describe('resolveEntryPointForFile', () => {
   it('rule option entryPoint wins over everything', () => {
-    expect(resolveEntryPointForFile('/explicit.css', 'will-be-ignored.css', '/any/file.tsx')).toBe(
-      '/explicit.css',
+    // Use a `resolve()`d absolute path so the assertion holds on Windows too
+    // (a bare "/explicit.css" is normalized to "<drive>:\explicit.css").
+    const explicit = resolve('/explicit.css')
+    expect(resolveEntryPointForFile(explicit, 'will-be-ignored.css', '/any/file.tsx')).toBe(
+      explicit,
     )
   })
 

--- a/packages/oxlint-tailwindcss/tests/design-system/loader.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/loader.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { resolve, sep } from 'node:path'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import {
   entryPointFromSettings,
   resolveByGlobMapping,
   resolveEntryPointForFile,
+  resolveStringEntryPoint,
+  resetDesignSystem,
   type EntryPointMapping,
 } from '../../src/design-system/loader'
 import { DeprecatedEntryPointShapeError, MissingEntryPointError } from '../../src/utils/fatal'
@@ -109,8 +113,22 @@ describe('resolveEntryPointForFile', () => {
     )
   })
 
-  it('falls back to the string-form settings entry', () => {
-    expect(resolveEntryPointForFile(undefined, 'src/app.css', '/any/file.tsx')).toBe('src/app.css')
+  it('resolves the string-form settings entry to an absolute path (cwd fallback)', () => {
+    // No `.oxlintrc.json` enclosing the file and the file does not exist on
+    // disk, so the relative entry is anchored to the passed cwd.
+    const cwd = resolve('/workspace/pkg')
+    expect(resolveEntryPointForFile(undefined, 'src/app.css', '/any/file.tsx', cwd)).toBe(
+      resolve(cwd, 'src/app.css'),
+    )
+  })
+
+  it('threads cwd into mapping resolution', () => {
+    const mappings: EntryPointMapping[] = [{ files: 'packages/ui/**', use: 'packages/ui/ui.css' }]
+    const cwd = resolve('/elsewhere')
+    const filePath = resolve(cwd, 'packages/ui/Button.tsx')
+    expect(resolveEntryPointForFile(undefined, mappings, filePath, cwd)).toBe(
+      resolve(cwd, 'packages/ui/ui.css'),
+    )
   })
 
   it('resolves through the mapping array when settings is a mapping', () => {
@@ -142,6 +160,121 @@ describe('resolveEntryPointForFile', () => {
     const mappings: EntryPointMapping[] = [{ files: '**', use: 'global.css' }]
     expect(() => resolveEntryPointForFile(undefined, mappings, undefined)).toThrow(
       MissingEntryPointError,
+    )
+  })
+})
+
+// Issue #39: a relative `entryPoint` must resolve relative to the config file's
+// directory (the nearest enclosing `.oxlintrc.json`), NOT the process CWD —
+// otherwise the same per-package config resolves to different CSS depending on
+// whether oxlint runs from the package (CLI) or the workspace root (editor).
+//
+// These tests build a real on-disk monorepo tree because the resolution probes
+// the filesystem for both `.oxlintrc.json` markers and the candidate CSS files.
+describe('resolveStringEntryPoint — config-relative anchoring (#39)', () => {
+  let MONO: string // a Pattern-B monorepo with nested .oxlintrc.json files
+  let NOCFG: string // a tree with no oxlint configs at all
+
+  function touch(path: string): void {
+    mkdirSync(resolve(path, '..'), { recursive: true })
+    writeFileSync(path, '')
+  }
+
+  beforeAll(() => {
+    MONO = mkdtempSync(resolve(tmpdir(), 'oxtw-mono-'))
+    // Root config + a couple of CSS files only present at the root. `shared.css`
+    // exists ONLY at the root — used to prove we never silently reach past the
+    // nearest config dir into an unrelated ancestor.
+    touch(resolve(MONO, '.oxlintrc.json'))
+    touch(resolve(MONO, 'root.css'))
+    touch(resolve(MONO, 'shared.css'))
+    // Mid-level config with no css of its own.
+    touch(resolve(MONO, 'packages/.oxlintrc.json'))
+    // Leaf package config + its own CSS, plus a `root.css` that shadows the
+    // root's to prove the nearest config dir wins.
+    touch(resolve(MONO, 'packages/ui/.oxlintrc.json'))
+    touch(resolve(MONO, 'packages/ui/styles.css'))
+    touch(resolve(MONO, 'packages/ui/root.css'))
+    touch(resolve(MONO, 'packages/ui/src/Button.tsx'))
+
+    NOCFG = mkdtempSync(resolve(tmpdir(), 'oxtw-nocfg-'))
+    touch(resolve(NOCFG, 'work/cwd-only.css'))
+    touch(resolve(NOCFG, 'leaf/File.tsx'))
+  })
+
+  afterAll(() => {
+    for (const dir of [MONO, NOCFG]) {
+      try {
+        rmSync(dir, { recursive: true, force: true })
+      } catch {}
+    }
+  })
+
+  beforeEach(() => resetDesignSystem()) // clears the nearest-config-dir cache
+
+  it('returns absolute paths normalized and untouched', () => {
+    const abs = resolve(MONO, 'packages/ui/styles.css')
+    expect(resolveStringEntryPoint(abs, resolve(MONO, 'packages/ui/src/Button.tsx'), MONO)).toBe(
+      abs,
+    )
+  })
+
+  it('anchors to the nearest config dir regardless of CWD (the bug)', () => {
+    const file = resolve(MONO, 'packages/ui/src/Button.tsx')
+    const expected = resolve(MONO, 'packages/ui/styles.css')
+    // Editor (CWD = workspace root), CLI (CWD = package dir), and an unrelated
+    // CWD must ALL resolve to the same package-local CSS.
+    expect(resolveStringEntryPoint('./styles.css', file, MONO)).toBe(expected)
+    expect(resolveStringEntryPoint('./styles.css', file, resolve(MONO, 'packages/ui'))).toBe(
+      expected,
+    )
+    expect(resolveStringEntryPoint('./styles.css', file, resolve('/some/other/cwd'))).toBe(expected)
+  })
+
+  it('prefers the nearest config dir when an ancestor also has the file', () => {
+    const file = resolve(MONO, 'packages/ui/src/Button.tsx')
+    // Both packages/ui/root.css and <root>/root.css exist — nearest wins.
+    expect(resolveStringEntryPoint('./root.css', file, MONO)).toBe(
+      resolve(MONO, 'packages/ui/root.css'),
+    )
+  })
+
+  it('falls back to CWD when the nearest config dir lacks the file', () => {
+    const file = resolve(MONO, 'packages/ui/src/Button.tsx')
+    // packages/ui has no `shared.css`; CWD (the monorepo root) does. The
+    // two-step [nearest config dir → CWD] resolution lands on the root copy.
+    expect(resolveStringEntryPoint('./shared.css', file, MONO)).toBe(resolve(MONO, 'shared.css'))
+  })
+
+  it('never silently reaches past the nearest config dir into an unrelated ancestor', () => {
+    // Determinism / fail-loud guard (review of #39): nearest config dir
+    // (packages/ui) lacks `shared.css` AND the CWD lacks it. Even though an
+    // ANCESTOR config dir (the monorepo root) has a `shared.css`, resolution
+    // must NOT bind to it — it resolves against the nearest config dir so the
+    // downstream stat error names the package-local path the user intended.
+    const file = resolve(MONO, 'packages/ui/src/Button.tsx')
+    const unrelatedCwd = resolve(tmpdir(), 'oxtw-unrelated-cwd-does-not-exist')
+    expect(resolveStringEntryPoint('./shared.css', file, unrelatedCwd)).toBe(
+      resolve(MONO, 'packages/ui/shared.css'),
+    )
+  })
+
+  it('falls back to CWD when no enclosing config exists', () => {
+    const file = resolve(NOCFG, 'leaf/File.tsx')
+    const cwd = resolve(NOCFG, 'work')
+    expect(resolveStringEntryPoint('cwd-only.css', file, cwd)).toBe(resolve(cwd, 'cwd-only.css'))
+  })
+
+  it('resolves against CWD when no file path is available', () => {
+    expect(resolveStringEntryPoint('./root.css', undefined, MONO)).toBe(resolve(MONO, 'root.css'))
+  })
+
+  it('resolves against the most-specific base for the error when nothing exists', () => {
+    const file = resolve(MONO, 'packages/ui/src/Button.tsx')
+    // Nothing matches `missing.css` anywhere — resolve against the nearest
+    // config dir so the downstream stat error names the intended location.
+    expect(resolveStringEntryPoint('./missing.css', file, MONO)).toBe(
+      resolve(MONO, 'packages/ui/missing.css'),
     )
   })
 })

--- a/packages/oxlint-tailwindcss/tests/e2e/monorepo-cwd.test.ts
+++ b/packages/oxlint-tailwindcss/tests/e2e/monorepo-cwd.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+
+// End-to-end regression for issue #39.
+//
+// Pattern-B monorepo: one `.oxlintrc.json` per package, with a RELATIVE
+// `entryPoint`. oxlint discovers the nested config by walking up from the
+// linted file, so the same config applies whether oxlint is launched from the
+// package (CLI: `cd packages/ui && oxlint`) or from the workspace root (what
+// editor extensions like the VS Code oxlint plugin do).
+//
+// The bug: the relative `entryPoint` was resolved against the process CWD, so
+// the editor run looked for `<workspace>/styles.css` instead of
+// `<workspace>/packages/ui/styles.css` and failed with
+// `Could not stat CSS entry point`. The fix anchors a relative entryPoint to
+// the nearest enclosing `.oxlintrc.json` directory, so every CWD agrees.
+//
+// This is the highest-fidelity guard: it drives the real oxlint binary loading
+// the built plugin, exactly as a user would hit it.
+
+const ROOT = resolve(__dirname, '../..')
+const DIST_CJS = resolve(ROOT, 'dist/index.cjs')
+const IS_WINDOWS = process.platform === 'win32'
+const OXLINT = resolve(ROOT, 'node_modules/.bin', IS_WINDOWS ? 'oxlint.cmd' : 'oxlint')
+
+function runOxlint(
+  cwd: string,
+  targetFile: string,
+  extraArgs: string[] = [],
+): { stdout: string; exitCode: number } {
+  try {
+    // With no `extraArgs` we rely on oxlint's nested-config discovery, which is
+    // the whole point of Pattern B (and the scenario the editor triggers).
+    // `extraArgs` lets a test pass `-c <config>` to exercise explicit-config runs.
+    const stdout = execFileSync(OXLINT, [...extraArgs, targetFile], {
+      encoding: 'utf-8',
+      cwd,
+      timeout: 60_000,
+      shell: IS_WINDOWS,
+    })
+    return { stdout, exitCode: 0 }
+  } catch (error: unknown) {
+    const err = error as { stdout?: string; stderr?: string; status?: number }
+    return { stdout: (err.stdout ?? '') + (err.stderr ?? ''), exitCode: err.status ?? 1 }
+  }
+}
+
+describe('E2E #39: relative entryPoint resolves per-package regardless of CWD', () => {
+  let MONO: string
+  let packageDir: string
+
+  beforeAll(() => {
+    if (!existsSync(DIST_CJS)) {
+      throw new Error('dist/index.cjs not found. Run `pnpm build` first.')
+    }
+
+    MONO = mkdtempSync(resolve(tmpdir(), 'oxtw-e2e39-'))
+    packageDir = resolve(MONO, 'packages/ui')
+    mkdirSync(resolve(packageDir, 'src/styles'), { recursive: true })
+    mkdirSync(resolve(packageDir, 'src/components'), { recursive: true })
+
+    // Root config declares the plugin + rule. Forward slashes so the absolute
+    // plugin path survives JSON + oxlint resolution on Windows.
+    writeFileSync(
+      resolve(MONO, '.oxlintrc.json'),
+      JSON.stringify(
+        {
+          jsPlugins: [DIST_CJS.split('\\').join('/')],
+          rules: { 'tailwindcss/no-deprecated-classes': 'error' },
+        },
+        null,
+        2,
+      ),
+    )
+
+    // Per-package config (Pattern B): RELATIVE entryPoint, meant to be relative
+    // to THIS file's directory — not whatever CWD oxlint runs from.
+    writeFileSync(
+      resolve(packageDir, '.oxlintrc.json'),
+      JSON.stringify(
+        {
+          extends: ['../../.oxlintrc.json'],
+          settings: { tailwindcss: { entryPoint: './src/styles/app.css' } },
+        },
+        null,
+        2,
+      ),
+    )
+
+    writeFileSync(resolve(packageDir, 'src/styles/app.css'), '@import "tailwindcss";\n')
+    // `flex-grow` is deprecated in Tailwind v4 (→ `grow`): triggers a
+    // DS-dependent rule, which only fires if the CSS entry point loaded.
+    writeFileSync(
+      resolve(packageDir, 'src/components/button.tsx'),
+      'const c = <div className="flex-grow" />;\n',
+    )
+  })
+
+  afterAll(() => {
+    try {
+      rmSync(MONO, { recursive: true, force: true })
+    } catch {}
+  })
+
+  it('detects the deprecated class when run from the package dir (CLI)', () => {
+    const { stdout } = runOxlint(packageDir, 'src/components/button.tsx')
+    expect(stdout).toContain('tailwindcss(no-deprecated-classes)')
+    expect(stdout).not.toContain('Could not stat CSS entry point')
+  })
+
+  it('detects the deprecated class when run from the workspace root (editor) — the bug', () => {
+    const { stdout } = runOxlint(MONO, 'packages/ui/src/components/button.tsx')
+    expect(stdout).toContain('tailwindcss(no-deprecated-classes)')
+    // The pre-fix failure mode: CWD-relative resolution → missing CSS.
+    expect(stdout).not.toContain('Could not stat CSS entry point')
+  })
+
+  it('detects the deprecated class when run from an intermediate dir', () => {
+    const { stdout } = runOxlint(resolve(MONO, 'packages'), 'ui/src/components/button.tsx')
+    expect(stdout).toContain('tailwindcss(no-deprecated-classes)')
+    expect(stdout).not.toContain('Could not stat CSS entry point')
+  })
+})
+
+// Explicit-config (`oxlint -c <config>`) edge from the #39 review. Under `-c`
+// oxlint uses ONLY that config and does NOT walk for nested ones — but the
+// plugin still finds the nearest `.oxlintrc.json` on disk. With the relative
+// entryPoint declared in the explicit root config and an UNRELATED rules-only
+// nested config below the file, the nearest config dir lacks the CSS, so the
+// two-step resolution falls back to the CWD (the workspace root, where the
+// explicit config lives) and resolves correctly. This locks down that the
+// realistic explicit-config layout keeps working.
+describe('E2E #39: explicit `-c` config with an unrelated nested config below', () => {
+  let MONO: string
+
+  beforeAll(() => {
+    if (!existsSync(DIST_CJS)) throw new Error('dist/index.cjs not found. Run `pnpm build` first.')
+
+    MONO = mkdtempSync(resolve(tmpdir(), 'oxtw-e2e39c-'))
+    mkdirSync(resolve(MONO, 'styles'), { recursive: true })
+    mkdirSync(resolve(MONO, 'src/components'), { recursive: true })
+
+    // Explicit root config (the `-c` target): plugin + rule + RELATIVE entry.
+    writeFileSync(
+      resolve(MONO, '.oxlintrc.json'),
+      JSON.stringify(
+        {
+          jsPlugins: [DIST_CJS.split('\\').join('/')],
+          rules: { 'tailwindcss/no-deprecated-classes': 'error' },
+          settings: { tailwindcss: { entryPoint: './styles/app.css' } },
+        },
+        null,
+        2,
+      ),
+    )
+    // Unrelated nested config (rules only, no tailwindcss settings). It is NOT
+    // used by oxlint under `-c`, but it IS the nearest `.oxlintrc.json` the
+    // plugin sees for the linted file.
+    writeFileSync(
+      resolve(MONO, 'src/.oxlintrc.json'),
+      JSON.stringify({ rules: { eqeqeq: 'error' } }, null, 2),
+    )
+    writeFileSync(resolve(MONO, 'styles/app.css'), '@import "tailwindcss";\n')
+    writeFileSync(
+      resolve(MONO, 'src/components/button.tsx'),
+      'const c = <div className="flex-grow" />;\n',
+    )
+  })
+
+  afterAll(() => {
+    try {
+      rmSync(MONO, { recursive: true, force: true })
+    } catch {}
+  })
+
+  it('falls back to CWD and resolves the root-relative CSS', () => {
+    const { stdout } = runOxlint(MONO, 'src/components/button.tsx', ['-c', '.oxlintrc.json'])
+    expect(stdout).toContain('tailwindcss(no-deprecated-classes)')
+    expect(stdout).not.toContain('Could not stat CSS entry point')
+  })
+})

--- a/packages/oxlint-tailwindcss/tests/integration/lazy-loader.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/lazy-loader.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest'
 import { resolve } from 'node:path'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import {
   createLazyLoader,
   getLoadedDesignSystem,
@@ -132,5 +134,72 @@ describe('entryPoint mapping array — first match wins', () => {
       filename: '/somewhere/else/Component.tsx',
     }
     expect(() => createLazyLoader(context)()).toThrow(MissingEntryPointError)
+  })
+})
+
+// Issue #39: in a Pattern-B monorepo (one `.oxlintrc.json` per package with a
+// relative `entryPoint`), the editor (CWD = workspace root) and the CLI
+// (CWD = package dir) must load the SAME package-local CSS. Before the fix the
+// editor resolved `./styles.css` against the workspace root and failed with
+// `Could not stat CSS entry point`.
+describe('createLazyLoader — relative entryPoint anchored to config dir (#39)', () => {
+  let MONO: string
+  let workspaceRoot: string
+  let packageDir: string
+  let lintedFile: string
+  let expectedCss: string
+
+  beforeAll(() => {
+    MONO = mkdtempSync(resolve(tmpdir(), 'oxtw-lazy39-'))
+    workspaceRoot = MONO
+    packageDir = resolve(MONO, 'packages/ui')
+    lintedFile = resolve(packageDir, 'src/Button.tsx')
+    expectedCss = resolve(packageDir, 'styles.css')
+
+    mkdirSync(resolve(packageDir, 'src'), { recursive: true })
+    // `.oxlintrc.json` markers oxlint would discover; only existence matters.
+    writeFileSync(resolve(MONO, '.oxlintrc.json'), '{}')
+    writeFileSync(resolve(packageDir, '.oxlintrc.json'), '{}')
+    // A real, loadable Tailwind v4 entry point local to the package.
+    writeFileSync(expectedCss, '@import "tailwindcss";\n')
+    writeFileSync(lintedFile, 'export const C = () => null\n')
+  })
+
+  afterAll(() => {
+    try {
+      rmSync(MONO, { recursive: true, force: true })
+    } catch {}
+  })
+
+  beforeEach(() => resetDesignSystem())
+
+  function ctx(cwd: string) {
+    return {
+      options: [{}],
+      settings: { tailwindcss: { entryPoint: './styles.css' } },
+      filename: lintedFile,
+      cwd,
+    }
+  }
+
+  it('resolves to the package-local CSS when run from the workspace root (editor)', () => {
+    const result = createLazyLoader(ctx(workspaceRoot))()
+    expect(result.entryPoint).toBe(expectedCss)
+    expect(result.cache.isValid('flex')).toBe(true)
+  })
+
+  it('resolves to the same CSS when run from the package dir (CLI)', () => {
+    const result = createLazyLoader(ctx(packageDir))()
+    expect(result.entryPoint).toBe(expectedCss)
+    expect(result.cache.isValid('flex')).toBe(true)
+  })
+
+  it('agrees on the entry point across every CWD', () => {
+    const fromRoot = createLazyLoader(ctx(workspaceRoot))()
+    const fromPkg = createLazyLoader(ctx(packageDir))()
+    const fromElsewhere = createLazyLoader(ctx(resolve(MONO, 'packages')))()
+    expect(fromRoot.entryPoint).toBe(expectedCss)
+    expect(fromPkg.entryPoint).toBe(expectedCss)
+    expect(fromElsewhere.entryPoint).toBe(expectedCss)
   })
 })


### PR DESCRIPTION
Closes #39.

## Problem

In a Pattern-B monorepo (one `.oxlintrc.json` per package with a **relative** `entryPoint` like `"./src/styles/app.css"`), the entry point was resolved against `process.cwd()`. So the same per-package config resolved to a different CSS depending on where oxlint was launched:

| Context | CWD | Result |
| --- | --- | --- |
| CLI (`cd packages/ui && oxlint`) | `packages/ui/` | ✅ works |
| Editor (VS Code oxlint extension) | workspace root | ❌ `Could not stat CSS entry point: <root>/src/styles/app.css` |

Root cause: oxlint does **not** expose the config file path to plugins — only `filename`, `cwd`, and `settings`.

## Fix

`resolveStringEntryPoint` (in `loader.ts`) now anchors a **relative string** `entryPoint` to the directory of the nearest enclosing `.oxlintrc.json` — the config oxlint applies under its default nested-config discovery — with the CWD as a single fallback.

Deterministic **two-step** `[nearest config dir → CWD]`, fail-loud:
1. nearest config dir candidate — if it exists on disk, use it;
2. CWD candidate — if it exists, use it;
3. otherwise resolve against the nearest config dir so the `Could not stat` diagnostic names the package-local path the user intended.

It deliberately does **not** walk through every ancestor config and probe existence: that would let a coincidentally same-named CSS in an unrelated parent silently shadow a genuine misconfiguration — the same non-determinism that got the legacy `string[]` shape removed in v1.

Absolute `entryPoint`s pass through `resolve()` untouched; the `EntryPointMapping[]` (glob) shape stays CWD-relative as documented.

## Tests

- **Unit** (`loader.test.ts`): config-relative anchoring, CWD-independence across editor/CLI/unrelated CWDs, nearest-wins, CWD fallback, a **determinism guard** proving it never reaches past the nearest config into an unrelated ancestor, no-filePath, and the error path.
- **Integration** (`lazy-loader.test.ts`): `createLazyLoader` editor vs CLI vs intermediate dir, with a real DS load — all agree on the same entry point.
- **E2E** (`monorepo-cwd.test.ts`): drives the real `oxlint` binary from 3 CWDs plus the explicit `-c` edge. Verified these **fail against the pre-fix build** (they reproduce the exact issue error), so they are genuine regression guards.

## Adversarial review

The fix was put through a multi-lens adversarial review (backward-compat, cross-platform, perf, determinism). Confirmed findings were all addressed: reworked from a multi-ancestor walk to the deterministic two-step above; documented the `-c` / `--disable-nested-config` limitation + added an e2e for it; fixed a stale `setup.md` note; removed dead code.

## Docs & versioning

- `monorepo.md`, `settings.md`, `setup.md` (EN + ES), package `README.md`, and `CLAUDE.md` updated to describe the new resolution and the `-c` limitation.
- Version bump `1.3.1 → 1.3.2` (patch) + `CHANGELOG.md` entry.

Full suite (1150 tests), typecheck, lint, format, and docs build all pass.

Thanks to @zorrodg for the detailed report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)