### PR TITLE
docs: document the release process and release-branch mirror invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,31 @@ features or non-breaking additions, major (X.0.0) for breaking changes.
 `packages/oxlint-tailwindcss/package.json` carries the published version; the root `package.json` is
 `private` and stays at `0.0.0`.
 
+## Releases
+
+`release.yml` runs on **push to the `release` branch** and does everything: lint/format/typecheck/
+build/test, deploy docs to Cloudflare Pages, publish to npm (idempotent — `npm view` skips the
+publish when the version already exists, so a docs-only release is fine), and create the GitHub
+Release. `main` is the dev branch; nothing publishes on a push to `main` (CI only).
+
+**To cut a release:**
+
+1. Land the version bump (`packages/oxlint-tailwindcss/package.json`) + `CHANGELOG.md` entry on
+   `main` via a normal PR (squash-merge is fine).
+2. `git push origin main:release`
+
+That's it — the push fast-forwards `release` to `main` and `release.yml` takes over.
+
+> **⚠️ Invariant: `release` is a pure fast-forward mirror of `main`. NEVER put a commit on `release`
+> that isn't on `main`** — no direct commits, no merges _into_ `release`, no cherry-picks, no
+> squash. The branch is only ever advanced by `git push origin main:release`. The moment `release`
+> gets a commit `main` doesn't have, the two diverge, `git push origin main:release` stops
+> fast-forwarding (non-fast-forward rejection), and — because `release` is a **protected branch with
+> `allow_force_pushes: false` and `enforce_admins: true`** — you can't just force it back.
+> Recovering then requires temporarily flipping `allow_force_pushes` to reset `release = main`, or a
+> conflict-resolving merge commit. This is exactly what happened around v1.3.1 (issue #39 work) and
+> cost a detour. Keep `release` clean and the one-liner keeps working.
+
 ## Architecture
 
 oxlint plugin with 23 Tailwind CSS v4 linting rules. Uses `@oxlint/plugins`' `createOnce` API (runs


### PR DESCRIPTION
Adds a **Releases** section to `CLAUDE.md` documenting how releases work and, critically, the invariant that keeps the one-liner release working.

### Why

During the #39 work we hit a branch divergence: `release` carried a commit (`a3e699e`, the v1.3.1 release) that wasn't on `main` (which had its own squashed `230a930`), so `git push origin main:release` stopped fast-forwarding and recovering it cost a detour (a conflict-resolving merge, then a protected-branch force-reset).

`release` has now been reset to an exact mirror of `main`, so `git push origin main:release` works cleanly again. This doc encodes the rule that prevents the divergence from recurring.

### What it documents

- **Release flow:** land the version bump + CHANGELOG on `main` via PR, then `git push origin main:release` — `release.yml` does the rest (docs deploy + idempotent npm publish + GitHub Release).
- **Invariant (⚠️):** `release` is a pure fast-forward mirror of `main`, advanced **only** by `git push origin main:release`. Never put a commit on `release` that isn't on `main` (no direct commits, merges into it, cherry-picks, or squashes) — doing so diverges the branches, breaks the one-liner, and (because `release` is protected with `allow_force_pushes: false` / `enforce_admins: true`) makes recovery costly.

Docs-only change; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)