### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
             node-version: 22
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.4.0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.4.0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,16 @@ jobs:
       deployments: write
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.4.0
 
       # No registry-url: it would write an .npmrc with an empty authToken,
       # which interferes with OIDC. npm defaults to registry.npmjs.org, where
       # the trusted publisher is configured.
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -62,7 +62,7 @@ jobs:
         run: pnpm -C packages/docs build
 
       - name: Deploy docs to Cloudflare Pages
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Clears the **"Node.js 20 actions are deprecated"** warning surfaced on recent workflow runs. GitHub forces Node 24 by default on 2026-06-16 and removes Node 20 from runners on 2026-09-16.

All pins stay as full commit SHAs + version comments (supply-chain best practice). Each target version was verified to run on `node24` (checked `runs.using` in each action's `action.yml` at the pinned tag):

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v4.3.1 | **v6.0.3** |
| `pnpm/action-setup` | v4.3.0 | **v6.0.8** |
| `actions/setup-node` | v4.4.0 | **v6.4.0** |
| `cloudflare/wrangler-action` | v3.15.0 | **v4.0.0** |

Applied across all three workflows (`ci.yml`, `docs.yml`, `release.yml`); `wrangler-action` is `release.yml` only.

### Compatibility checked

- **Inputs unchanged & still valid:** `pnpm/action-setup` still accepts `version` (kept `11.4.0`, consistent with the root `packageManager: pnpm@11.4.0`); `setup-node` still takes `node-version` + `cache: pnpm`.
- **setup-node v5+ auto-cache:** triggered by the `packageManager` field, but the explicit `cache: pnpm` is honored and consistent — no conflict.
- **checkout v5/v6:** only Node 24 + a minimum-runner-version note (GitHub-hosted runners satisfy it). Basic checkout usage unchanged.

### ⚠️ One thing CI can't validate

`wrangler-action` runs **only in `release.yml`** (push to `release`), so it isn't exercised by this PR's CI. Its single breaking change in v4 is that **the default Wrangler version becomes v4** (`latest`) when `wranglerVersion` isn't pinned. Our `wrangler pages deploy <dir> --project-name --branch` command is fully supported on Wrangler v4, so this should be a no-op for the docs deploy — but it'll first be exercised on the next release. If you'd rather stay conservative, we can pin `wranglerVersion: "3.x"` while keeping the node24 action runtime.

Docs/CI-config only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)