### PR TITLE
ci: allow (skip) sharp build script so the Pages deploy doesn't fail

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,7 @@ allowBuilds:
   # as an undecided build and fail with ERR_PNPM_IGNORED_BUILDS. We don't need
   # workerd compiled for a static Pages upload — `false` skips it without error.
   workerd: false
+  # wrangler@4 also pulls `sharp` (native image lib) with a build script. Same
+  # deal as workerd: we're uploading prebuilt static files, so sharp never runs.
+  # `false` decides it so pnpm doesn't fail with ERR_PNPM_IGNORED_BUILDS.
+  sharp: false


### PR DESCRIPTION
## Problem

The v1.3.3 release run failed at **Deploy docs to Cloudflare Pages** (so **Publish to npm** never ran — v1.3.3 is not on npm yet).

`cloudflare/wrangler-action` runs `pnpm add wrangler@4` on the runner. wrangler@4.100 now pulls `sharp`, whose native build script pnpm 11.4 treats as an *undecided* build and aborts with `ERR_PNPM_IGNORED_BUILDS` (exit 1) — the same failure mode the existing `workerd: false` entry already guards against.

## Fix

Add `sharp: false` to `allowBuilds` in `pnpm-workspace.yaml`. We upload prebuilt static files, so sharp never needs to run; `false` decides it and the deploy proceeds.

No version bump: v1.3.3 hasn't published, and `release.yml` is idempotent (`npm view` gates the publish). After merge, `git push origin main:release` re-runs the release and publishes 1.3.3.