### PR TITLE
fix(no-deprecated-classes): remove design-system dependency

### DIFF
--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- **`no-deprecated-classes`**: no longer requires `settings.tailwindcss.entryPoint`. The rule only
+  consults a hardcoded map of v3→v4 renames (`flex-grow` → `grow`, `bg-gradient-to-*` →
+  `bg-linear-to-*`, etc.) and never actually reads the design system, so gating it on a successful
+  design-system load produced a "design system unavailable" fatal diagnostic in projects that hadn't
+  configured `entryPoint` — even though the check itself needed nothing from the design system. The
+  rule now runs unconditionally. Existing configs that pass `entryPoint` as a rule option keep
+  working (the option is ignored).
+
 ## 1.3.4 (2026-06-30)
 
 Dependency maintenance release — no rule behavior changes.

--- a/packages/oxlint-tailwindcss/src/rules/no-deprecated-classes.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-deprecated-classes.ts
@@ -3,8 +3,6 @@ import { createExtractorVisitors, type ClassLocation } from '../utils/extractors
 import { splitClassesWithSeparators } from '../utils/class-splitter'
 import { reportClassReplacements } from '../utils/report'
 import { reattachImportant, splitImportant, splitUtilityAndVariant } from '../utils/class-parser'
-import { createLazyLoader } from '../design-system/loader'
-import { DS_UNAVAILABLE_MESSAGE, safeGetDS } from '../utils/fatal'
 
 // Mapping of deprecated classes in TW v4 to their replacements
 export const DEPRECATED_MAP: Record<string, string> = {
@@ -36,6 +34,9 @@ export const noDeprecatedClasses = defineRule({
       {
         type: 'object',
         properties: {
+          // Accepted for backwards compat with configs from before the DS-guard
+          // was removed. This rule uses a hardcoded rename map and never reads
+          // the design system, so the option is ignored.
           entryPoint: { type: 'string' },
         },
         additionalProperties: false,
@@ -46,16 +47,11 @@ export const noDeprecatedClasses = defineRule({
     messages: {
       deprecated: '"{{className}}" is deprecated in Tailwind v4. Use "{{replacement}}" instead.',
       suggestReplace: 'Replace "{{className}}" with "{{replacement}}".',
-      ...DS_UNAVAILABLE_MESSAGE,
     },
   },
   createOnce(context) {
-    const getDS = createLazyLoader(context)
-
     function check(locations: ClassLocation[]) {
       if (locations.length === 0) return
-      const dsResult = safeGetDS(getDS, context, locations[0].node)
-      if (!dsResult) return
       for (const loc of locations) {
         const split = splitClassesWithSeparators(loc.value)
         const offending = split.classes.flatMap((cls) => {

--- a/packages/oxlint-tailwindcss/tests/rules/no-deprecated-classes.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-deprecated-classes.test.ts
@@ -1,8 +1,5 @@
-import { resolve } from 'node:path'
 import { RuleTester } from 'oxlint/plugins-dev'
 import { noDeprecatedClasses, DEPRECATED_MAP } from '../../src/rules/no-deprecated-classes'
-
-const ENTRY_POINT = resolve(__dirname, '../fixtures/default.css')
 
 const ruleTester = new RuleTester()
 
@@ -11,22 +8,24 @@ ruleTester.run('no-deprecated-classes', noDeprecatedClasses, {
     {
       code: '<div className="grow shrink" />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
     },
     {
       code: '<div className="grow-0 shrink-0" />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
     },
     {
       code: '<div className="text-ellipsis" />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
     },
     {
       code: '<div className="flex items-center" />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
+    },
+    // Backwards compat: `entryPoint` option is still accepted (and ignored).
+    {
+      code: '<div className="grow" />',
+      filename: 'test.tsx',
+      options: [{ entryPoint: '/tmp/does-not-exist.css' }],
     },
   ],
   invalid: [
@@ -34,7 +33,6 @@ ruleTester.run('no-deprecated-classes', noDeprecatedClasses, {
     ...Object.entries(DEPRECATED_MAP).map(([deprecated, replacement]) => ({
       code: `<div className="${deprecated}" />`,
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
       errors: [{ messageId: 'deprecated' as const }],
       output: `<div className="${replacement}" />`,
     })),
@@ -42,7 +40,6 @@ ruleTester.run('no-deprecated-classes', noDeprecatedClasses, {
     {
       code: '<div className="hover:flex-grow" />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
       errors: [{ messageId: 'deprecated' }],
       output: '<div className="hover:grow" />',
     },
@@ -50,7 +47,6 @@ ruleTester.run('no-deprecated-classes', noDeprecatedClasses, {
     {
       code: '<div className={`flex flex-grow ${x}`} />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
       errors: [{ messageId: 'deprecated' }],
       output: '<div className={`flex grow ${x}`} />',
     },
@@ -58,7 +54,6 @@ ruleTester.run('no-deprecated-classes', noDeprecatedClasses, {
     {
       code: '<div className={`${base} flex-grow`} />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
       errors: [{ messageId: 'deprecated' }],
       output: '<div className={`${base} grow`} />',
     },
@@ -66,7 +61,6 @@ ruleTester.run('no-deprecated-classes', noDeprecatedClasses, {
     {
       code: '<div className="flex-grow flex-shrink" />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
       errors: [
         { messageId: 'deprecated' },
         {
@@ -86,7 +80,6 @@ ruleTester.run('no-deprecated-classes', noDeprecatedClasses, {
     {
       code: '<div className="!flex-grow" />',
       filename: 'test.tsx',
-      options: [{ entryPoint: ENTRY_POINT }],
       errors: [{ messageId: 'deprecated' }],
       output: '<div className="!grow" />',
     },


### PR DESCRIPTION
## Summary

`no-deprecated-classes` uses a hardcoded `v3 → v4` rename map (`flex-grow` → `grow`, `bg-gradient-to-*` → `bg-linear-to-*`, etc.) and never consults the design system, but it was calling `safeGetDS()` to gate the check. On projects that hadn't configured `settings.tailwindcss.entryPoint`, this surfaced a `MissingEntryPointError` — even though the rule's logic needed nothing from the design system to run correctly.

I hit this on a Tailwind v4 codebase where the other DS-dependent rules crash with a `__unstable__loadDesignSystem` recursion error, so I disabled them — and was surprised to see `no-deprecated-classes` (a purely mechanical rewrite) fail with the same "design system unavailable" diagnostic.

## The change

- Drop the `safeGetDS()` call in the visitor.
- Drop the `DS_UNAVAILABLE_MESSAGE` spread from `meta.messages` (no longer emitted).
- Drop the import of `createLazyLoader` (no longer used).
- Keep `entryPoint` in the schema (marked as ignored) so existing configs that pass it don't fail schema validation — backwards compatible.
- Update the existing tests to drop the `entryPoint` option, and add a "backwards-compat" test proving the option is still accepted and ignored.

## Before → after

Before, on a project without `settings.tailwindcss.entryPoint`:
```
test.tsx:1:20  error  tailwindcss(no-deprecated-classes): `settings.tailwindcss.entryPoint` is required (linting `test.tsx`)
```

After:
```
test.tsx:1:20  error  tailwindcss(no-deprecated-classes): "flex-grow" is deprecated in Tailwind v4. Use "grow" instead.
```

## Test plan

- [x] Existing tests pass without providing an `entryPoint` — all 24 existing cases still work.
- [x] Added a backwards-compat case with `options: [{ entryPoint: '/tmp/does-not-exist.css' }]` proving the option is still accepted and ignored.
- [x] `pnpm format && pnpm lint && pnpm typecheck && pnpm test` all green.