### PR TITLE
docs(no-deprecated-classes): drop stale DS-dependent wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,10 +117,12 @@ Core sync/async bridge: `@tailwindcss/node`'s `__unstable__loadDesignSystem` is 
    `sort-service`, and `canonicalize-service` all consume those constants — no per-call
    `require.resolve` dance.
 
-DS-dependent rules: `no-unknown-classes`, `no-conflicting-classes`, `no-deprecated-classes`,
-`enforce-canonical`, `enforce-sort-order`, `no-unnecessary-arbitrary-value`, `prefer-theme-tokens`.
+DS-dependent rules: `no-unknown-classes`, `no-conflicting-classes`, `enforce-canonical`,
+`enforce-sort-order`, `no-unnecessary-arbitrary-value`, `prefer-theme-tokens`.
 `consistent-variant-order` is the sole DS-optional rule — its static-order fallback is itself
-deterministic, so a missing entryPoint is tolerated silently there.
+deterministic, so a missing entryPoint is tolerated silently there. `no-deprecated-classes` is
+DS-independent outright (guard removed in #69): it consults only the hardcoded `DEPRECATED_MAP`, so
+it never loads the design system and never emits `designSystemUnavailable`.
 
 ## Extraction System
 

--- a/packages/docs/es/rules/_extras/no-deprecated-classes.md
+++ b/packages/docs/es/rules/_extras/no-deprecated-classes.md
@@ -7,17 +7,16 @@ sobre el nombre viejo. Ejemplos: `flex-grow` → `grow`, `flex-shrink` → `shri
 `bg-linear-to-r` (y el resto de las direcciones de gradient). Los variants y modificadores `!`
 (important) se preservan en ambos lados de la reescritura.
 
-DS-dependiente — requiere `settings.tailwindcss.entryPoint`. La regla usa el design system para
-saber contra qué archivo está trabajando y así jugar bien con el resto del plugin (en particular,
-`no-unknown-classes` omite las clases que esta regla marca para que no veas dos diagnósticos por el
-mismo token). Si el design system no puede cargar, la regla emite un único diagnóstico fatal
-`designSystemUnavailable` por archivo en vez de pasar en silencio.
+No necesita design system. La regla consulta solo el `DEPRECATED_MAP` hardcodeado, así que corre
+incluso cuando `settings.tailwindcss.entryPoint` no está configurado, y nunca emite un diagnóstico
+`designSystemUnavailable`. Igual juega bien con el resto del plugin: `no-unknown-classes` reconoce
+los spellings viejos de v3, así que `flex-grow` recibe un único diagnóstico `deprecated` acá en vez
+de ese más un "unknown class" de otra regla.
 
 ## Opciones
 
-Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, defaultea
-a `settings.tailwindcss.entryPoint`). Configura el entry point en `settings.tailwindcss.entryPoint`
-para todo el proyecto en vez de por-regla cuando puedas.
+Esta regla no tiene opciones. Por compatibilidad hacia atrás todavía acepta un string `entryPoint`
+(sobrante de cuando cargaba el design system), pero el valor se ignora — la regla nunca lo lee.
 
 ## Ejemplos
 
@@ -67,8 +66,8 @@ para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Cuándo desactivarla
 
-- **Sigues en Tailwind v3** y los nombres nuevos no resuelven contra tu design system. Fija el
-  plugin y desactiva esta regla hasta que migres.
+- **Sigues en Tailwind v3** y quieres mantener los spellings de v3. Desactiva esta regla hasta que
+  migres.
 - **Mantienes a propósito una capa de clases v3-compatibles** al lado de v4 (por ejemplo, una
   librería compartida que apunta a ambos). En ese caso prefiere un `eslint-disable` puntual en el
   archivo antes que un disable a nivel proyecto.

--- a/packages/docs/es/rules/no-deprecated-classes.md
+++ b/packages/docs/es/rules/no-deprecated-classes.md
@@ -11,17 +11,16 @@ sobre el nombre viejo. Ejemplos: `flex-grow` → `grow`, `flex-shrink` → `shri
 `bg-linear-to-r` (y el resto de las direcciones de gradient). Los variants y modificadores `!`
 (important) se preservan en ambos lados de la reescritura.
 
-DS-dependiente — requiere `settings.tailwindcss.entryPoint`. La regla usa el design system para
-saber contra qué archivo está trabajando y así jugar bien con el resto del plugin (en particular,
-`no-unknown-classes` omite las clases que esta regla marca para que no veas dos diagnósticos por el
-mismo token). Si el design system no puede cargar, la regla emite un único diagnóstico fatal
-`designSystemUnavailable` por archivo en vez de pasar en silencio.
+No necesita design system. La regla consulta solo el `DEPRECATED_MAP` hardcodeado, así que corre
+incluso cuando `settings.tailwindcss.entryPoint` no está configurado, y nunca emite un diagnóstico
+`designSystemUnavailable`. Igual juega bien con el resto del plugin: `no-unknown-classes` reconoce
+los spellings viejos de v3, así que `flex-grow` recibe un único diagnóstico `deprecated` acá en vez
+de ese más un "unknown class" de otra regla.
 
 ## Opciones
 
-Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, defaultea
-a `settings.tailwindcss.entryPoint`). Configura el entry point en `settings.tailwindcss.entryPoint`
-para todo el proyecto en vez de por-regla cuando puedas.
+Esta regla no tiene opciones. Por compatibilidad hacia atrás todavía acepta un string `entryPoint`
+(sobrante de cuando cargaba el design system), pero el valor se ignora — la regla nunca lo lee.
 
 ## Ejemplos
 
@@ -71,8 +70,8 @@ para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Cuándo desactivarla
 
-- **Sigues en Tailwind v3** y los nombres nuevos no resuelven contra tu design system. Fija el
-  plugin y desactiva esta regla hasta que migres.
+- **Sigues en Tailwind v3** y quieres mantener los spellings de v3. Desactiva esta regla hasta que
+  migres.
 - **Mantienes a propósito una capa de clases v3-compatibles** al lado de v4 (por ejemplo, una
   librería compartida que apunta a ambos). En ese caso prefiere un `eslint-disable` puntual en el
   archivo antes que un disable a nivel proyecto.

--- a/packages/docs/rules/_extras/no-deprecated-classes.md
+++ b/packages/docs/rules/_extras/no-deprecated-classes.md
@@ -7,17 +7,16 @@ deprecated name. Examples: `flex-grow` → `grow`, `flex-shrink` → `shrink`, `
 (and the rest of the gradient directions). Variants and `!` (important) modifiers are preserved on
 both sides of the rewrite.
 
-DS-dependent — requires `settings.tailwindcss.entryPoint`. The rule uses the design system to know
-which file it's working against so it plays nicely with the rest of the plugin (in particular,
-`no-unknown-classes` skips classes flagged here so you don't get two diagnostics for the same
-token). If the design system can't load, the rule emits a single fatal `designSystemUnavailable`
-diagnostic per file instead of silently passing.
+Needs **no** design system. The rule consults only the hardcoded `DEPRECATED_MAP`, so it runs even
+when `settings.tailwindcss.entryPoint` is not configured, and it never emits a
+`designSystemUnavailable` diagnostic. It still plays nicely with the rest of the plugin:
+`no-unknown-classes` recognizes the legacy v3 spellings, so `flex-grow` gets a single `deprecated`
+diagnostic here rather than that plus an "unknown class" from another rule.
 
 ## Options
 
-This rule has no per-rule options beyond the standard `entryPoint` override (string, defaults to
-`settings.tailwindcss.entryPoint`). Configure the entry point in `settings.tailwindcss.entryPoint`
-for the whole project instead of per-rule whenever possible.
+This rule has no options. For backwards compatibility it still accepts an `entryPoint` string (left
+over from when it loaded the design system), but the value is ignored — the rule never reads it.
 
 ## Examples
 
@@ -67,8 +66,8 @@ for the whole project instead of per-rule whenever possible.
 
 ## When to disable it
 
-- **You're still on Tailwind v3** and the new names don't resolve against your design system. Pin
-  the plugin and disable this rule until you migrate.
+- **You're still on Tailwind v3** and want to keep the v3 spellings. Disable this rule until you
+  migrate.
 - **You intentionally ship a v3-compatible class layer** alongside v4 (for example, a shared library
   that targets both). In that case prefer a targeted `eslint-disable` on the file rather than a
   project-wide disable.

--- a/packages/docs/rules/no-deprecated-classes.md
+++ b/packages/docs/rules/no-deprecated-classes.md
@@ -11,17 +11,16 @@ deprecated name. Examples: `flex-grow` → `grow`, `flex-shrink` → `shrink`, `
 (and the rest of the gradient directions). Variants and `!` (important) modifiers are preserved on
 both sides of the rewrite.
 
-DS-dependent — requires `settings.tailwindcss.entryPoint`. The rule uses the design system to know
-which file it's working against so it plays nicely with the rest of the plugin (in particular,
-`no-unknown-classes` skips classes flagged here so you don't get two diagnostics for the same
-token). If the design system can't load, the rule emits a single fatal `designSystemUnavailable`
-diagnostic per file instead of silently passing.
+Needs **no** design system. The rule consults only the hardcoded `DEPRECATED_MAP`, so it runs even
+when `settings.tailwindcss.entryPoint` is not configured, and it never emits a
+`designSystemUnavailable` diagnostic. It still plays nicely with the rest of the plugin:
+`no-unknown-classes` recognizes the legacy v3 spellings, so `flex-grow` gets a single `deprecated`
+diagnostic here rather than that plus an "unknown class" from another rule.
 
 ## Options
 
-This rule has no per-rule options beyond the standard `entryPoint` override (string, defaults to
-`settings.tailwindcss.entryPoint`). Configure the entry point in `settings.tailwindcss.entryPoint`
-for the whole project instead of per-rule whenever possible.
+This rule has no options. For backwards compatibility it still accepts an `entryPoint` string (left
+over from when it loaded the design system), but the value is ignored — the rule never reads it.
 
 ## Examples
 
@@ -71,8 +70,8 @@ for the whole project instead of per-rule whenever possible.
 
 ## When to disable it
 
-- **You're still on Tailwind v3** and the new names don't resolve against your design system. Pin
-  the plugin and disable this rule until you migrate.
+- **You're still on Tailwind v3** and want to keep the v3 spellings. Disable this rule until you
+  migrate.
 - **You intentionally ship a v3-compatible class layer** alongside v4 (for example, a shared library
   that targets both). In that case prefer a targeted `eslint-disable` on the file rather than a
   project-wide disable.

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -205,11 +205,12 @@ Output:
 ```
 
 If no entry point is configured, the DS-dependent rules (`no-unknown-classes`,
-`no-conflicting-classes`, `no-deprecated-classes`, `enforce-canonical`, `enforce-sort-order`,
+`no-conflicting-classes`, `enforce-canonical`, `enforce-sort-order`,
 `no-unnecessary-arbitrary-value`, `prefer-theme-tokens`) emit a single `designSystemUnavailable`
-diagnostic per file with an actionable hint — no more silent skips. `consistent-variant-order` is
-the lone exception: its static fallback is itself deterministic, so a missing entryPoint is
-tolerated there. All non-DS rules work without an entry point.
+diagnostic per file with an actionable hint — no more silent skips. `consistent-variant-order`
+tolerates a missing entryPoint (its static fallback is itself deterministic), and
+`no-deprecated-classes` needs no design system at all (it only consults a hardcoded v3→v4 rename
+map). All non-DS rules work without an entry point.
 
 ## Custom class detection
 


### PR DESCRIPTION
Follow-up to #69, which removed the design-system guard from `no-deprecated-classes`.

The docs and internal notes still described the pre-#69 behavior — that the rule "uses the design system", "requires `settings.tailwindcss.entryPoint`", and emits a fatal `designSystemUnavailable`. None of that holds anymore: the rule consults only the hardcoded `DEPRECATED_MAP` and needs no design system to run.

## Changes

- **Rule pages (`_extras`, EN + ES)** — rewrite the paragraph to "needs no design system"; fix the Options section (the `entryPoint` option is now accepted-but-ignored for backwards compat); soften the "When to disable" bullet that implied a DS check. Regenerated `rules/no-deprecated-classes.md` + `es/rules/no-deprecated-classes.md` via `pnpm -C packages/docs generate`.
- **`packages/oxlint-tailwindcss/README.md`** — move `no-deprecated-classes` out of the DS-dependent list into the non-DS note.
- **`CLAUDE.md`** — drop it from the DS-dependent list; note it is DS-independent outright.

Docs-only; no rule behavior changes. `pnpm format:check && pnpm lint && pnpm typecheck` all green locally.