### PR TITLE
release: v1.3.5 — no-deprecated-classes fix + dependency maintenance

### DIFF
--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.3.5 (2026-07-10)
 
 ### Bug fixes
 

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",


### PR DESCRIPTION
Cuts **v1.3.5**. Patch release — no breaking changes, no new features.

## What ships

- **`no-deprecated-classes` no longer requires `settings.tailwindcss.entryPoint`** (#69). The rule only consults a hardcoded v3→v4 rename map and never reads the design system; the removed guard was producing a spurious fatal `designSystemUnavailable`.
- **Dependency maintenance** (#71) — `oxlint`/`@oxlint/plugins` 1.73.0 (bundled), `oxfmt` 0.58.0, `vitest` 4.1.10, `@types/node` 26.1.1, `tsdown` 0.22.4, `@typescript/native-preview` 20260707.2, `vitepress` alpha.18. Runtime deps unchanged (`tailwindcss`/`@tailwindcss/node` 4.3.2).
- Docs sweep dropping the stale "DS-dependent" wording for the rule (#70).

## Changes in this PR

- `packages/oxlint-tailwindcss/package.json`: `1.3.4` → `1.3.5`.
- `CHANGELOG.md`: finalize `## Unreleased` → `## 1.3.5 (2026-07-10)`.

## Verified

`pnpm format:check`, `pnpm build`, `pnpm test` (1151) all green locally; the tooling bumps were already CI-verified in #71.

## Release step (after squash-merge)

`git push origin main:release` fast-forwards `release` and triggers `release.yml` (publish to npm + GitHub Release + docs deploy). `release` is currently at v1.3.4 (a strict ancestor of `main`), so the push stays a clean fast-forward.