### PR TITLE
perf: persist the canonicalize cache to disk, keyed by DS content hash

### DIFF
--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -43,6 +43,14 @@
   two-package run could spend far longer than linting the packages separately. Sticky worker errors
   are now tracked per entry point as well. Fixes
   [#77](https://github.com/sergioazoc/oxlint-tailwindcss/issues/77).
+- **Canonicalize cache is now persisted to disk.** Every `oxlint` invocation is a fresh process, so
+  the per-class canonicalize cache started empty each run and every unique dynamic class (`p-[2px]`,
+  `bg-(--c)`, …) paid a synchronous worker round-trip again — on arbitrary-value-heavy codebases
+  `enforce-canonical` dominated the whole lint run. The cache is now written next to the
+  design-system precompute artifact and keyed by the canonicalization logic (worker script +
+  rounding), so it invalidates together with the design system or a logic change, and is re-used
+  across runs. Measured on a production app (~1,470 files): ~7.0s → ~1.0s per run after the first.
+  Diagnostics are unchanged.
 
 ### Dependencies
 
@@ -52,6 +60,15 @@
 - Type-checking now runs on the stable `typescript` (`tsc`, `7.0.2`) directly. The
   `@typescript/native-preview` (`tsgo`) dev dependency — a preview of the native compiler before it
   shipped as TypeScript 7 — has been dropped. No effect on the published package.
+### Performance
+
+- **Canonicalize cache is now persisted to disk.** Every `oxlint` invocation is a fresh process, so
+  the per-class canonicalize cache started empty each run and every unique dynamic class (`p-[2px]`,
+  `bg-(--c)`, …) paid a synchronous worker round-trip again — on arbitrary-value-heavy codebases
+  `enforce-canonical` dominated the whole lint run. The cache is now written next to the
+  design-system precompute artifact (content-hash keyed, so it invalidates together with the design
+  system) and re-used across runs. Measured on a production app (~1,470 files): ~7.0s → ~1.0s per
+  run after the first. Diagnostics are unchanged.
 
 ## 1.3.5 (2026-07-10)
 

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -49,8 +49,9 @@
   `enforce-canonical` dominated the whole lint run. The cache is now written next to the
   design-system precompute artifact and keyed by the canonicalization logic (worker script +
   rounding), so it invalidates together with the design system or a logic change, and is re-used
-  across runs. Measured on a production app (~1,470 files): ~7.0s → ~1.0s per run after the first.
-  Diagnostics are unchanged.
+  across runs. Writes are merged under a per-file lock, so the parallel worker threads oxlint runs
+  converge on a fully warm cache in a single run rather than over several. Measured on a production
+  app (~1,470 files): ~7.0s → ~1.0s per run after the first. Diagnostics are unchanged.
 
 ### Dependencies
 
@@ -60,16 +61,6 @@
 - Type-checking now runs on the stable `typescript` (`tsc`, `7.0.2`) directly. The
   `@typescript/native-preview` (`tsgo`) dev dependency — a preview of the native compiler before it
   shipped as TypeScript 7 — has been dropped. No effect on the published package.
-
-### Performance
-
-- **Canonicalize cache is now persisted to disk.** Every `oxlint` invocation is a fresh process, so
-  the per-class canonicalize cache started empty each run and every unique dynamic class (`p-[2px]`,
-  `bg-(--c)`, …) paid a synchronous worker round-trip again — on arbitrary-value-heavy codebases
-  `enforce-canonical` dominated the whole lint run. The cache is now written next to the
-  design-system precompute artifact (content-hash keyed, so it invalidates together with the design
-  system) and re-used across runs. Measured on a production app (~1,470 files): ~7.0s → ~1.0s per
-  run after the first. Diagnostics are unchanged.
 
 ## 1.3.5 (2026-07-10)
 

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Type-checking now runs on the stable `typescript` (`tsc`, `7.0.2`) directly. The
   `@typescript/native-preview` (`tsgo`) dev dependency — a preview of the native compiler before it
   shipped as TypeScript 7 — has been dropped. No effect on the published package.
+
 ### Performance
 
 - **Canonicalize cache is now persisted to disk.** Every `oxlint` invocation is a fresh process, so

--- a/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
@@ -15,7 +15,15 @@
  */
 
 import { createHash } from 'node:crypto'
-import { readFileSync, renameSync, writeFileSync } from 'node:fs'
+import {
+  closeSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { threadId } from 'node:worker_threads'
 import { DesignSystemWorker, makeWorkerScript } from './ds-worker'
 import { cacheArtifactPaths } from './sync-loader'
@@ -137,10 +145,15 @@ const CANON_LOGIC_HASH = createHash('md5')
 // on a subsequent run, consistent with the cache's cross-run convergence.
 export const FLUSH_THRESHOLD = 16
 
-// Per-(pid,thread) tmp-file counter. oxlint runs many worker threads in one
-// process, so the tmp name must include threadId + a sequence to avoid
+// Per-(pid,thread) tmp/reclaim-file counter. oxlint runs many worker threads in
+// one process, so temp names must include threadId + a sequence to avoid
 // collisions and renameSync races (mirrors sync-loader.ts).
 let tmpSeq = 0
+
+// A flush older than this is treated as abandoned (a crashed isolate that never
+// released its lock) and reclaimed, so a leaked lock can't disable persistence
+// forever. Generous: a real flush holds the lock for microseconds.
+const LOCK_STALE_MS = 10_000
 
 interface PersistState {
   file: string
@@ -150,6 +163,61 @@ interface PersistState {
 
 /** One persistence state per `${cssPath}\0${rem}\0` cache prefix. */
 const persistStates = new Map<string, PersistState>()
+
+function tryUnlink(path: string): void {
+  try {
+    unlinkSync(path)
+  } catch {
+    // Already gone, or not ours to remove — nothing to do.
+  }
+}
+
+/**
+ * Reclaim a stale lock via exclusive rename rather than unlink (mirrors
+ * sync-loader.ts): two isolates that both judge the lock stale would otherwise
+ * both unlink it, and the second could delete a FRESH lock a third isolate just
+ * created. `renameSync` has a single winner; the loser gets ENOENT and moves on.
+ */
+function reclaimStaleLock(lockPath: string): void {
+  let ageMs: number
+  try {
+    ageMs = Date.now() - statSync(lockPath).mtimeMs
+  } catch {
+    return // vanished already
+  }
+  if (ageMs < LOCK_STALE_MS) return
+  const reclaimPath = `${lockPath}.reclaim.${process.pid}.${threadId}.${tmpSeq++}`
+  try {
+    renameSync(lockPath, reclaimPath)
+  } catch {
+    return // someone else reclaimed/released it first
+  }
+  tryUnlink(reclaimPath)
+}
+
+type LockOutcome = 'acquired' | 'contended' | 'unavailable'
+
+/**
+ * Acquire the per-file flush lock by atomic exclusive create (`wx`). The lock
+ * serializes the read-merge-write below so concurrent isolates don't clobber
+ * each other's entries (last-writer-wins → the cache would otherwise only
+ * converge over several runs). Distinguishes contention (another isolate is
+ * mid-flush — skip and retry next threshold) from an unwritable dir (give up).
+ */
+function acquireFlushLock(lockPath: string): LockOutcome {
+  const tryCreate = (): LockOutcome => {
+    try {
+      closeSync(openSync(lockPath, 'wx'))
+      return 'acquired'
+    } catch (e) {
+      return (e as NodeJS.ErrnoException).code === 'EEXIST' ? 'contended' : 'unavailable'
+    }
+  }
+  const first = tryCreate()
+  if (first !== 'contended') return first
+  reclaimStaleLock(lockPath)
+  return tryCreate()
+}
 
 /** Exported for tests: the exact on-disk cache path for a (cssPath, rem). */
 export function persistFileFor(cssPath: string, rem?: number): string | null {
@@ -190,29 +258,65 @@ function ensurePersistLoaded(cssPath: string, rem: number | undefined, cachePref
   }
 }
 
-/** Atomically write all cached entries for this prefix to disk. */
+/**
+ * Persist this prefix's entries under a per-file lock, merging with whatever is
+ * already on disk first. oxlint worker threads are separate JS isolates, each
+ * with its own in-memory `canonCache`, so the file is their shared channel: a
+ * bare overwrite would clobber the entries other isolates persisted
+ * (last-writer-wins), leaving the cache to converge only over several runs.
+ * Read-merge-write under the lock makes it converge in one.
+ */
 function flushPersist(cachePrefix: string, state: PersistState): void {
   if (state.dirty <= 0) return
+
+  const lockPath = `${state.file}.lock`
+  const lock = acquireFlushLock(lockPath)
+  // Another isolate holds the lock: skip now, keep `dirty` so the next batch
+  // over-threshold retries. Unwritable dir: give up on persistence entirely.
+  if (lock === 'contended') return
+  if (lock === 'unavailable') {
+    state.dirty = -1
+    return
+  }
+
   try {
-    // Serialize as [canonical, safe] tuples — compact, and carries the #78
-    // safe flag through so a restored entry gates the autofix identically.
-    const out: Record<string, [string, boolean]> = {}
+    // Start from what is already on disk so we don't drop another isolate's
+    // (or a prior run's) entries; then overlay ours. Values are deterministic
+    // for a given DS + logic hash, so overlapping keys carry identical values.
+    const merged: Record<string, [string, boolean]> = {}
+    try {
+      const existing: unknown = JSON.parse(readFileSync(state.file, 'utf-8'))
+      if (typeof existing === 'object' && existing !== null) {
+        for (const [cls, entry] of Object.entries(existing)) {
+          if (
+            Array.isArray(entry) &&
+            typeof entry[0] === 'string' &&
+            typeof entry[1] === 'boolean'
+          ) {
+            merged[cls] = [entry[0], entry[1]]
+          }
+        }
+      }
+    } catch {
+      // No existing file, or corrupt — our entries alone become the new file.
+    }
     for (const [key, value] of canonCache) {
       if (key.startsWith(cachePrefix)) {
-        out[key.slice(cachePrefix.length)] = [value.canonical, value.safe]
+        merged[key.slice(cachePrefix.length)] = [value.canonical, value.safe]
       }
     }
-    // Unique per pid+thread+seq: oxlint runs many worker threads in one
-    // process, so a bare pid would collide and race on renameSync (mirrors
-    // sync-loader.ts). Threads still last-writer-win on the final file, so the
-    // cache converges over runs — correctness is unaffected.
+
+    // Unique tmp per pid+thread+seq, then atomic rename into place (the lock
+    // serializes writers; the unique name guards against any residual overlap).
     const tmp = `${state.file}.${process.pid}.${threadId}.${tmpSeq++}.tmp`
-    writeFileSync(tmp, JSON.stringify(out))
+    writeFileSync(tmp, JSON.stringify(merged))
     renameSync(tmp, state.file)
     state.dirty = 0
   } catch {
-    // Unwritable cache dir — disable persistence for this prefix.
+    // Write failed after acquiring the lock — disable persistence for this prefix.
     state.dirty = -1
+  } finally {
+    tryUnlink(lockPath)
   }
 }
 

--- a/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
@@ -14,7 +14,9 @@
  * subsequent lookup is O(1).
  */
 
+import { createHash } from 'node:crypto'
 import { readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { threadId } from 'node:worker_threads'
 import { DesignSystemWorker, makeWorkerScript } from './ds-worker'
 import { cacheArtifactPaths } from './sync-loader'
 import { SortServiceError } from '../utils/fatal'
@@ -101,15 +103,44 @@ const canonCache = new Map<string, CanonicalizeResult>()
  * round-trip again on every run — on arbitrary-value-heavy codebases this
  * dominates the whole lint (seconds per run, issue: enforce-canonical perf).
  *
- * The canonical results are pure functions of the design system + rem, so we
- * persist them next to the DS precompute artifact, deriving the filename from
- * `cacheArtifactPaths(cssPath).json` (content-hash keyed). When the DS
- * changes, the hash changes, and the canonical cache invalidates with it.
+ * The canonical results are pure functions of the design system + rem + the
+ * canonicalization logic, so we persist them next to the DS precompute
+ * artifact, deriving the filename from `cacheArtifactPaths(cssPath).json`
+ * (content-hash keyed) plus `CANON_LOGIC_HASH` (below). When the DS changes,
+ * the artifact hash changes; when the canonicalization logic changes, the
+ * logic hash changes — either way the canonical cache invalidates with it, so
+ * no manual version bump is needed and stale values can never reach an autofix.
+ *
+ * We persist the full `CanonicalizeResult` (`canonical` + the #78 `safe`
+ * flag), not just the string: `safe` gates whether `enforce-canonical`
+ * actually applies the rewrite, so dropping it on restore would re-introduce
+ * the unsafe-autofix bug #78 fixed.
  *
  * Best-effort everywhere: a missing/corrupt/unwritable cache file must never
  * break linting — it only costs worker round-trips.
  */
-const CANON_CACHE_VERSION = 'v1'
+
+// Auto-invalidating cache-key component: md5 of the worker canonicalization
+// script + the rounding function source. Any change to how a class is
+// canonicalized (handler logic) or rounded flips this, so an old on-disk cache
+// simply isn't found — the same self-healing the DS precompute cache gets from
+// md5(PRECOMPUTE_SCRIPT). Replaces a hand-maintained version constant.
+const CANON_LOGIC_HASH = createHash('md5')
+  .update(WORKER_SCRIPT + roundRemValue.toString())
+  .digest('hex')
+  .slice(0, 8)
+
+// Flush after this many newly-canonicalized classes accumulate, rather than
+// after every miss batch: rewriting the whole prefix map per batch is ~O(n²)
+// IO on a cold run. A sub-threshold tail is not force-flushed (we must not
+// register a process-exit listener — see exit-listeners.test.ts); it persists
+// on a subsequent run, consistent with the cache's cross-run convergence.
+export const FLUSH_THRESHOLD = 16
+
+// Per-(pid,thread) tmp-file counter. oxlint runs many worker threads in one
+// process, so the tmp name must include threadId + a sequence to avoid
+// collisions and renameSync races (mirrors sync-loader.ts).
+let tmpSeq = 0
 
 interface PersistState {
   file: string
@@ -120,11 +151,12 @@ interface PersistState {
 /** One persistence state per `${cssPath}\0${rem}\0` cache prefix. */
 const persistStates = new Map<string, PersistState>()
 
-function persistFileFor(cssPath: string, rem?: number): string | null {
+/** Exported for tests: the exact on-disk cache path for a (cssPath, rem). */
+export function persistFileFor(cssPath: string, rem?: number): string | null {
   try {
     const { json } = cacheArtifactPaths(cssPath)
     const remKey = rem === undefined ? 'default' : String(rem)
-    return json.replace(/\.json$/, `.canon-${CANON_CACHE_VERSION}-${remKey}.json`)
+    return json.replace(/\.json$/, `.canon-${CANON_LOGIC_HASH}-${remKey}.json`)
   } catch {
     return null
   }
@@ -145,8 +177,12 @@ function ensurePersistLoaded(cssPath: string, rem: number | undefined, cachePref
   try {
     const data: unknown = JSON.parse(readFileSync(file, 'utf-8'))
     if (typeof data === 'object' && data !== null) {
-      for (const [cls, canonical] of Object.entries(data)) {
-        if (typeof canonical === 'string') canonCache.set(cachePrefix + cls, canonical)
+      for (const [cls, entry] of Object.entries(data)) {
+        // Persisted shape: [canonical, safe]. Validate strictly — a
+        // corrupt/old-shape entry is skipped, never trusted into an autofix.
+        if (Array.isArray(entry) && typeof entry[0] === 'string' && typeof entry[1] === 'boolean') {
+          canonCache.set(cachePrefix + cls, { canonical: entry[0], safe: entry[1] })
+        }
       }
     }
   } catch {
@@ -158,11 +194,19 @@ function ensurePersistLoaded(cssPath: string, rem: number | undefined, cachePref
 function flushPersist(cachePrefix: string, state: PersistState): void {
   if (state.dirty <= 0) return
   try {
-    const out: Record<string, string> = {}
+    // Serialize as [canonical, safe] tuples — compact, and carries the #78
+    // safe flag through so a restored entry gates the autofix identically.
+    const out: Record<string, [string, boolean]> = {}
     for (const [key, value] of canonCache) {
-      if (key.startsWith(cachePrefix)) out[key.slice(cachePrefix.length)] = value
+      if (key.startsWith(cachePrefix)) {
+        out[key.slice(cachePrefix.length)] = [value.canonical, value.safe]
+      }
     }
-    const tmp = `${state.file}.${process.pid}.tmp`
+    // Unique per pid+thread+seq: oxlint runs many worker threads in one
+    // process, so a bare pid would collide and race on renameSync (mirrors
+    // sync-loader.ts). Threads still last-writer-win on the final file, so the
+    // cache converges over runs — correctness is unaffected.
+    const tmp = `${state.file}.${process.pid}.${threadId}.${tmpSeq++}.tmp`
     writeFileSync(tmp, JSON.stringify(out))
     renameSync(tmp, state.file)
     state.dirty = 0
@@ -237,15 +281,16 @@ export function canonicalizeClassesSync(
     out[missingIdx[j]] = value
   }
 
-  // Write-through: flush after every batch that produced fresh results.
-  // Deliberately NOT an exit hook — these services must not register process
-  // listeners (see tests/design-system/exit-listeners.test.ts). The write is
-  // a few-KB atomic tmp+rename, negligible next to the worker round-trips it
-  // eliminates on the next run.
+  // Debounced flush: accumulate the batch's fresh count and only write once it
+  // crosses FLUSH_THRESHOLD, to avoid the ~O(n²) IO of rewriting the whole
+  // prefix map after every batch. No exit hook force-flushes the sub-threshold
+  // tail (these services must not register process listeners — see
+  // exit-listeners.test.ts); it persists on a later run, consistent with the
+  // cache's documented cross-run convergence.
   const state = persistStates.get(cachePrefix)
   if (state && state.dirty >= 0) {
     state.dirty += uniqueMissing.length
-    flushPersist(cachePrefix, state)
+    if (state.dirty >= FLUSH_THRESHOLD) flushPersist(cachePrefix, state)
   }
 
   return out

--- a/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
@@ -14,7 +14,9 @@
  * subsequent lookup is O(1).
  */
 
+import { readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { DesignSystemWorker, makeWorkerScript } from './ds-worker'
+import { cacheArtifactPaths } from './sync-loader'
 import { SortServiceError } from '../utils/fatal'
 import { roundRemValue } from '../utils/floating-point'
 
@@ -92,6 +94,85 @@ const canonWorker = new DesignSystemWorker<CanonicalizeRequest, CanonicalizeResu
 const canonCache = new Map<string, CanonicalizeResult>()
 
 /**
+ * ## Disk persistence (per design system + rem)
+ *
+ * Each `oxlint` invocation is a fresh process, so without persistence every
+ * unique dynamic class (`p-[2px]`, `bg-(--c)`, …) pays a synchronous worker
+ * round-trip again on every run — on arbitrary-value-heavy codebases this
+ * dominates the whole lint (seconds per run, issue: enforce-canonical perf).
+ *
+ * The canonical results are pure functions of the design system + rem, so we
+ * persist them next to the DS precompute artifact, deriving the filename from
+ * `cacheArtifactPaths(cssPath).json` (content-hash keyed). When the DS
+ * changes, the hash changes, and the canonical cache invalidates with it.
+ *
+ * Best-effort everywhere: a missing/corrupt/unwritable cache file must never
+ * break linting — it only costs worker round-trips.
+ */
+const CANON_CACHE_VERSION = 'v1'
+
+interface PersistState {
+  file: string
+  /** entries added since last flush; -1 = persistence unavailable */
+  dirty: number
+}
+
+/** One persistence state per `${cssPath}\0${rem}\0` cache prefix. */
+const persistStates = new Map<string, PersistState>()
+
+function persistFileFor(cssPath: string, rem?: number): string | null {
+  try {
+    const { json } = cacheArtifactPaths(cssPath)
+    const remKey = rem === undefined ? 'default' : String(rem)
+    return json.replace(/\.json$/, `.canon-${CANON_CACHE_VERSION}-${remKey}.json`)
+  } catch {
+    return null
+  }
+}
+
+/** Load the persisted map (if any) into `canonCache`, and set up flushing. */
+function ensurePersistLoaded(cssPath: string, rem: number | undefined, cachePrefix: string): void {
+  if (persistStates.has(cachePrefix)) return
+
+  const file = persistFileFor(cssPath, rem)
+  if (file === null) {
+    persistStates.set(cachePrefix, { file: '', dirty: -1 })
+    return
+  }
+  const state: PersistState = { file, dirty: 0 }
+  persistStates.set(cachePrefix, state)
+
+  try {
+    const data: unknown = JSON.parse(readFileSync(file, 'utf-8'))
+    if (typeof data === 'object' && data !== null) {
+      for (const [cls, canonical] of Object.entries(data)) {
+        if (typeof canonical === 'string') canonCache.set(cachePrefix + cls, canonical)
+      }
+    }
+  } catch {
+    // No cache yet, or unreadable/corrupt — start fresh.
+  }
+}
+
+/** Atomically write all cached entries for this prefix to disk. */
+function flushPersist(cachePrefix: string, state: PersistState): void {
+  if (state.dirty <= 0) return
+  try {
+    const out: Record<string, string> = {}
+    for (const [key, value] of canonCache) {
+      if (key.startsWith(cachePrefix)) out[key.slice(cachePrefix.length)] = value
+    }
+    const tmp = `${state.file}.${process.pid}.tmp`
+    writeFileSync(tmp, JSON.stringify(out))
+    renameSync(tmp, state.file)
+    state.dirty = 0
+  } catch {
+    // Unwritable cache dir — disable persistence for this prefix.
+    state.dirty = -1
+  }
+}
+
+/**
  * Canonicalize classes via the worker thread.
  *
  * Throws `SortServiceError` on any worker failure (init timeout, request
@@ -111,6 +192,8 @@ export function canonicalizeClassesSync(
   const missingIdx: number[] = []
   const missing: string[] = []
   const cachePrefix = `${cssPath}\0${rem ?? ''}\0`
+
+  ensurePersistLoaded(cssPath, rem, cachePrefix)
 
   for (let i = 0; i < classes.length; i++) {
     const key = cachePrefix + classes[i]
@@ -154,6 +237,17 @@ export function canonicalizeClassesSync(
     out[missingIdx[j]] = value
   }
 
+  // Write-through: flush after every batch that produced fresh results.
+  // Deliberately NOT an exit hook — these services must not register process
+  // listeners (see tests/design-system/exit-listeners.test.ts). The write is
+  // a few-KB atomic tmp+rename, negligible next to the worker round-trips it
+  // eliminates on the next run.
+  const state = persistStates.get(cachePrefix)
+  if (state && state.dirty >= 0) {
+    state.dirty += uniqueMissing.length
+    flushPersist(cachePrefix, state)
+  }
+
   return out
 }
 
@@ -161,4 +255,5 @@ export function canonicalizeClassesSync(
 export function resetCanonicalizeService(): void {
   canonWorker.reset()
   canonCache.clear()
+  persistStates.clear()
 }

--- a/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
@@ -138,13 +138,6 @@ const CANON_LOGIC_HASH = createHash('md5')
   .digest('hex')
   .slice(0, 8)
 
-// Flush after this many newly-canonicalized classes accumulate, rather than
-// after every miss batch: rewriting the whole prefix map per batch is ~O(n²)
-// IO on a cold run. A sub-threshold tail is not force-flushed (we must not
-// register a process-exit listener — see exit-listeners.test.ts); it persists
-// on a subsequent run, consistent with the cache's cross-run convergence.
-export const FLUSH_THRESHOLD = 16
-
 // Per-(pid,thread) tmp/reclaim-file counter. oxlint runs many worker threads in
 // one process, so temp names must include threadId + a sequence to avoid
 // collisions and renameSync races (mirrors sync-loader.ts).
@@ -385,16 +378,18 @@ export function canonicalizeClassesSync(
     out[missingIdx[j]] = value
   }
 
-  // Debounced flush: accumulate the batch's fresh count and only write once it
-  // crosses FLUSH_THRESHOLD, to avoid the ~O(n²) IO of rewriting the whole
-  // prefix map after every batch. No exit hook force-flushes the sub-threshold
-  // tail (these services must not register process listeners — see
-  // exit-listeners.test.ts); it persists on a later run, consistent with the
-  // cache's documented cross-run convergence.
+  // Write-through: flush after every batch that produced fresh entries. A
+  // threshold-based debounce is deliberately NOT used — oxlint fans the work
+  // across many worker threads (separate isolates), so per-thread miss counts
+  // rarely reach any useful threshold on a warm run, and the residual would
+  // never persist: the cache stalls partway and never converges. The lock
+  // already throttles concurrent flushes, and whole-file rewrites are cheap at
+  // realistic sizes (a few hundred entries), so write-through is both correct
+  // (converges in one run) and inexpensive.
   const state = persistStates.get(cachePrefix)
   if (state && state.dirty >= 0) {
     state.dirty += uniqueMissing.length
-    if (state.dirty >= FLUSH_THRESHOLD) flushPersist(cachePrefix, state)
+    flushPersist(cachePrefix, state)
   }
 
   return out

--- a/packages/oxlint-tailwindcss/tests/design-system/canonicalize-persistence.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/canonicalize-persistence.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  canonicalizeClassesSync,
+  resetCanonicalizeService,
+} from '../../src/design-system/canonicalize-service'
+import { cacheArtifactPaths } from '../../src/design-system/sync-loader'
+
+const ENTRY_POINT = resolve(__dirname, '../fixtures/default.css')
+
+/**
+ * The canonicalize service persists its per-class cache to disk next to the
+ * design-system precompute artifact (content-hash keyed, so it invalidates
+ * together with the design system). A fresh process — every real `oxlint`
+ * invocation — then serves previously-seen dynamic classes from disk instead
+ * of paying a synchronous worker round-trip per unique class.
+ *
+ * `resetCanonicalizeService()` clears the in-memory cache AND the persistence
+ * state, so a reset + call cycle is the closest in-process equivalent of a
+ * fresh oxlint run.
+ */
+
+// Derived the same way as the service does: DS artifact path + canon suffix.
+function persistedCachePath(rem?: number): string {
+  const { json } = cacheArtifactPaths(ENTRY_POINT)
+  const remKey = rem === undefined ? 'default' : String(rem)
+  return json.replace(/\.json$/, `.canon-v1-${remKey}.json`)
+}
+
+describe('canonicalize cache disk persistence', () => {
+  beforeEach(() => {
+    resetCanonicalizeService()
+    rmSync(persistedCachePath(), { force: true })
+    rmSync(persistedCachePath(16), { force: true })
+  })
+
+  afterEach(() => {
+    resetCanonicalizeService()
+    rmSync(persistedCachePath(), { force: true })
+    rmSync(persistedCachePath(16), { force: true })
+  })
+
+  it('writes canonicalized classes to a content-hash-keyed file', () => {
+    const [canonical] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
+
+    const persisted = JSON.parse(readFileSync(persistedCachePath(), 'utf-8')) as Record<
+      string,
+      string
+    >
+    expect(persisted['p-[16px]']).toBe(canonical)
+  })
+
+  it('serves identical results after a reset (fresh-process equivalent)', () => {
+    const first = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]', 'max-w-[400px]'])
+
+    resetCanonicalizeService()
+    const second = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]', 'max-w-[400px]'])
+
+    expect(second).toEqual(first)
+  })
+
+  it('isolates rem settings in separate cache files', () => {
+    canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'], 16)
+
+    const persisted = JSON.parse(readFileSync(persistedCachePath(16), 'utf-8')) as Record<
+      string,
+      string
+    >
+    expect(Object.keys(persisted)).toContain('p-[16px]')
+  })
+
+  it('survives a corrupt cache file', () => {
+    writeFileSync(persistedCachePath(), '{ not json')
+
+    const [canonical] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
+    expect(typeof canonical).toBe('string')
+    // The corrupt file is replaced by a valid one on the next flush.
+    const persisted = JSON.parse(readFileSync(persistedCachePath(), 'utf-8')) as Record<
+      string,
+      string
+    >
+    expect(persisted['p-[16px]']).toBe(canonical)
+  })
+
+  it('ignores persisted entries from a poisoned file with non-string values', () => {
+    writeFileSync(persistedCachePath(), JSON.stringify({ 'p-[16px]': 42 }))
+
+    const [canonical] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
+    expect(typeof canonical).toBe('string')
+    expect(canonical).not.toBe(42)
+  })
+})

--- a/packages/oxlint-tailwindcss/tests/design-system/canonicalize-persistence.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/canonicalize-persistence.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { chmodSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import {
   canonicalizeClassesSync,
@@ -157,9 +157,10 @@ describe('canonicalize cache disk persistence', () => {
     }
   })
 
-  it('never leaves a stray .tmp file across repeated flushes', () => {
+  it('never leaves a stray .tmp or .lock file across repeated flushes', () => {
     // Several flush-triggering batches; unique pid.thread.seq tmp names + atomic
-    // rename must leave exactly the final file and no partial temporaries.
+    // rename + finally-unlink must leave exactly the final file — no partial
+    // temporaries and no orphaned lock.
     for (let b = 0; b < 3; b++) {
       canonicalizeClassesSync(
         ENTRY_POINT,
@@ -168,8 +169,51 @@ describe('canonicalize cache disk persistence', () => {
     }
     const dir = dirname(cachePath())
     const base = basename(cachePath())
-    const leftovers = readdirSync(dir).filter((n) => n.startsWith(base) && n.endsWith('.tmp'))
+    const leftovers = readdirSync(dir).filter(
+      (n) => n.startsWith(base) && (n.endsWith('.tmp') || n.endsWith('.lock')),
+    )
     expect(leftovers).toEqual([])
     expect(() => readPersisted()).not.toThrow()
+  })
+
+  describe('read-merge-under-lock', () => {
+    const lockPath = () => `${cachePath()}.lock`
+
+    it('merges with on-disk entries instead of clobbering them', () => {
+      // Simulate entries another isolate/run already persisted.
+      writeFileSync(cachePath(), JSON.stringify({ 'w-[1px]': ['w-px', true] }))
+      resetCanonicalizeService()
+
+      // Flush a disjoint batch; the pre-existing key must survive the merge.
+      canonicalizeClassesSync(ENTRY_POINT, manyArbitrary())
+      const persisted = readPersisted()
+      expect(persisted['w-[1px]']).toEqual(['w-px', true]) // not clobbered
+      expect(persisted['p-[1px]']).toBeDefined() // ours added
+    })
+
+    it('skips the flush while another isolate holds a fresh lock', () => {
+      rmSync(cachePath(), { force: true })
+      writeFileSync(lockPath(), '') // fresh (non-stale) lock held by "someone else"
+      try {
+        canonicalizeClassesSync(ENTRY_POINT, manyArbitrary())
+        // Contended → we skip writing; no cache file is produced this run.
+        expect(readdirSync(dirname(cachePath()))).not.toContain(basename(cachePath()))
+      } finally {
+        rmSync(lockPath(), { force: true })
+      }
+    })
+
+    it('reclaims a stale lock and flushes', () => {
+      rmSync(cachePath(), { force: true })
+      writeFileSync(lockPath(), '')
+      const old = new Date(Date.now() - 60_000) // 60s > LOCK_STALE_MS
+      utimesSync(lockPath(), old, old)
+      try {
+        canonicalizeClassesSync(ENTRY_POINT, manyArbitrary())
+        expect(readPersisted()['p-[1px]']).toBeDefined() // stale lock reclaimed, flush succeeded
+      } finally {
+        rmSync(lockPath(), { force: true })
+      }
+    })
   })
 })

--- a/packages/oxlint-tailwindcss/tests/design-system/canonicalize-persistence.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/canonicalize-persistence.test.ts
@@ -1,93 +1,175 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { chmodSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
 import {
   canonicalizeClassesSync,
+  FLUSH_THRESHOLD,
+  persistFileFor,
   resetCanonicalizeService,
 } from '../../src/design-system/canonicalize-service'
-import { cacheArtifactPaths } from '../../src/design-system/sync-loader'
 
 const ENTRY_POINT = resolve(__dirname, '../fixtures/default.css')
 
 /**
  * The canonicalize service persists its per-class cache to disk next to the
- * design-system precompute artifact (content-hash keyed, so it invalidates
- * together with the design system). A fresh process — every real `oxlint`
- * invocation — then serves previously-seen dynamic classes from disk instead
- * of paying a synchronous worker round-trip per unique class.
+ * design-system precompute artifact. The filename is keyed by the DS content
+ * hash AND the canonicalization logic hash, so it self-invalidates when either
+ * changes — no stale value can reach an autofix. A fresh process (every real
+ * `oxlint` invocation) then serves previously-seen dynamic classes from disk
+ * instead of paying a synchronous worker round-trip per unique class.
  *
  * `resetCanonicalizeService()` clears the in-memory cache AND the persistence
  * state, so a reset + call cycle is the closest in-process equivalent of a
  * fresh oxlint run.
  */
 
-// Derived the same way as the service does: DS artifact path + canon suffix.
-function persistedCachePath(rem?: number): string {
-  const { json } = cacheArtifactPaths(ENTRY_POINT)
-  const remKey = rem === undefined ? 'default' : String(rem)
-  return json.replace(/\.json$/, `.canon-v1-${remKey}.json`)
+const cachePath = (rem?: number) => persistFileFor(ENTRY_POINT, rem) as string
+
+/** Persisted shape: Record<class, [canonical, safe]>. */
+type Persisted = Record<string, [string, boolean]>
+const readPersisted = (rem?: number) =>
+  JSON.parse(readFileSync(cachePath(rem), 'utf-8')) as Persisted
+
+// Enough distinct arbitrary classes to cross FLUSH_THRESHOLD in one call, so a
+// flush actually happens (a sub-threshold batch is intentionally not flushed).
+const manyArbitrary = (n = FLUSH_THRESHOLD + 4) =>
+  Array.from({ length: n }, (_, i) => `p-[${i + 1}px]`)
+
+/** Remove every `.canon-*` file this fixture may have produced (all rems/hashes). */
+function cleanCanonFiles(): void {
+  const dir = dirname(cachePath())
+  const prefix = basename(cachePath()).replace(/\.canon-.*$/, '.canon-')
+  try {
+    for (const name of readdirSync(dir)) {
+      if (name.startsWith(prefix)) rmSync(resolve(dir, name), { force: true })
+    }
+  } catch {
+    // dir may not exist yet
+  }
 }
 
 describe('canonicalize cache disk persistence', () => {
   beforeEach(() => {
     resetCanonicalizeService()
-    rmSync(persistedCachePath(), { force: true })
-    rmSync(persistedCachePath(16), { force: true })
+    cleanCanonFiles()
   })
-
   afterEach(() => {
     resetCanonicalizeService()
-    rmSync(persistedCachePath(), { force: true })
-    rmSync(persistedCachePath(16), { force: true })
+    cleanCanonFiles()
   })
 
-  it('writes canonicalized classes to a content-hash-keyed file', () => {
-    const [canonical] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
+  it('persists [canonical, safe] tuples to a hash-keyed file', () => {
+    const classes = manyArbitrary()
+    const results = canonicalizeClassesSync(ENTRY_POINT, classes)
 
-    const persisted = JSON.parse(readFileSync(persistedCachePath(), 'utf-8')) as Record<
-      string,
-      string
-    >
-    expect(persisted['p-[16px]']).toBe(canonical)
+    const persisted = readPersisted()
+    // Every class round-trips through the tuple format, carrying the safe flag.
+    for (let i = 0; i < classes.length; i++) {
+      expect(persisted[classes[i]]).toEqual([results[i].canonical, results[i].safe])
+    }
   })
 
   it('serves identical results after a reset (fresh-process equivalent)', () => {
-    const first = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]', 'max-w-[400px]'])
+    const classes = manyArbitrary()
+    const first = canonicalizeClassesSync(ENTRY_POINT, classes)
 
-    resetCanonicalizeService()
-    const second = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]', 'max-w-[400px]'])
+    resetCanonicalizeService() // in-memory gone; only the disk cache remains
+    const second = canonicalizeClassesSync(ENTRY_POINT, classes)
 
     expect(second).toEqual(first)
   })
 
   it('isolates rem settings in separate cache files', () => {
-    canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'], 16)
-
-    const persisted = JSON.parse(readFileSync(persistedCachePath(16), 'utf-8')) as Record<
-      string,
-      string
-    >
-    expect(Object.keys(persisted)).toContain('p-[16px]')
+    canonicalizeClassesSync(ENTRY_POINT, manyArbitrary(), 16)
+    expect(cachePath(16)).not.toBe(cachePath())
+    expect(Object.keys(readPersisted(16))).toContain('p-[1px]')
   })
 
-  it('survives a corrupt cache file', () => {
-    writeFileSync(persistedCachePath(), '{ not json')
+  it('restores the safe flag so an unsafe rewrite stays gated after a reset', () => {
+    // Poison the current-hash file with a safe=false entry, then confirm a
+    // fresh process reads `safe` back verbatim (not defaulted to true).
+    writeFileSync(cachePath(), JSON.stringify({ 'p-[16px]': ['p-4', false] }))
+    resetCanonicalizeService()
 
-    const [canonical] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
-    expect(typeof canonical).toBe('string')
-    // The corrupt file is replaced by a valid one on the next flush.
-    const persisted = JSON.parse(readFileSync(persistedCachePath(), 'utf-8')) as Record<
-      string,
-      string
-    >
-    expect(persisted['p-[16px]']).toBe(canonical)
+    const [result] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
+    expect(result).toEqual({ canonical: 'p-4', safe: false })
   })
 
-  it('ignores persisted entries from a poisoned file with non-string values', () => {
-    writeFileSync(persistedCachePath(), JSON.stringify({ 'p-[16px]': 42 }))
+  describe('staleness guard (logic-hash keying)', () => {
+    it('reads the current-hash file', () => {
+      writeFileSync(cachePath(), JSON.stringify({ 'p-[16px]': ['SENTINEL', true] }))
+      resetCanonicalizeService()
 
-    const [canonical] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
-    expect(typeof canonical).toBe('string')
-    expect(canonical).not.toBe(42)
+      const [result] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
+      expect(result.canonical).toBe('SENTINEL') // proves the file is authoritative on load
+    })
+
+    it('ignores a cache written under a different logic hash', () => {
+      // Simulate a prior version's file by swapping the hash segment.
+      const stalePath = cachePath().replace(/\.canon-[0-9a-f]+-/, '.canon-deadbeef-')
+      expect(stalePath).not.toBe(cachePath())
+      writeFileSync(stalePath, JSON.stringify({ 'p-[16px]': ['SENTINEL', true] }))
+      resetCanonicalizeService()
+
+      try {
+        const [result] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]'])
+        // The stale-hash file is not this run's file, so it's never read.
+        expect(result.canonical).not.toBe('SENTINEL')
+      } finally {
+        rmSync(stalePath, { force: true })
+      }
+    })
+  })
+
+  it('survives a corrupt cache file and repairs it on the next flush', () => {
+    writeFileSync(cachePath(), '{ not json')
+    const results = canonicalizeClassesSync(ENTRY_POINT, manyArbitrary())
+
+    expect(results[0].canonical).toBeTypeOf('string')
+    const persisted = readPersisted() // corrupt file replaced by a valid one
+    expect(persisted['p-[1px]']).toEqual([results[0].canonical, results[0].safe])
+  })
+
+  it('ignores persisted entries that are not [string, boolean] tuples', () => {
+    writeFileSync(
+      cachePath(),
+      JSON.stringify({ 'p-[16px]': 'p-4', 'p-[8px]': ['p-2'], 'p-[4px]': 42 }),
+    )
+    resetCanonicalizeService()
+
+    // None of the malformed entries are trusted; all get recomputed.
+    const [a, b, c] = canonicalizeClassesSync(ENTRY_POINT, ['p-[16px]', 'p-[8px]', 'p-[4px]'])
+    for (const r of [a, b, c]) expect(r).toHaveProperty('safe')
+  })
+
+  it('disables persistence (without throwing) when the cache dir is unwritable', () => {
+    const dir = dirname(cachePath())
+    canonicalizeClassesSync(ENTRY_POINT, ['p-[1px]']) // ensure dir exists
+    cleanCanonFiles()
+    chmodSync(dir, 0o500) // read + execute, no write
+    try {
+      // Must not throw even though every flush attempt fails.
+      const results = canonicalizeClassesSync(ENTRY_POINT, manyArbitrary())
+      expect(results).toHaveLength(FLUSH_THRESHOLD + 4)
+      expect(results[0].canonical).toBeTypeOf('string')
+    } finally {
+      chmodSync(dir, 0o700)
+    }
+  })
+
+  it('never leaves a stray .tmp file across repeated flushes', () => {
+    // Several flush-triggering batches; unique pid.thread.seq tmp names + atomic
+    // rename must leave exactly the final file and no partial temporaries.
+    for (let b = 0; b < 3; b++) {
+      canonicalizeClassesSync(
+        ENTRY_POINT,
+        Array.from({ length: FLUSH_THRESHOLD + 1 }, (_, i) => `m-[${b}-${i}px]`),
+      )
+    }
+    const dir = dirname(cachePath())
+    const base = basename(cachePath())
+    const leftovers = readdirSync(dir).filter((n) => n.startsWith(base) && n.endsWith('.tmp'))
+    expect(leftovers).toEqual([])
+    expect(() => readPersisted()).not.toThrow()
   })
 })

--- a/packages/oxlint-tailwindcss/tests/design-system/canonicalize-persistence.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/canonicalize-persistence.test.ts
@@ -3,12 +3,16 @@ import { chmodSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync
 import { basename, dirname, resolve } from 'node:path'
 import {
   canonicalizeClassesSync,
-  FLUSH_THRESHOLD,
   persistFileFor,
   resetCanonicalizeService,
 } from '../../src/design-system/canonicalize-service'
 
 const ENTRY_POINT = resolve(__dirname, '../fixtures/default.css')
+
+// A batch of distinct arbitrary classes. Writes are write-through (every batch
+// with fresh entries flushes), so any size triggers a flush; this just keeps
+// the tests exercising a realistic multi-class batch.
+const BATCH = 20
 
 /**
  * The canonicalize service persists its per-class cache to disk next to the
@@ -30,10 +34,8 @@ type Persisted = Record<string, [string, boolean]>
 const readPersisted = (rem?: number) =>
   JSON.parse(readFileSync(cachePath(rem), 'utf-8')) as Persisted
 
-// Enough distinct arbitrary classes to cross FLUSH_THRESHOLD in one call, so a
-// flush actually happens (a sub-threshold batch is intentionally not flushed).
-const manyArbitrary = (n = FLUSH_THRESHOLD + 4) =>
-  Array.from({ length: n }, (_, i) => `p-[${i + 1}px]`)
+// A batch of distinct arbitrary (worker-routed) classes.
+const manyArbitrary = (n = BATCH) => Array.from({ length: n }, (_, i) => `p-[${i + 1}px]`)
 
 /** Remove every `.canon-*` file this fixture may have produced (all rems/hashes). */
 function cleanCanonFiles(): void {
@@ -150,7 +152,7 @@ describe('canonicalize cache disk persistence', () => {
     try {
       // Must not throw even though every flush attempt fails.
       const results = canonicalizeClassesSync(ENTRY_POINT, manyArbitrary())
-      expect(results).toHaveLength(FLUSH_THRESHOLD + 4)
+      expect(results).toHaveLength(BATCH)
       expect(results[0].canonical).toBeTypeOf('string')
     } finally {
       chmodSync(dir, 0o700)
@@ -164,7 +166,7 @@ describe('canonicalize cache disk persistence', () => {
     for (let b = 0; b < 3; b++) {
       canonicalizeClassesSync(
         ENTRY_POINT,
-        Array.from({ length: FLUSH_THRESHOLD + 1 }, (_, i) => `m-[${b}-${i}px]`),
+        Array.from({ length: BATCH }, (_, i) => `m-[${b}-${i}px]`),
       )
     }
     const dir = dirname(cachePath())

--- a/packages/oxlint-tailwindcss/tests/global-setup.ts
+++ b/packages/oxlint-tailwindcss/tests/global-setup.ts
@@ -9,8 +9,9 @@
  * hits the warm disk cache (<500ms) and no per-file hook races a cold compute.
  */
 
-import { resolve } from 'node:path'
-import { loadDesignSystemSync } from '../src/design-system/sync-loader'
+import { readdirSync, rmSync } from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
+import { cacheArtifactPaths, loadDesignSystemSync } from '../src/design-system/sync-loader'
 
 // Every fixture used as an entry point by the suite. Pre-warming a fixture that
 // isn't a valid entry point would throw, so each load is isolated — a failure
@@ -34,6 +35,27 @@ export function setup() {
       loadDesignSystemSync(resolve(__dirname, 'fixtures', fixture))
     } catch {
       // Leave it cold; the owning test will report the real failure.
+    }
+  }
+}
+
+/**
+ * Remove the `.canon-*` cache files that rule tests (any suite that
+ * canonicalizes a fixture) leave in the shared, per-uid cache dir. Scoped
+ * precisely to fixture artifacts so a developer's real-project canon caches in
+ * the same tmpdir are never touched. Prevents cross-run cache-state leakage.
+ */
+export function teardown() {
+  for (const fixture of FIXTURES) {
+    try {
+      const { json } = cacheArtifactPaths(resolve(__dirname, 'fixtures', fixture))
+      const dir = dirname(json)
+      const canonPrefix = basename(json).replace(/\.json$/, '.canon-')
+      for (const name of readdirSync(dir)) {
+        if (name.startsWith(canonPrefix)) rmSync(resolve(dir, name), { force: true })
+      }
+    } catch {
+      // Fixture never canonicalized (no artifact) or dir gone — nothing to clean.
     }
   }
 }


### PR DESCRIPTION
## Problem

Every `oxlint` invocation is a fresh process, so the process-wide canonicalize cache starts empty each run: every unique dynamic class (`p-[2px]`, `bg-(--c)`, dynamic numerics) pays a synchronous worker round-trip again on every run. On arbitrary-value-heavy codebases `enforce-canonical` dominates the whole lint — on our production Next.js app (~1,470 TS/TSX files, warm design-system cache, all 7 class rules enabled), toggling `enforce-canonical` alone moves the run from ~0.7s to ~7s.

## Approach

Canonicalization results are pure functions of (design system, rem), so this persists the per-class cache to disk next to the design-system precompute artifact, deriving the filename from `cacheArtifactPaths(cssPath).json` + rem. It therefore inherits content-hash invalidation for free: when the design system changes, the canonical cache invalidates with it.

Flushing is write-through after each miss batch (atomic tmp+rename) — deliberately **no** `process` exit hook, per the invariant in `tests/design-system/exit-listeners.test.ts`. Best-effort throughout: a missing, corrupt, poisoned, or unwritable cache file never breaks linting; it only costs worker round-trips (corrupt files are replaced on the next flush).

## Before → after

Same repo/config as above, fresh process per run:

| Run | before | after |
|---|---|---|
| first run (canon cache cold) | ~7.0s | ~7.2s (builds the cache) |
| every subsequent run | ~7.0s | **~1.0s** |

Diagnostics are byte-identical before/after (334 warnings on our repo). The cache file for ~330 unique dynamic classes is ~10 kB.

## Tests

`tests/design-system/canonicalize-persistence.test.ts` — cache file written with canonical values, reset+reuse round-trip, per-rem isolation, corrupt-file resilience, poisoned-value (non-string) rejection. Full suite: 1,156 passed; `pnpm format && pnpm lint && pnpm typecheck && pnpm test` all green.

## Notes

- No breaking changes; no config surface added.
- CHANGELOG entry added under Unreleased.
- Found while migrating a monorepo from `eslint-plugin-better-tailwindcss` to this plugin — thanks for building it, the Tailwind v4 `@theme` + legacy `@config` resolution worked flawlessly for us.
