### PR TITLE
fix(no-conflicting-classes): don't report --tw-* writer/reader composition as a conflict

### DIFF
--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- **`no-conflicting-classes`**: no longer reports Tailwind's writer/reader composition through
+  `--tw-*` custom properties as a conflict. `outline-1 outline-dashed` was flagged as both affecting
+  `outline-style`, but `outline-<n>` only READS the variable
+  (`outline-style: var(--tw-outline-style)`) that `outline-dashed` WRITES — the standard Tailwind
+  composition pattern. A shared property is now excluded from the conflict overlap when exactly one
+  of the two classes defines the matching `--tw-<property>`; two writers
+  (`outline-dashed outline-solid`) and two direct declarations (`outline-1 outline-2`) still report.
+
 ## 1.3.5 (2026-07-10)
 
 ### Bug fixes

--- a/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes.ts
@@ -25,6 +25,31 @@ export function isCompositionViaCssVars(
 }
 
 /**
+ * A shared declared property composes (rather than conflicts) when exactly one
+ * of the two classes also defines the matching `--tw-<property>` custom
+ * property. The definer WRITES the variable (its direct declaration is the
+ * fallback), while the other class READS it via `var(--tw-<property>)` —
+ * Tailwind's standard composition pattern. Example (Tailwind v4):
+ *
+ *   .outline-1      { outline-style: var(--tw-outline-style); outline-width: 1px; }
+ *   .outline-dashed { --tw-outline-style: dashed; outline-style: dashed; }
+ *
+ * Both declare `outline-style`, but they compose. Two definers (outline-dashed
+ * vs outline-solid) both write the variable — a real conflict. Two
+ * non-definers (outline-1 vs outline-2) both declare directly — also a real
+ * conflict (on outline-width). Only the writer/reader mix composes.
+ */
+export function isVarComposedProperty(
+  prop: string,
+  propsA: readonly string[],
+  propsB: readonly string[],
+): boolean {
+  if (prop.startsWith('--')) return false
+  const twVar = `--tw-${prop}`
+  return propsA.includes(twVar) !== propsB.includes(twVar)
+}
+
+/**
  * Detect a narrowing override: the later class's CSS properties are a strict
  * subset of the earlier class's, so the later class refines one of the
  * shorthand's properties (size-4 h-6, rounded-t-lg rounded-tl-sm, truncate
@@ -158,7 +183,9 @@ export const noConflictingClasses = defineRule({
               if (shouldSkipPair(classA, classB, propsA, propsB)) continue
 
               const propsBSet = new Set(propsB)
-              const overlap = propsA.filter((p) => propsBSet.has(p))
+              const overlap = propsA.filter(
+                (p) => propsBSet.has(p) && !isVarComposedProperty(p, propsA, propsB),
+              )
               if (overlap.length > 0) {
                 const propList =
                   overlap.length <= 3

--- a/packages/oxlint-tailwindcss/tests/rules/no-conflicting-classes.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-conflicting-classes.test.ts
@@ -4,6 +4,7 @@ import { RuleTester } from 'oxlint/plugins-dev'
 import {
   noConflictingClasses,
   isCompositionViaCssVars,
+  isVarComposedProperty,
   isNarrowingOverride,
   shouldSkipPair,
 } from '../../src/rules/no-conflicting-classes'
@@ -58,6 +59,11 @@ runWithFixture(ruleTester, 'no-conflicting-classes', noConflictingClasses, ENTRY
     { code: '<div className="transition-colors duration-150" />', filename: 'test.tsx' },
     // border width + border style compose
     { code: '<div className="border border-dashed" />', filename: 'test.tsx' },
+    // outline width + outline style compose: outline-<n> READS --tw-outline-style
+    // (outline-style: var(--tw-outline-style)), outline-dashed WRITES it (#80-adjacent)
+    { code: '<div className="outline-1 outline-dashed" />', filename: 'test.tsx' },
+    { code: '<div className="outline-2 outline-solid" />', filename: 'test.tsx' },
+    { code: '<div className="outline-dashed outline-4" />', filename: 'test.tsx' },
     { code: '<div className="border-2 border-dotted" />', filename: 'test.tsx' },
     // transform axes compose (x + y are independent)
     { code: '<div className="translate-x-2 -translate-y-2" />', filename: 'test.tsx' },
@@ -114,6 +120,18 @@ runWithFixture(ruleTester, 'no-conflicting-classes', noConflictingClasses, ENTRY
     { code: '<div className="mask-add mask-linear-from-20%" />', filename: 'test.tsx' },
   ],
   invalid: [
+    {
+      // Two WRITERS of --tw-outline-style — a genuine conflict
+      code: '<div className="outline-dashed outline-solid" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      // Two readers, but both also declare outline-width directly — conflict
+      code: '<div className="outline-1 outline-2" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
     {
       code: '<div className="text-red-500 text-blue-500" />',
       filename: 'test.tsx',
@@ -290,6 +308,33 @@ describe('isCompositionViaCssVars', () => {
 
   it('returns false when neither side has custom properties', () => {
     expect(isCompositionViaCssVars(['color'], ['color'])).toBe(false)
+  })
+})
+
+describe('isVarComposedProperty', () => {
+  it('composes when exactly one side defines the matching --tw- variable', () => {
+    const outline1 = ['outline-style', 'outline-width']
+    const outlineDashed = ['--tw-outline-style', 'outline-style']
+    expect(isVarComposedProperty('outline-style', outline1, outlineDashed)).toBe(true)
+    expect(isVarComposedProperty('outline-style', outlineDashed, outline1)).toBe(true)
+  })
+
+  it('does not compose when both sides define the variable (two writers)', () => {
+    const dashed = ['--tw-outline-style', 'outline-style']
+    const solid = ['--tw-outline-style', 'outline-style']
+    expect(isVarComposedProperty('outline-style', dashed, solid)).toBe(false)
+  })
+
+  it('does not compose when neither side defines the variable', () => {
+    const a = ['outline-style', 'outline-width']
+    const b = ['outline-style', 'outline-width']
+    expect(isVarComposedProperty('outline-style', a, b)).toBe(false)
+  })
+
+  it('never treats custom properties themselves as composed', () => {
+    expect(
+      isVarComposedProperty('--tw-outline-style', ['--tw-outline-style'], ['outline-style']),
+    ).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Problem

`no-conflicting-classes` reports `outline-1 outline-dashed` as conflicting on `outline-style`. Tailwind v4 generates:

```css
.outline-1      { outline-style: var(--tw-outline-style); outline-width: 1px; }
.outline-dashed { --tw-outline-style: dashed; outline-style: dashed; }
```

Both *declare* `outline-style` (so the precomputed `cssProps` overlap), but `outline-<n>` only **reads** the variable that `outline-dashed` **writes** — the standard Tailwind composition pattern. On our codebase this produced 45 false positives, all idiomatic `outline-<width> outline-<style>` pairs in component galleries. `border-*` has the same CSS shape but was already covered by `COMPOSITION_PAIRS`; outline (and any future family with this shape) was not.

## Approach

Data-driven rather than another regex table entry: a shared declared property is excluded from the conflict overlap when **exactly one** of the two classes also defines the matching `--tw-<property>` custom property (writer + reader = composition). Two writers still conflict (`outline-dashed outline-solid`), and two direct declarations still conflict (`outline-1 outline-2`, via `outline-width`). Implemented as an exported pure helper `isVarComposedProperty` next to `isCompositionViaCssVars`/`isNarrowingOverride`.

## Before → after

| code | before | after |
|---|---|---|
| `outline-1 outline-dashed` | ❌ conflict on `outline-style` | ✅ no report |
| `outline-dashed outline-solid` | conflict | conflict (unchanged) |
| `outline-1 outline-2` | conflict | conflict (unchanged) |
| `border border-dashed` | no report (via `COMPOSITION_PAIRS`) | no report (unchanged) |

Verified on a production app: 45 false positives → 0, with genuine conflicts still reported.

## Tests

Rule-level valid/invalid cases + a `describe('isVarComposedProperty')` unit block in `tests/rules/no-conflicting-classes.test.ts`. Full suite: 1,160 passed, zero changes to existing expectations; `pnpm format && pnpm lint && pnpm typecheck && pnpm test` all green.

## Notes

- No breaking changes; no config surface added. CHANGELOG entry under Unreleased.
- Independent of #80 (both branch from `main`); trivial CHANGELOG merge conflict if both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)