### PR TITLE
fix: resolve #76, #77, #78 (+ #81 follow-ups)

### DIFF
--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Bug fixes
 
+- **`enforce-canonical`**: no longer rewrites a literal arbitrary value to a variable-backed named
+  token, which silently corrupted the design on projects that override a theme variable in `:root`
+  (the standard shadcn/ui `--radius` pattern, and likewise `--spacing`). `canonicalizeCandidates`
+  matches an arbitrary literal (`rounded-[4px]` = `4px`) against the compile-time theme default, so
+  it happily maps it to `rounded-lg` — but `rounded-lg` compiles to `var(--radius-lg)`, which the
+  `:root` override makes resolve to a different value (e.g. 14px). The rule now only reports a
+  canonicalization when the two forms emit byte-identical CSS. Value-preserving conversions still
+  apply: legacy renames (`break-words` → `wrap-break-word`), variable-syntax normalization
+  (`bg-[var(--x)]` → `bg-(--x)`, `rounded-[var(--radius-sm)]` → `rounded-sm`), and literal-valued
+  utilities (`z-[10]` → `z-10`, `flex-grow-[2]` → `grow-2`). Literal→token conversions such as
+  `p-[2px]` → `p-0.5` are no longer enforced (they are only coincidentally equal under the default
+  theme). Fixes [#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78).
+- **`no-unknown-classes`**: no longer flags Tailwind v4's typed CSS-variable shorthand
+  (`border-(length:--stroke)`, `bg-(color:--c)`, `text-(length:--fs)`) as an unknown class. The
+  class-boundary scanners tracked `[]` bracket depth but not `()` paren depth, so the `:` type hint
+  inside the parentheses was mistaken for a variant separator, mangling the utility. This also
+  resolved a contradiction with `enforce-canonical`, which rewrites the `[type:var(--x)]` long form
+  into exactly the shorthand `no-unknown-classes` was rejecting. Fixes
+  [#76](https://github.com/sergioazoc/oxlint-tailwindcss/issues/76).
 - **`no-conflicting-classes`**: no longer reports Tailwind's writer/reader composition through
   `--tw-*` custom properties as a conflict. `outline-1 outline-dashed` was flagged as both affecting
   `outline-style`, but `outline-<n>` only READS the variable
@@ -11,6 +30,19 @@
   composition pattern. A shared property is now excluded from the conflict overlap when exactly one
   of the two classes defines the matching `--tw-<property>`; two writers
   (`outline-dashed outline-solid`) and two direct declarations (`outline-1 outline-2`) still report.
+  The same mechanism now also covers `outline-none`/`outline-hidden` and subsumes the hardcoded
+  `border` width/style pair. Fixes the false-positive half of
+  [#79](https://github.com/sergioazoc/oxlint-tailwindcss/issues/79).
+
+### Performance
+
+- **Monorepos with multiple entry points**: the sort/canonicalize worker services now keep one warm
+  worker **per** CSS entry point (LRU-bounded) instead of a single worker that was torn down and
+  reloaded whenever oxlint fed the plugin two consecutive files from different packages. Each
+  respawn re-paid the full design-system warmup (~200 ms load plus a cold first canonicalize), so a
+  two-package run could spend far longer than linting the packages separately. Sticky worker errors
+  are now tracked per entry point as well. Fixes
+  [#77](https://github.com/sergioazoc/oxlint-tailwindcss/issues/77).
 
 ## 1.3.5 (2026-07-10)
 

--- a/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
@@ -23,21 +23,62 @@ interface CanonicalizeRequest {
   rem?: number
 }
 
+/**
+ * One canonicalization result.
+ *
+ * `safe` is the #78 guard: `true` only when the canonical form emits
+ * byte-identical CSS to the original. A canonicalization like
+ * `rounded-[4px]` → `rounded-lg` is UNSAFE because `rounded-lg` compiles to
+ * `border-radius: var(--radius-lg)`, whose value depends on a `:root`
+ * override that `canonicalizeCandidates` resolves against the compile-time
+ * theme default — so accepting it would silently change the design. The rule
+ * layer only rewrites when `safe` is true; unsafe results are left as written.
+ * Value-preserving canonicalizations (legacy renames, var-syntax
+ * normalization like `bg-[var(--x)]` → `bg-(--x)`, literal-valued utilities
+ * like `z-[10]` → `z-10`) all stay `safe: true`.
+ */
+export interface CanonicalizeResult {
+  canonical: string
+  safe: boolean
+}
+
 // Handler: canonicalize each class. canonicalizeCandidates deduplicates its
 // input, so we call it one class at a time to preserve order/length (see
 // sync-loader.ts). The shared protocol/load/loop lives in makeWorkerScript.
+//
+// `safe` (#78) is computed here, inside the worker, where the design system
+// lives: a rewrite is value-preserving iff the two classes emit byte-identical
+// CSS *declarations* (the selector differs by construction, so it is stripped —
+// everything between the first `{` and the last `}`). candidatesToCss is the
+// source of truth; when the canonical form resolves through a `var()`/`calc()`
+// whose value a `:root` override can change, the declarations differ and the
+// rewrite is flagged unsafe.
 const CANONICALIZE_HANDLER = `(ds, request) => {
   const { classes, rem } = request;
   const options = rem ? { rem } : undefined;
+  const declsOf = (cls) => {
+    let out;
+    try { out = ds.candidatesToCss([cls]); } catch (e) { return null; }
+    if (!out || !out[0]) return null;
+    const css = out[0];
+    const open = css.indexOf('{');
+    const close = css.lastIndexOf('}');
+    if (open < 0 || close < 0) return null;
+    return css.slice(open + 1, close).replace(/\\s+/g, ' ').trim();
+  };
   return classes.map((cls) => {
     const r = ds.canonicalizeCandidates([cls], options);
-    return r[0] ?? cls;
+    const canonical = r[0] ?? cls;
+    if (canonical === cls) return { canonical: cls, safe: true };
+    const a = declsOf(cls);
+    const b = declsOf(canonical);
+    return { canonical, safe: a !== null && b !== null && a === b };
   });
 }`
 
 const WORKER_SCRIPT = makeWorkerScript(CANONICALIZE_HANDLER)
 
-const canonWorker = new DesignSystemWorker<CanonicalizeRequest, string[]>({
+const canonWorker = new DesignSystemWorker<CanonicalizeRequest, CanonicalizeResult[]>({
   workerScript: WORKER_SCRIPT,
   serviceName: 'canonicalize',
 })
@@ -45,9 +86,10 @@ const canonWorker = new DesignSystemWorker<CanonicalizeRequest, string[]>({
 /**
  * Process-wide cache of canonicalized classes.
  * Key: `${cssPath}\0${rem}\0${className}` — isolates monorepos (multiple
- * DSs) and different rem settings. Value: canonicalized class string.
+ * DSs) and different rem settings. Value: the canonical form + its #78 `safe`
+ * flag.
  */
-const canonCache = new Map<string, string>()
+const canonCache = new Map<string, CanonicalizeResult>()
 
 /**
  * Canonicalize classes via the worker thread.
@@ -64,8 +106,8 @@ export function canonicalizeClassesSync(
   cssPath: string,
   classes: string[],
   rem?: number,
-): string[] {
-  const out: string[] = Array.from({ length: classes.length })
+): CanonicalizeResult[] {
+  const out: CanonicalizeResult[] = Array.from({ length: classes.length })
   const missingIdx: number[] = []
   const missing: string[] = []
   const cachePrefix = `${cssPath}\0${rem ?? ''}\0`
@@ -95,17 +137,19 @@ export function canonicalizeClassesSync(
     )
   }
 
-  const freshByClass = new Map<string, string>()
+  const freshByClass = new Map<string, CanonicalizeResult>()
   for (let k = 0; k < uniqueMissing.length; k++) {
     freshByClass.set(uniqueMissing[k], fresh[k])
   }
 
   for (let j = 0; j < missing.length; j++) {
     const cls = missing[j]
+    const raw = freshByClass.get(cls) ?? { canonical: cls, safe: true }
     // Round rem/em/px floats so the worker path matches the precomputed map
     // (cache.ts does the same): canonicalizing arbitrary values can yield
-    // `2.4000000000000004rem`, which must never reach the user's source.
-    const value = roundRemValue(freshByClass.get(cls) ?? cls)
+    // `2.4000000000000004rem`, which must never reach the user's source. The
+    // `safe` flag is decided in the worker and carried through unchanged.
+    const value: CanonicalizeResult = { canonical: roundRemValue(raw.canonical), safe: raw.safe }
     canonCache.set(cachePrefix + cls, value)
     out[missingIdx[j]] = value
   }

--- a/packages/oxlint-tailwindcss/src/design-system/ds-worker.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/ds-worker.ts
@@ -34,6 +34,15 @@ const DATA_OFFSET = LENGTH_OFFSET + 4 // 20 bytes
 const INIT_TIMEOUT = 60_000 // 60 s to load DS (raised in v1 to avoid spurious timeouts on slow CI)
 const REQUEST_TIMEOUT = 30_000 // 30 s per request
 
+// LRU bound on live workers (#77). In a monorepo linted in one oxlint run the
+// plugin can resolve several entry points, and oxlint feeds files in
+// nondeterministic order — a singleton worker tore itself down and re-loaded
+// the design system (~200 ms + a ~1.9 s cold canonicalize) on every switch. We
+// keep one warm worker PER cssPath instead. Each entry is a full design system
+// plus a 4 MB SharedArrayBuffer, so the count is capped and the
+// least-recently-used worker is evicted past the cap.
+const MAX_WORKERS = 8
+
 /**
  * Build the worker script shared by `sort-service` and `canonicalize-service`.
  * Owns the entire SharedArrayBuffer protocol (offsets derived from the same
@@ -131,22 +140,20 @@ export interface DesignSystemWorkerOptions {
 }
 
 export class DesignSystemWorker<Req, Res> {
-  private ready: ReadyState | null = null
-  private lastError: SortServiceError | null = null
-  // The cssPath the sticky error belongs to. Checking `this.ready?.cssPath`
-  // (the old guard) never worked: every failure path leaves `ready === null`
-  // (init failures throw before assigning it; request failures call cleanup),
-  // so the next call re-ran the full init — re-paying the 60 s timeout (or
-  // respawning the worker) per call. Tracking the path separately makes the
-  // error genuinely sticky (DS-A1).
-  private lastErrorCssPath: string | null = null
+  // One warm worker per cssPath (#77), insertion-ordered so the first key is
+  // the least-recently-used; `ensure` re-inserts on a hit to mark it MRU.
+  private workers = new Map<string, ReadyState>()
+  // Sticky errors keyed per cssPath. A failure for one entry point must not be
+  // forgotten when another entry point is linted in between — the old single
+  // lastError/lastErrorCssPath pair was cleared on ANY cssPath switch, so it
+  // never stayed sticky across the alternating-file pattern #77 describes.
+  private errors = new Map<string, SortServiceError>()
 
   constructor(private readonly opts: DesignSystemWorkerOptions) {}
 
   /** Record an error as sticky for `cssPath` and return it for `throw`. */
   private remember(cssPath: string, err: SortServiceError): SortServiceError {
-    this.lastError = err
-    this.lastErrorCssPath = cssPath
+    this.errors.set(cssPath, err)
     return err
   }
 
@@ -157,12 +164,17 @@ export class DesignSystemWorker<Req, Res> {
    * cssPath rethrow without retrying.
    */
   private ensure(cssPath: string): ReadyState {
-    if (this.lastError && this.lastErrorCssPath === cssPath) throw this.lastError
-    if (this.ready && this.ready.cssPath === cssPath) return this.ready
+    const sticky = this.errors.get(cssPath)
+    if (sticky) throw sticky
 
-    if (this.ready) this.cleanup()
-    this.lastError = null
-    this.lastErrorCssPath = null
+    const existing = this.workers.get(cssPath)
+    if (existing) {
+      // Mark most-recently-used: delete + re-insert moves it to the tail so
+      // the LRU eviction below always drops the coldest entry point.
+      this.workers.delete(cssPath)
+      this.workers.set(cssPath, existing)
+      return existing
+    }
 
     if (TAILWIND_NODE_PATH === null) {
       throw this.remember(
@@ -198,12 +210,20 @@ export class DesignSystemWorker<Req, Res> {
 
     worker.unref()
     worker.on('error', (err: Error) => {
-      this.lastError = new SortServiceError(
-        `${this.opts.serviceName} worker died: ${err.message}`,
-        'The worker will not be restarted in this process. Restart the lint session.',
-        { cause: err },
+      this.errors.set(
+        cssPath,
+        new SortServiceError(
+          `${this.opts.serviceName} worker died: ${err.message}`,
+          'The worker will not be restarted in this process. Restart the lint session.',
+          { cause: err },
+        ),
       )
-      this.lastErrorCssPath = cssPath
+      // Drop the corpse so a later ensure() for this cssPath doesn't reuse it.
+      // Guard on identity: an evicted worker's late error must not delete a
+      // fresh worker created for the same cssPath afterwards (terminateWorker
+      // also removes this listener, so an intentional teardown never fires it).
+      const current = this.workers.get(cssPath)
+      if (current && current.worker === worker) this.workers.delete(cssPath)
     })
 
     // Wait for DS to load
@@ -237,8 +257,21 @@ export class DesignSystemWorker<Req, Res> {
       )
     }
 
-    this.ready = { worker, controlArray, lengthView, dataArea, cssPath }
-    return this.ready
+    const state: ReadyState = { worker, controlArray, lengthView, dataArea, cssPath }
+    this.workers.set(cssPath, state)
+    this.evictIfNeeded()
+    return state
+  }
+
+  /** Evict least-recently-used workers past the cap (#77). */
+  private evictIfNeeded(): void {
+    while (this.workers.size > MAX_WORKERS) {
+      const oldestKey = this.workers.keys().next().value
+      if (oldestKey === undefined) break
+      const oldest = this.workers.get(oldestKey)
+      this.workers.delete(oldestKey)
+      if (oldest) this.terminateWorker(oldest.worker)
+    }
   }
 
   /**
@@ -264,7 +297,7 @@ export class DesignSystemWorker<Req, Res> {
 
     const result = Atomics.wait(state.controlArray, 1, 0, REQUEST_TIMEOUT)
     if (result === 'timed-out') {
-      this.cleanup()
+      this.dropWorker(cssPath)
       throw this.remember(
         cssPath,
         new SortServiceError(
@@ -283,7 +316,7 @@ export class DesignSystemWorker<Req, Res> {
     try {
       parsed = JSON.parse(responseStr)
     } catch (cause) {
-      this.cleanup()
+      this.dropWorker(cssPath)
       throw this.remember(
         cssPath,
         new SortServiceError(
@@ -295,7 +328,7 @@ export class DesignSystemWorker<Req, Res> {
     }
 
     if (parsed === null) {
-      this.cleanup()
+      this.dropWorker(cssPath)
       throw this.remember(
         cssPath,
         new SortServiceError(
@@ -309,20 +342,25 @@ export class DesignSystemWorker<Req, Res> {
   }
 
   reset(): void {
-    this.cleanup()
-    this.lastError = null
-    this.lastErrorCssPath = null
+    for (const state of this.workers.values()) this.terminateWorker(state.worker)
+    this.workers.clear()
+    this.errors.clear()
   }
 
-  private cleanup(): void {
-    if (this.ready) {
-      this.terminateWorker(this.ready.worker)
-      this.ready = null
+  /** Terminate and forget the worker for a single cssPath (on request failure). */
+  private dropWorker(cssPath: string): void {
+    const state = this.workers.get(cssPath)
+    if (state) {
+      this.workers.delete(cssPath)
+      this.terminateWorker(state.worker)
     }
   }
 
   private terminateWorker(worker: Worker): void {
     try {
+      // Remove the crash listener first so an intentional teardown (evict,
+      // drop, reset) never fires the sticky-error handler for this cssPath.
+      worker.removeAllListeners('error')
       worker.terminate()
     } catch {
       // Already dead — nothing to do.

--- a/packages/oxlint-tailwindcss/src/rules/enforce-canonical.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-canonical.ts
@@ -112,7 +112,17 @@ export const enforceCanonical = defineRule({
           )
           if (!dynamic) return // worker fatal already reported; stop the check
           for (let k = 0; k < arbitrary.length; k++) {
-            canonicals[arbitraryIdx[k]] = preserveImportantPosition(arbitrary[k], dynamic[k])
+            const { canonical, safe } = dynamic[k]
+            // #78: only rewrite when the canonical form is CSS-value-equivalent.
+            // `canonicalizeCandidates` matches an arbitrary literal (e.g.
+            // `rounded-[4px]` = `4px`) against the compile-time theme, so it
+            // happily maps it to a var-backed token (`rounded-lg` =
+            // `var(--radius-lg)`) that a `:root` override makes NON-equivalent —
+            // autofixing that silently corrupts the design. When the emitted CSS
+            // isn't byte-identical the conversion is left as the user wrote it.
+            canonicals[arbitraryIdx[k]] = safe
+              ? preserveImportantPosition(arbitrary[k], canonical)
+              : arbitrary[k]
           }
         }
 

--- a/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes.ts
@@ -38,6 +38,14 @@ export function isCompositionViaCssVars(
  * vs outline-solid) both write the variable — a real conflict. Two
  * non-definers (outline-1 vs outline-2) both declare directly — also a real
  * conflict (on outline-width). Only the writer/reader mix composes.
+ *
+ * The check is value-blind by design: the precomputed `cssProps` carry property
+ * NAMES, not values, so this is sound only while no utility declares a
+ * name-matched property CONCRETELY (a literal value) without also writing its
+ * `--tw-<property>`. Every Tailwind v4 family with this shape today (outline,
+ * border, content, font-weight) satisfies that: the only non-writers are width
+ * utilities that read `P: var(--tw-P)`. If a future utility broke that
+ * assumption it could over-suppress a real conflict — revisit here.
  */
 export function isVarComposedProperty(
   prop: string,

--- a/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes/spec.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes/spec.ts
@@ -72,11 +72,12 @@ export const COMPOSITION_PAIRS: readonly CompositionPair[] = [
     b: /^tracking-/,
     reason: '`text-*` may set letter-spacing via its size token; `tracking-*` overrides it.',
   },
-  {
-    a: /^border(?:-[0-9]|$)/,
-    b: /^border-(?:solid|dashed|dotted|double|hidden|none)$/,
-    reason: '`border-*` (width) composes with `border-{solid,dashed,…}` (style).',
-  },
+  // NOTE: the former `border-*` (width) + `border-{solid,dashed,…}` (style)
+  // entry was removed — the general writer/reader mechanism
+  // (`isVarComposedProperty`) now subsumes it: `border` READS
+  // `border-style: var(--tw-border-style)` while `border-dashed` WRITES
+  // `--tw-border-style`, so their shared `border-style` is excluded from the
+  // overlap automatically (same shape as the `outline` family from #81).
   {
     a: /^divide-/,
     b: /^border(?:-[trblxyse])?-/,

--- a/packages/oxlint-tailwindcss/src/utils/class-parser.ts
+++ b/packages/oxlint-tailwindcss/src/utils/class-parser.ts
@@ -2,7 +2,10 @@
  * Parses a Tailwind class into its constituent parts:
  * variants, important modifier, negative prefix, utility name, and arbitrary value.
  *
- * Handles bracket-aware variant extraction (e.g., `[&>svg]:hover:w-4`).
+ * Handles bracket- and paren-aware variant extraction (e.g. `[&>svg]:hover:w-4`).
+ * The paren-awareness matters for Tailwind v4's typed CSS-variable shorthand:
+ * the `:` inside `border-(length:--stroke)` / `bg-(color:--c)` is a type hint,
+ * NOT a variant separator, so the boundary scanners must track `()` depth too.
  */
 
 export interface ParsedClass {
@@ -34,8 +37,8 @@ export function extractVariants(cls: string): string[] {
   let segmentStart = 0
 
   for (let i = 0; i < cls.length; i++) {
-    if (cls[i] === '[') depth++
-    else if (cls[i] === ']') depth--
+    if (cls[i] === '[' || cls[i] === '(') depth++
+    else if (cls[i] === ']' || cls[i] === ')') depth--
     else if (cls[i] === ':' && depth === 0) {
       variants.push(cls.slice(segmentStart, i))
       segmentStart = i + 1
@@ -60,8 +63,8 @@ export function extractUtility(cls: string): string {
   let depth = 0
   let lastColon = -1
   for (let i = 0; i < cls.length; i++) {
-    if (cls[i] === '[') depth++
-    else if (cls[i] === ']') depth--
+    if (cls[i] === '[' || cls[i] === '(') depth++
+    else if (cls[i] === ']' || cls[i] === ')') depth--
     else if (cls[i] === ':' && depth === 0) lastColon = i
   }
   return lastColon >= 0 ? cls.slice(lastColon + 1) : cls
@@ -76,8 +79,8 @@ export function getVariantPrefix(cls: string): string {
   let depth = 0
   let lastColon = -1
   for (let i = 0; i < cls.length; i++) {
-    if (cls[i] === '[') depth++
-    else if (cls[i] === ']') depth--
+    if (cls[i] === '[' || cls[i] === '(') depth++
+    else if (cls[i] === ']' || cls[i] === ')') depth--
     else if (cls[i] === ':' && depth === 0) lastColon = i
   }
   return lastColon >= 0 ? cls.slice(0, lastColon + 1) : ''
@@ -91,8 +94,8 @@ export function splitUtilityAndVariant(cls: string): { utility: string; variant:
   let depth = 0
   let lastColon = -1
   for (let i = 0; i < cls.length; i++) {
-    if (cls[i] === '[') depth++
-    else if (cls[i] === ']') depth--
+    if (cls[i] === '[' || cls[i] === '(') depth++
+    else if (cls[i] === ']' || cls[i] === ')') depth--
     else if (cls[i] === ':' && depth === 0) lastColon = i
   }
   return {

--- a/packages/oxlint-tailwindcss/tests/design-system/service-cache.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/service-cache.test.ts
@@ -61,8 +61,9 @@ describe('canonicalize-service cache', () => {
   it('different cssPaths do not collide in the cache', () => {
     const classes = ['flex']
     const a = canonicalizeClassesSync(DEFAULT_CSS, classes, 16)
-    // Switching cssPath restarts the worker but the cache (keyed by cssPath)
-    // keeps entries from both design systems alive.
+    // #77: switching cssPath no longer tears down the worker — the service now
+    // keeps one warm worker per cssPath (LRU-bounded) — and the cache (keyed by
+    // cssPath) keeps entries from both design systems alive.
     const b = canonicalizeClassesSync(ALT_CSS, classes, 16)
     expect(a).not.toBeNull()
     expect(b).not.toBeNull()
@@ -70,6 +71,27 @@ describe('canonicalize-service cache', () => {
     // Going back to the original path must still return the same result.
     const aAgain = canonicalizeClassesSync(DEFAULT_CSS, classes, 16)
     expect(aAgain).toEqual(a)
+  })
+
+  it('keeps multiple cssPaths warm across interleaved calls (#77)', () => {
+    // Monorepo pattern: oxlint feeds files from two packages in arbitrary
+    // order, so the service sees the two entry points interleaved. Each call
+    // uses a DISTINCT arbitrary value (cache miss → real worker round-trip),
+    // so this exercises the per-cssPath worker map, not just the class cache.
+    // Before #77 this thrashed a singleton worker; it must now stay correct.
+    const results: Array<{ canonical: string }> = []
+    for (let i = 0; i < 4; i++) {
+      const [ra] = canonicalizeClassesSync(DEFAULT_CSS, [`p-[${i + 1}px]`], 16)
+      const [rb] = canonicalizeClassesSync(ALT_CSS, [`m-[${i + 1}px]`], 16)
+      expect(ra.canonical).toBeTypeOf('string')
+      expect(rb.canonical).toBeTypeOf('string')
+      results.push(ra, rb)
+    }
+    expect(results).toHaveLength(8)
+    // A previously-seen class on the first path is still served correctly after
+    // visiting the other path repeatedly (worker + cache both survived).
+    const [again] = canonicalizeClassesSync(DEFAULT_CSS, ['p-[1px]'], 16)
+    expect(again.canonical).toBe(results[0].canonical)
   })
 
   it('reset clears cached entries (new call takes worker path again)', () => {

--- a/packages/oxlint-tailwindcss/tests/rules/enforce-canonical.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/enforce-canonical.test.ts
@@ -22,6 +22,23 @@ runWithFixture(ruleTester, 'enforce-canonical', enforceCanonical, ENTRY_POINT, {
     // Important modifier: position is not enforce-canonical's concern
     { code: '<div className="!rounded-lg" />', filename: 'test.tsx' },
     { code: '<div className="rounded-lg!" />', filename: 'test.tsx' },
+    // #78: a literal arbitrary value is NOT canonicalized to a var-backed token.
+    // `p-0.5` compiles to `calc(var(--spacing) * 0.5)`, `rounded-sm` to
+    // `var(--radius-sm)`, etc. — canonicalizeCandidates matches them against the
+    // compile-time theme, but a `:root` override (the standard shadcn `--radius`
+    // /`--spacing` pattern) makes them non-equivalent, so autofixing would
+    // silently change the design. Only value-preserving (byte-equal CSS)
+    // conversions are enforced; these literal→token ones are left as written.
+    { code: '<div className="p-[2px]" />', filename: 'test.tsx' },
+    { code: '<div className="max-w-[400px]" />', filename: 'test.tsx' },
+    { code: '<div className="rounded-[4px]" />', filename: 'test.tsx' },
+    { code: '<div className="start-[10px]" />', filename: 'test.tsx' },
+    { code: '<div className="hover:p-[2px]" />', filename: 'test.tsx' },
+    { code: '<div className="!p-[2px]" />', filename: 'test.tsx' },
+    { code: '<div className="p-[2px] max-w-[400px] flex" />', filename: 'test.tsx' },
+    // theme(spacing.1) (compile-time literal 0.25rem) → --spacing(1) (runtime
+    // var(--spacing)) is the same literal→var hazard, so it is left as written.
+    { code: '<div className="[--w-padding:theme(spacing.1)]" />', filename: 'test.tsx' },
   ],
   invalid: [
     {
@@ -78,65 +95,14 @@ runWithFixture(ruleTester, 'enforce-canonical', enforceCanonical, ENTRY_POINT, {
       errors: [{ messageId: 'nonCanonical' }],
       output: '<div className="m-0!" />',
     },
-    // Issue #11: arbitrary values with named equivalents (px → named via rem conversion)
-    {
-      code: '<div className="p-[2px]" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'nonCanonical' }],
-      output: '<div className="p-0.5" />',
-    },
-    {
-      code: '<div className="max-w-[400px]" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'nonCanonical' }],
-      output: '<div className="max-w-100" />',
-    },
-    // Issue #11: var() syntax canonicalization with opacity modifier
+    // Issue #11: var() syntax canonicalization with opacity modifier. Value-safe
+    // (#78): both sides emit `color: color-mix(in oklab, var(--color-text) …)`,
+    // so this is a byte-equal syntax normalization, not a literal→token change.
     {
       code: '<div className="text-[var(--color-text)]/90" />',
       filename: 'test.tsx',
       errors: [{ messageId: 'nonCanonical' }],
       output: '<div className="text-(--color-text)/90" />',
-    },
-    // Issue #11: theme() function canonicalization
-    {
-      code: '<div className="[--w-padding:theme(spacing.1)]" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'nonCanonical' }],
-      output: '<div className="[--w-padding:--spacing(1)]" />',
-    },
-    // Issue #11: with variant prefix
-    {
-      code: '<div className="hover:p-[2px]" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'nonCanonical' }],
-      output: '<div className="hover:p-0.5" />',
-    },
-    // Issue #11: with important modifier
-    {
-      code: '<div className="!p-[2px]" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'nonCanonical' }],
-      output: '<div className="!p-0.5" />',
-    },
-    // Issue #11: multiple in same string
-    {
-      code: '<div className="p-[2px] max-w-[400px] flex" />',
-      filename: 'test.tsx',
-      errors: [
-        { messageId: 'nonCanonical' },
-        {
-          messageId: 'nonCanonical',
-          suggestions: [
-            {
-              messageId: 'suggestReplace',
-              data: { className: 'max-w-[400px]', replacement: 'max-w-100' },
-              output: '<div className="p-0.5 max-w-100 flex" />',
-            },
-          ],
-        },
-      ],
-      output: '<div className="p-0.5 max-w-100 flex" />',
     },
     // Multiple non-canonical classes in same string
     {
@@ -260,15 +226,11 @@ runWithFixture(ruleTester, 'enforce-canonical', enforceCanonical, ENTRY_POINT, {
       errors: [{ messageId: 'nonCanonical' }],
       output: '<div className="bg-linear-to-r" />',
     },
-    // Arbitrary forms route through the worker (canonicalize-service)
-    {
-      code: '<div className="start-[10px]" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'nonCanonical' }],
-      // 10px = 0.625rem, which is spacing token 2.5 — the worker canonicalizes
-      // both the legacy prefix AND the arbitrary value in one pass.
-      output: '<div className="inset-s-2.5" />',
-    },
+    // Arbitrary forms route through the worker (canonicalize-service). This one
+    // is value-safe (#78): both `flex-grow-[2]` and `grow-2` emit
+    // `flex-grow: 2` (a literal), so the byte-equal check keeps the autofix.
+    // (`start-[10px]` → `inset-s-2.5` is NOT enforced — 10px vs
+    // `calc(var(--spacing) * 2.5)` differ — see the valid block above.)
     {
       code: '<div className="flex-grow-[2]" />',
       filename: 'test.tsx',
@@ -277,3 +239,42 @@ runWithFixture(ruleTester, 'enforce-canonical', enforceCanonical, ENTRY_POINT, {
     },
   ],
 })
+
+// #78 regression on a real shadcn theme: `@theme inline { --radius-lg:
+// var(--radius); … }` + `:root { --radius: 0.625rem }`. canonicalizeCandidates
+// still maps `rounded-[4px]` → `rounded-lg` against the compile-time default,
+// but `rounded-lg` resolves to 10px here — so the rule must NOT rewrite it.
+// Value-preserving conversions (the var-reference form) still fire.
+const SHADCN_ENTRY_POINT = resolve(__dirname, '../fixtures/shadcn.css')
+
+// Pre-warm shadcn alongside default WITHOUT resetting — the loader keeps
+// multiple design systems cached (keyed by entry point), and runWithFixture
+// injects each case's own entryPoint, so both fixtures coexist.
+beforeAll(() => {
+  getLoadedDesignSystem(SHADCN_ENTRY_POINT)
+})
+
+runWithFixture(
+  ruleTester,
+  'enforce-canonical (shadcn :root override)',
+  enforceCanonical,
+  SHADCN_ENTRY_POINT,
+  {
+    valid: [
+      // The design-corrupting conversion from the issue — must stay untouched.
+      { code: '<div className="rounded-[4px]" />', filename: 'test.tsx' },
+      { code: '<div className="rounded-[10px]" />', filename: 'test.tsx' },
+      { code: '<div className="p-[2px]" />', filename: 'test.tsx' },
+    ],
+    invalid: [
+      // Value-preserving (byte-equal) canonicalization still fires: the user
+      // already wrote the var, and `rounded-sm` emits the same `var(--radius-sm)`.
+      {
+        code: '<div className="rounded-[var(--radius-sm)]" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'nonCanonical' }],
+        output: '<div className="rounded-sm" />',
+      },
+    ],
+  },
+)

--- a/packages/oxlint-tailwindcss/tests/rules/no-conflicting-classes.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-conflicting-classes.test.ts
@@ -64,6 +64,11 @@ runWithFixture(ruleTester, 'no-conflicting-classes', noConflictingClasses, ENTRY
     { code: '<div className="outline-1 outline-dashed" />', filename: 'test.tsx' },
     { code: '<div className="outline-2 outline-solid" />', filename: 'test.tsx' },
     { code: '<div className="outline-dashed outline-4" />', filename: 'test.tsx' },
+    // outline-none/outline-hidden WRITE --tw-outline-style (: none); outline-<n>
+    // READS it — same writer/reader shape, so they intentionally compose (#81
+    // follow-up: locks this behavior change down).
+    { code: '<div className="outline-none outline-1" />', filename: 'test.tsx' },
+    { code: '<div className="outline-1 outline-hidden" />', filename: 'test.tsx' },
     { code: '<div className="border-2 border-dotted" />', filename: 'test.tsx' },
     // transform axes compose (x + y are independent)
     { code: '<div className="translate-x-2 -translate-y-2" />', filename: 'test.tsx' },
@@ -129,6 +134,14 @@ runWithFixture(ruleTester, 'no-conflicting-classes', noConflictingClasses, ENTRY
     {
       // Two readers, but both also declare outline-width directly — conflict
       code: '<div className="outline-1 outline-2" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'conflict' }],
+    },
+    {
+      // font-weight has the same --tw-* shape, but font-bold and font-normal
+      // both WRITE --tw-font-weight (two writers) — a genuine conflict that the
+      // composition exclusion must NOT suppress (#81 follow-up regression).
+      code: '<div className="font-bold font-normal" />',
       filename: 'test.tsx',
       errors: [{ messageId: 'conflict' }],
     },

--- a/packages/oxlint-tailwindcss/tests/rules/no-unknown-classes.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-unknown-classes.test.ts
@@ -25,6 +25,15 @@ runWithFixture(ruleTester, 'no-unknown-classes', noUnknownClasses, ENTRY_POINT, 
     { code: '<div className="hover:bg-blue-700" />', filename: 'test.tsx' },
     { code: '<div className="bg-[#123456]" />', filename: 'test.tsx' },
     { code: '<div className="w-[200px]" />', filename: 'test.tsx' },
+    // Typed CSS-variable shorthand (#76): `(type:--var)` is a valid v4 utility
+    // (the `:` is a type hint, not a variant separator) — and it's the exact
+    // form enforce-canonical rewrites the `[type:var(--x)]` long form into, so
+    // no-unknown-classes must accept it or the two rules contradict each other.
+    { code: '<div className="border-(length:--stroke)" />', filename: 'test.tsx' },
+    { code: '<div className="bg-(color:--brand)" />', filename: 'test.tsx' },
+    { code: '<div className="text-(length:--fs)" />', filename: 'test.tsx' },
+    { code: '<div className="border-(--stroke)" />', filename: 'test.tsx' },
+    { code: '<div className="hover:border-(length:--stroke)" />', filename: 'test.tsx' },
     { code: 'cn("flex", "items-center")', filename: 'test.tsx' },
     // Variable: name doesn't match pattern — should be ignored
     { code: 'const foo = "fex"', filename: 'test.tsx' },

--- a/packages/oxlint-tailwindcss/tests/utils/class-parser.test.ts
+++ b/packages/oxlint-tailwindcss/tests/utils/class-parser.test.ts
@@ -4,8 +4,10 @@ import {
   extractVariants,
   extractUtility,
   getVariantPrefix,
+  splitUtilityAndVariant,
   hasArbitraryValue,
   getArbitraryValue,
+  utilityHasDynamicValue,
   splitImportant,
   reattachImportant,
 } from '../../src/utils/class-parser'
@@ -163,6 +165,48 @@ describe('parseClass', () => {
     expect(result.negative).toBe(true)
     expect(result.utility).toBe('translate-x-[10px]')
     expect(result.arbitraryValue).toBe('10px')
+  })
+})
+
+// #76: the boundary scanners must track `()` depth, not just `[]`. The `:` in
+// Tailwind v4's typed CSS-variable shorthand (`border-(length:--stroke)`,
+// `bg-(color:--c)`) is a type hint, not a variant separator — mistaking it for
+// one mangled the utility and made `no-unknown-classes` reject a valid class it
+// `enforce-canonical` even recommends.
+describe('typed CSS-variable shorthand is paren-aware (#76)', () => {
+  it('extractVariants ignores the type-hint colon inside parens', () => {
+    expect(extractVariants('border-(length:--stroke)')).toEqual([])
+    expect(extractVariants('bg-(color:--c)')).toEqual([])
+    expect(extractVariants('hover:border-(length:--stroke)')).toEqual(['hover'])
+    expect(extractVariants('sm:focus:text-(length:--fs)')).toEqual(['sm', 'focus'])
+  })
+
+  it('extractUtility keeps the typed shorthand intact', () => {
+    expect(extractUtility('border-(length:--stroke)')).toBe('border-(length:--stroke)')
+    expect(extractUtility('hover:border-(length:--stroke)')).toBe('border-(length:--stroke)')
+    // plain (--var) form (no type hint) was already fine — regression guard
+    expect(extractUtility('border-(--stroke)')).toBe('border-(--stroke)')
+  })
+
+  it('getVariantPrefix / splitUtilityAndVariant split before the utility, not inside the parens', () => {
+    expect(getVariantPrefix('hover:border-(length:--stroke)')).toBe('hover:')
+    expect(getVariantPrefix('border-(length:--stroke)')).toBe('')
+    expect(splitUtilityAndVariant('sm:bg-(color:--c)')).toEqual({
+      utility: 'bg-(color:--c)',
+      variant: 'sm:',
+    })
+  })
+
+  it('parseClass resolves variants and utility for the typed shorthand', () => {
+    const result = parseClass('hover:border-(length:--stroke)')
+    expect(result.variants).toEqual(['hover'])
+    expect(result.variantPrefix).toBe('hover:')
+    expect(result.utility).toBe('border-(length:--stroke)')
+  })
+
+  it('utilityHasDynamicValue still routes the shorthand to the DS path', () => {
+    expect(utilityHasDynamicValue('border-(length:--stroke)')).toBe(true)
+    expect(utilityHasDynamicValue('bg-(color:--c)')).toBe(true)
   })
 })
 


### PR DESCRIPTION
Resolves the three open issues without a PR (#76, #77, #78) and adds the follow-ups I promised on
#81. Each fix is its own commit; the full gate (`format` / `lint` / `typecheck` / `test` / `build`)
is green — **1179 tests pass**.

> #79 is intentionally left open: its false-positive half was closed by #81 (merged), and its perf
> half is tracked by #80 (changes requested).

---

## `fix(no-unknown-classes)`: typed CSS-variable shorthand — #76

`border-(length:--stroke)`, `bg-(color:--c)`, `text-(length:--fs)` are valid v4 utilities but were
flagged as unknown. The four class-boundary scanners in `class-parser.ts` tracked `[]` depth but not
`()` depth, so the `:` type hint inside the parens was mistaken for a variant separator and mangled
the utility. This also removed a live contradiction: `enforce-canonical` rewrites the
`[type:var(--x)]` long form into exactly the shorthand `no-unknown-classes` was rejecting.
One-character-per-scanner fix (`[` / `(` → depth++), plus parser unit tests and end-to-end valid
cases.

## `fix(enforce-canonical)`: don't corrupt the design via autofix — #78

**This changes rule behavior — please read.** `canonicalizeCandidates` matches an arbitrary literal
(`rounded-[4px]` = `4px`) against the _compile-time_ theme default, so it maps it to a
variable-backed token (`rounded-lg` = `var(--radius-lg)`). On any project that overrides that
variable in `:root` — the standard shadcn `--radius`/`--spacing` pattern — the token resolves to a
different value, so `--fix` silently changed the design (the reporter had 8 such autofixes land
across 6 files).

The canonicalize worker now also returns a `safe` flag, **true only when the original and canonical
forms emit byte-identical CSS declarations**, and the rule rewrites only when safe.

- **Still enforced** (byte-equal): legacy renames (`break-words` → `wrap-break-word`,
  `bg-gradient-to-r` → `bg-linear-to-r`, `flex-grow` → `grow`), variable-syntax normalization
  (`bg-[var(--x)]` → `bg-(--x)`, `rounded-[var(--radius-sm)]` → `rounded-sm`), literal-valued
  utilities (`z-[10]` → `z-10`, `flex-grow-[2]` → `grow-2`, `max-w-[100%]` → `max-w-full`).
- **No longer enforced** (literal → var-backed token, only coincidentally equal under the default
  theme): `p-[2px]` → `p-0.5`, `max-w-[400px]` → `max-w-100`, `start-[10px]` → `inset-s-2.5`,
  `[--w-padding:theme(spacing.1)]` → `[--w-padding:--spacing(1)]`. This partially walks back the
  `px → token` numeric conversion from #11 — it was the exact mechanism #78 proved unsafe.
- The full `prefer-theme-tokens` coexistence matrix is preserved (those cases were already
  byte-equal).

I chose **skip** (don't report) over demote-to-suggestion, matching the issue's "should not suggest
… when the token does not resolve to [the literal]". Easy to switch to suggestion-only if you'd
rather keep the nudge.

## `perf(design-system)`: one worker per cssPath in monorepos — #77

`DesignSystemWorker` kept a single worker and tore it down + reloaded the design system on every
`cssPath` change. When oxlint interleaves files from two entry points in one run, the worker
respawned constantly, each time re-paying the full DS warmup (~200 ms + a cold canonicalize). It now
keeps one warm worker **per** cssPath in an LRU-bounded map (cap 8), tracks the sticky error per
cssPath (the old single field was cleared on any switch, so it never actually stayed sticky), and
`reset()` tears down all of them. `terminateWorker` now drops the crash listener so an intentional
teardown can't fire a spurious sticky error.

## `#81` follow-ups (test + cleanup)

- Two-writer `font-weight` regression (`font-bold font-normal` still conflicts — both WRITE
  `--tw-font-weight`, so the composition exclusion must not suppress it).
- Cases pinning the intentional `outline-none`/`outline-hidden` + `outline-<n>` composition.
- Removed the now-redundant `border` width/style `COMPOSITION_PAIRS` entry — the general
  `isVarComposedProperty` mechanism subsumes it.
- Documented that the check is value-blind by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
