### PR TITLE
feat: prefer-scale-token (#91), and three reliability fixes from the 1.5.0 review

### DIFF
--- a/packages/docs/es/rules/_extras/enforce-canonical.md
+++ b/packages/docs/es/rules/_extras/enforce-canonical.md
@@ -77,6 +77,11 @@ para todo el proyecto en vez de por-regla cuando puedas.
   → `inset-s-2`, y las formas con valor arbitrario como `flex-grow-[2]` → `grow-2` (la lista de
   renombres tiene spellings, no valores). Mantén ambas activas — con solo esta los renombres quedan
   sin reportar.
+- **`prefer-scale-token`**: la mitad solo-reporte de lo que esta regla cedió en #78. Una reescritura
+  cuyo CSS emitido difiere textualmente (`p-[10px]` → `p-2.5`, donde el token llega por
+  `var(--spacing)`) no se autofixea aquí y no lo hará nunca; esa regla lo reporta con una
+  sugerencia. Las dos no pueden disparar juntas: esta solo reescribe pares byte-idénticos, que es
+  exactamente lo que la otra salta.
 - **`enforce-consistent-important-position`**: esta regla preserva la posición del `!` que
   escribiste (prefix vs suffix vs ninguno). `enforce-consistent-important-position` es la única
   fuente de verdad para imponer una posición en particular.

--- a/packages/docs/es/rules/_extras/prefer-scale-token.md
+++ b/packages/docs/es/rules/_extras/prefer-scale-token.md
@@ -1,0 +1,148 @@
+## Qué hace esta regla
+
+Reporta un valor hardcodeado que es **numéricamente igual** a algo que tu design system ya nombra, y
+sugiere el nombre — `p-[10px]` → `p-2.5`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` → `rounded-lg`.
+
+Existe porque las otras tres reglas de arbitrario→nombrado se apoyan cada una en algo que este caso
+no cumple:
+
+| Regla                            | Dispara en                              | Se apoya en               |
+| -------------------------------- | --------------------------------------- | ------------------------- |
+| `no-unnecessary-arbitrary-value` | `w-[100%]` → `w-full`                   | CSS byte-idéntico         |
+| `enforce-canonical`              | lo que `canonicalizeCandidates` propone | lo mismo, desde #78       |
+| `prefer-theme-tokens`            | `bg-(--primary)` → `bg-primary`         | el NOMBRE de una variable |
+| **esta regla**                   | `p-[10px]` → `p-2.5`                    | **igualdad numérica**     |
+
+`p-2.5` compila a `padding: calc(var(--spacing) * 2.5)` y `p-[10px]` a `padding: 10px`. Misma
+longitud, texto distinto — así que ninguna regla que exija CSS idéntico puede reportarlo, y eso es
+exactamente lo que cambió en [#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78) al
+volver conservador el autofix.
+
+### Solo reporta, a propósito
+
+**No hay autofix.** La equivalencia se cumple en _este_ tema: el token llega a su valor a través de
+una variable CSS, así que un override en `:root` o un root font size distinto los separa. Reescribir
+eso automáticamente es el bug que arregló #78. La regla reporta, ofrece el reemplazo como sugerencia
+de editor, y lo dice en el mensaje.
+
+### Qué cuenta como "igual"
+
+Dos familias, las dos derivadas de tu design system — en esta regla no hay ninguna tabla de nombres:
+
+- **La escala de spacing.** `--spacing` se lee de tu tema, y los prefijos de utility que la usan se
+  descubren preguntando a qué compila `<prefix>-1`. `p-[10px]` ÷ `0.25rem` = 2.5 pasos → `p-2.5`.
+- **Tokens del tema con nombre, por valor.** Para cada clase que emite exactamente una declaración
+  cuyo valor entero es un solo `var(--x)`, el tema dice cuánto vale `--x`: `0.5rem` → `rounded-lg`.
+  De esa forma salen dos restricciones que importan:
+  - una clase que declara MÁS que el literal no es un equivalente, así que `text-[14px]` → `text-sm`
+    **no** se reporta (`text-sm` además fija `line-height`);
+  - un token de color nunca puede coincidir con un valor que escribió una persona, así que las ~7
+    000 clases de color simplemente no son candidatas.
+
+### Por qué hay una granularidad
+
+Tailwind v4 compila _cualquier_ número: `w-8.425` es una clase válida. Así que toda longitud son N
+unidades de spacing para algún N, y reportarlas todas haría que esta regla disparara en casi
+cualquier valor arbitrario — que es para lo que está `no-arbitrary-value`.
+
+El corte no es un número elegido aquí. Todos los pasos que la propia escala de Tailwind enumera
+(`0`, `0.5`, `1`, `1.5`, `2`, `2.5`, `3`, `3.5`, `4`, `5`…`96`) son múltiplos de `0.5`, y el
+precompute lo deriva de esos mismos pasos. `w-[140px]` → `w-35` sí se reporta (35 es un número
+entero de pasos); `w-[33.7px]` → `w-8.425` no. Usa `step` para afinar.
+
+## Opciones
+
+### `entryPoint`
+
+`string`, opcional. Un entry point CSS solo para esta regla, que pisa
+`settings.tailwindcss.entryPoint`. Esta regla es DS-dependiente — todas las equivalencias salen del
+design system, así que no hay fallback estático y la falta de entry point es un diagnóstico fatal
+`designSystemUnavailable`.
+
+### `step`
+
+`number`, opcional. Por defecto, la granularidad derivada de la escala enumerada de tu tema (`0.5`
+con el `--spacing` por defecto de Tailwind). Bájalo para reportar valores más finos:
+
+```jsonc
+// reporta también w-[33px] → w-8.25
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
+Subirlo vuelve la regla más callada (`step: 1` deja de reportar `p-[10px]` → `p-2.5`). No afecta a
+los tokens del tema con nombre: esos coinciden por valor, no por granularidad.
+
+### `allow`
+
+`string[]`, default `[]`. Prefijos de utility a saltar, comparados con `startsWith` contra la
+utility bare — la misma forma que la opción de `no-arbitrary-value`.
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "allow": ["grid-cols-", "bg-[url("] }] }
+```
+
+## Ejemplos
+
+### ✗ Incorrecto
+
+```tsx
+// Valores que son pasos enteros de la escala de spacing
+<div className="p-[10px] gap-[4px] mt-[6px]" />
+//              ~~~~~~~~ ~~~~~~~~~ ~~~~~~~~  → p-2.5 gap-1 mt-1.5
+
+// Fuera de la escala enumerada pero aún un paso entero — Tailwind compila w-35
+<div className="w-[140px]" />
+//              ~~~~~~~~~  → w-35
+
+// Un token del tema, encontrado por su valor
+<div className="rounded-[0.5rem] basis-[28rem]" />
+//              ~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~  → rounded-lg basis-md
+
+// Los variants y el `!` viajan con la clase
+<div className="hover:p-[10px] p-[10px]!" />
+```
+
+### ✓ Correcto
+
+```tsx
+// El token en sí
+<div className="p-2.5 rounded-lg w-35" />
+
+// Más fino que la granularidad que usa la propia escala de Tailwind
+<div className="w-[33px] w-[33.7px]" />
+
+// Byte-idéntico a una clase nombrada — asunto de no-unnecessary-arbitrary-value
+<div className="w-[100%] z-[10] p-[0px]" />
+
+// text-sm además fija line-height, así que no es lo que dice text-[14px]
+<div className="text-[14px]" />
+
+// Una referencia a variable no tiene literal que comparar — eso lo mira prefer-theme-tokens
+<div className="p-(--gutter) p-[var(--gutter)]" />
+
+// No es una longitud, o el prefijo no lee la escala
+<div className="w-[50%] grid-cols-[18rem_1fr] bg-[#ff0000]" />
+```
+
+## Interacciones con otras reglas
+
+- **`enforce-canonical`**: esta regla es la mitad solo-reporte de lo que aquella cedió en #78. No
+  pueden disparar las dos en la misma clase: todo lo que `enforce-canonical` reescribe es
+  byte-idéntico, y la guardia `getNamedEquivalent` de esta regla salta exactamente esos casos.
+- **`no-unnecessary-arbitrary-value`**: es la dueña de los casos byte-idénticos (`w-[100%]` →
+  `w-full`). Misma guardia, misma razón.
+- **`prefer-theme-tokens`**: es la dueña de los casos donde el usuario escribió una referencia a
+  variable (`bg-(--primary)`), encontrada por NOMBRE. Esta regla solo mira literales.
+- **`no-arbitrary-value`**: un superconjunto en espíritu — prohíbe los arbitrary values
+  directamente. Si la usas, esta regla añade el mensaje específico de "y existe un token para este
+  valor exacto".
+
+La frontera entre las cuatro está fijada en
+`tests/integration/prefer-theme-tokens-coexistence.test.ts`.
+
+## Cuándo desactivarla
+
+- **Usas píxeles a propósito** en un subsistema donde la escala es la unidad equivocada (un gráfico,
+  un overlay sobre canvas, un widget de terceros embebido). Prefiere `allow` con esos prefijos.
+- **No quieres el empujón.** Esta regla está apagada salvo que la actives: la equivalencia es real,
+  pero actuar sobre ella es una convención, no un arreglo de corrección.

--- a/packages/docs/es/rules/enforce-canonical.md
+++ b/packages/docs/es/rules/enforce-canonical.md
@@ -81,6 +81,11 @@ para todo el proyecto en vez de por-regla cuando puedas.
   → `inset-s-2`, y las formas con valor arbitrario como `flex-grow-[2]` → `grow-2` (la lista de
   renombres tiene spellings, no valores). Mantén ambas activas — con solo esta los renombres quedan
   sin reportar.
+- **`prefer-scale-token`**: la mitad solo-reporte de lo que esta regla cedió en #78. Una reescritura
+  cuyo CSS emitido difiere textualmente (`p-[10px]` → `p-2.5`, donde el token llega por
+  `var(--spacing)`) no se autofixea aquí y no lo hará nunca; esa regla lo reporta con una
+  sugerencia. Las dos no pueden disparar juntas: esta solo reescribe pares byte-idénticos, que es
+  exactamente lo que la otra salta.
 - **`enforce-consistent-important-position`**: esta regla preserva la posición del `!` que
   escribiste (prefix vs suffix vs ninguno). `enforce-consistent-important-position` es la única
   fuente de verdad para imponer una posición en particular.

--- a/packages/docs/es/rules/index.md
+++ b/packages/docs/es/rules/index.md
@@ -20,10 +20,12 @@ Reglas que atrapan problemas que generarían CSS inválido o inesperado.
 - [no-deprecated-classes](./no-deprecated-classes) — `flex-grow` → `grow`, etc.
 - [enforce-canonical](./enforce-canonical) — `-m-0` → `m-0`, `bg-gradient-to-r` → `bg-linear-to-r`,
   etc.
-- [no-unnecessary-arbitrary-value](./no-unnecessary-arbitrary-value) — `w-[200px]` → `w-50` cuando
-  existe el named.
+- [no-unnecessary-arbitrary-value](./no-unnecessary-arbitrary-value) — `w-[100%]` → `w-full` cuando
+  la clase nombrada emite CSS idéntico.
 - [prefer-theme-tokens](./prefer-theme-tokens) — `border-(--border)` → `border-border` cuando un
   named utility mapea al mismo variable.
+- [prefer-scale-token](./prefer-scale-token) — `p-[10px]` → `p-2.5`, `w-[200px]` → `w-50` cuando el
+  token es el mismo VALOR (solo reporta; el CSS difiere textualmente).
 - [enforce-negative-arbitrary-values](./enforce-negative-arbitrary-values) — `-top-[5px]` →
   `top-[-5px]`.
 
@@ -77,6 +79,7 @@ fatal `designSystemUnavailable` cuando falta.
 | `no-conflicting-classes`         | `{ reportRedundant: true }`             |
 | `no-unknown-classes`             | `{ allowlist: [], ignorePrefixes: [] }` |
 | `no-unnecessary-arbitrary-value` | `{}`                                    |
+| `prefer-scale-token`             | `{}`                                    |
 | `prefer-theme-tokens`            | `{}`                                    |
 
 ### Reglas DS-opcionales

--- a/packages/docs/es/rules/prefer-scale-token.md
+++ b/packages/docs/es/rules/prefer-scale-token.md
@@ -1,0 +1,152 @@
+# prefer-scale-token
+
+> Prefer the scale step or theme token a hardcoded value is numerically equal to
+
+## Qué hace esta regla
+
+Reporta un valor hardcodeado que es **numéricamente igual** a algo que tu design system ya nombra, y
+sugiere el nombre — `p-[10px]` → `p-2.5`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` → `rounded-lg`.
+
+Existe porque las otras tres reglas de arbitrario→nombrado se apoyan cada una en algo que este caso
+no cumple:
+
+| Regla                            | Dispara en                              | Se apoya en               |
+| -------------------------------- | --------------------------------------- | ------------------------- |
+| `no-unnecessary-arbitrary-value` | `w-[100%]` → `w-full`                   | CSS byte-idéntico         |
+| `enforce-canonical`              | lo que `canonicalizeCandidates` propone | lo mismo, desde #78       |
+| `prefer-theme-tokens`            | `bg-(--primary)` → `bg-primary`         | el NOMBRE de una variable |
+| **esta regla**                   | `p-[10px]` → `p-2.5`                    | **igualdad numérica**     |
+
+`p-2.5` compila a `padding: calc(var(--spacing) * 2.5)` y `p-[10px]` a `padding: 10px`. Misma
+longitud, texto distinto — así que ninguna regla que exija CSS idéntico puede reportarlo, y eso es
+exactamente lo que cambió en [#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78) al
+volver conservador el autofix.
+
+### Solo reporta, a propósito
+
+**No hay autofix.** La equivalencia se cumple en _este_ tema: el token llega a su valor a través de
+una variable CSS, así que un override en `:root` o un root font size distinto los separa. Reescribir
+eso automáticamente es el bug que arregló #78. La regla reporta, ofrece el reemplazo como sugerencia
+de editor, y lo dice en el mensaje.
+
+### Qué cuenta como "igual"
+
+Dos familias, las dos derivadas de tu design system — en esta regla no hay ninguna tabla de nombres:
+
+- **La escala de spacing.** `--spacing` se lee de tu tema, y los prefijos de utility que la usan se
+  descubren preguntando a qué compila `<prefix>-1`. `p-[10px]` ÷ `0.25rem` = 2.5 pasos → `p-2.5`.
+- **Tokens del tema con nombre, por valor.** Para cada clase que emite exactamente una declaración
+  cuyo valor entero es un solo `var(--x)`, el tema dice cuánto vale `--x`: `0.5rem` → `rounded-lg`.
+  De esa forma salen dos restricciones que importan:
+  - una clase que declara MÁS que el literal no es un equivalente, así que `text-[14px]` → `text-sm`
+    **no** se reporta (`text-sm` además fija `line-height`);
+  - un token de color nunca puede coincidir con un valor que escribió una persona, así que las ~7
+    000 clases de color simplemente no son candidatas.
+
+### Por qué hay una granularidad
+
+Tailwind v4 compila _cualquier_ número: `w-8.425` es una clase válida. Así que toda longitud son N
+unidades de spacing para algún N, y reportarlas todas haría que esta regla disparara en casi
+cualquier valor arbitrario — que es para lo que está `no-arbitrary-value`.
+
+El corte no es un número elegido aquí. Todos los pasos que la propia escala de Tailwind enumera
+(`0`, `0.5`, `1`, `1.5`, `2`, `2.5`, `3`, `3.5`, `4`, `5`…`96`) son múltiplos de `0.5`, y el
+precompute lo deriva de esos mismos pasos. `w-[140px]` → `w-35` sí se reporta (35 es un número
+entero de pasos); `w-[33.7px]` → `w-8.425` no. Usa `step` para afinar.
+
+## Opciones
+
+### `entryPoint`
+
+`string`, opcional. Un entry point CSS solo para esta regla, que pisa
+`settings.tailwindcss.entryPoint`. Esta regla es DS-dependiente — todas las equivalencias salen del
+design system, así que no hay fallback estático y la falta de entry point es un diagnóstico fatal
+`designSystemUnavailable`.
+
+### `step`
+
+`number`, opcional. Por defecto, la granularidad derivada de la escala enumerada de tu tema (`0.5`
+con el `--spacing` por defecto de Tailwind). Bájalo para reportar valores más finos:
+
+```jsonc
+// reporta también w-[33px] → w-8.25
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
+Subirlo vuelve la regla más callada (`step: 1` deja de reportar `p-[10px]` → `p-2.5`). No afecta a
+los tokens del tema con nombre: esos coinciden por valor, no por granularidad.
+
+### `allow`
+
+`string[]`, default `[]`. Prefijos de utility a saltar, comparados con `startsWith` contra la
+utility bare — la misma forma que la opción de `no-arbitrary-value`.
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "allow": ["grid-cols-", "bg-[url("] }] }
+```
+
+## Ejemplos
+
+### ✗ Incorrecto
+
+```tsx
+// Valores que son pasos enteros de la escala de spacing
+<div className="p-[10px] gap-[4px] mt-[6px]" />
+//              ~~~~~~~~ ~~~~~~~~~ ~~~~~~~~  → p-2.5 gap-1 mt-1.5
+
+// Fuera de la escala enumerada pero aún un paso entero — Tailwind compila w-35
+<div className="w-[140px]" />
+//              ~~~~~~~~~  → w-35
+
+// Un token del tema, encontrado por su valor
+<div className="rounded-[0.5rem] basis-[28rem]" />
+//              ~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~  → rounded-lg basis-md
+
+// Los variants y el `!` viajan con la clase
+<div className="hover:p-[10px] p-[10px]!" />
+```
+
+### ✓ Correcto
+
+```tsx
+// El token en sí
+<div className="p-2.5 rounded-lg w-35" />
+
+// Más fino que la granularidad que usa la propia escala de Tailwind
+<div className="w-[33px] w-[33.7px]" />
+
+// Byte-idéntico a una clase nombrada — asunto de no-unnecessary-arbitrary-value
+<div className="w-[100%] z-[10] p-[0px]" />
+
+// text-sm además fija line-height, así que no es lo que dice text-[14px]
+<div className="text-[14px]" />
+
+// Una referencia a variable no tiene literal que comparar — eso lo mira prefer-theme-tokens
+<div className="p-(--gutter) p-[var(--gutter)]" />
+
+// No es una longitud, o el prefijo no lee la escala
+<div className="w-[50%] grid-cols-[18rem_1fr] bg-[#ff0000]" />
+```
+
+## Interacciones con otras reglas
+
+- **`enforce-canonical`**: esta regla es la mitad solo-reporte de lo que aquella cedió en #78. No
+  pueden disparar las dos en la misma clase: todo lo que `enforce-canonical` reescribe es
+  byte-idéntico, y la guardia `getNamedEquivalent` de esta regla salta exactamente esos casos.
+- **`no-unnecessary-arbitrary-value`**: es la dueña de los casos byte-idénticos (`w-[100%]` →
+  `w-full`). Misma guardia, misma razón.
+- **`prefer-theme-tokens`**: es la dueña de los casos donde el usuario escribió una referencia a
+  variable (`bg-(--primary)`), encontrada por NOMBRE. Esta regla solo mira literales.
+- **`no-arbitrary-value`**: un superconjunto en espíritu — prohíbe los arbitrary values
+  directamente. Si la usas, esta regla añade el mensaje específico de "y existe un token para este
+  valor exacto".
+
+La frontera entre las cuatro está fijada en
+`tests/integration/prefer-theme-tokens-coexistence.test.ts`.
+
+## Cuándo desactivarla
+
+- **Usas píxeles a propósito** en un subsistema donde la escala es la unidad equivocada (un gráfico,
+  un overlay sobre canvas, un widget de terceros embebido). Prefiere `allow` con esos prefijos.
+- **No quieres el empujón.** Esta regla está apagada salvo que la actives: la equivalencia es real,
+  pero actuar sobre ella es una convención, no un arreglo de corrección.

--- a/packages/docs/rules/_extras/enforce-canonical.md
+++ b/packages/docs/rules/_extras/enforce-canonical.md
@@ -74,6 +74,11 @@ for the whole project instead of per-rule whenever possible.
   What stays here is everything that is current-but-not-canonical: `-m-0` → `m-0`, `start-2` →
   `inset-s-2`, and arbitrary-valued forms like `flex-grow-[2]` → `grow-2` (the rename list holds
   spellings, not values). Keep both rules on — with only this one enabled the renames go unreported.
+- **`prefer-scale-token`**: the report-only half of what this rule gave up in #78. A rewrite whose
+  emitted CSS differs textually (`p-[10px]` → `p-2.5`, where the token resolves through
+  `var(--spacing)`) is not autofixed here and never will be; that rule reports it with a suggestion
+  instead. The two can never both fire: this one only rewrites byte-identical pairs, which is
+  exactly what the other one skips.
 - **`enforce-consistent-important-position`**: this rule preserves the `!` position you wrote
   (prefix vs suffix vs none). `enforce-consistent-important-position` is the single source of truth
   for enforcing a particular position.

--- a/packages/docs/rules/_extras/prefer-scale-token.md
+++ b/packages/docs/rules/_extras/prefer-scale-token.md
@@ -1,0 +1,147 @@
+## What this rule does
+
+Reports a hardcoded value that is **numerically equal** to something your design system already
+names, and suggests the name — `p-[10px]` → `p-2.5`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` →
+`rounded-lg`.
+
+It exists because the other three arbitrary→named rules each key on something this case does not
+satisfy:
+
+| Rule                             | Fires on                               | Keyed on               |
+| -------------------------------- | -------------------------------------- | ---------------------- |
+| `no-unnecessary-arbitrary-value` | `w-[100%]` → `w-full`                  | byte-identical CSS     |
+| `enforce-canonical`              | what `canonicalizeCandidates` proposes | the same, since #78    |
+| `prefer-theme-tokens`            | `bg-(--primary)` → `bg-primary`        | the NAME of a variable |
+| **this rule**                    | `p-[10px]` → `p-2.5`                   | **numeric equality**   |
+
+`p-2.5` compiles to `padding: calc(var(--spacing) * 2.5)` and `p-[10px]` to `padding: 10px`. Same
+length, different text — so no rule that requires identical CSS can report it, which is exactly what
+changed in [#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78) when the autofixer was
+made conservative.
+
+### Report-only, on purpose
+
+**There is no autofix.** The equivalence holds in _this_ theme: the token reaches its value through
+a CSS variable, so a `:root` override or a different root font size makes the two diverge. Rewriting
+that automatically is the bug #78 fixed. The rule reports, offers the replacement as an editor
+suggestion, and says so in the message.
+
+### What counts as "equal"
+
+Two families, both derived from your design system — there is no name table in this rule:
+
+- **The spacing scale.** `--spacing` is read from your theme, and the utility prefixes that use it
+  are found by asking what `<prefix>-1` compiles to. `p-[10px]` ÷ `0.25rem` = 2.5 steps → `p-2.5`.
+- **Named theme tokens, by value.** For every class that emits exactly one declaration whose whole
+  value is one `var(--x)`, the theme says what `--x` is worth: `0.5rem` → `rounded-lg`. Two
+  restrictions come out of that shape and matter:
+  - a class that declares MORE than the literal is not an equivalent, so `text-[14px]` → `text-sm`
+    is **not** reported (`text-sm` also sets `line-height`);
+  - a colour token can never match a value a human typed, so the ~7 000 colour classes are simply
+    not candidates.
+
+### Why there is a granularity at all
+
+Tailwind v4 compiles _any_ number: `w-8.425` is a valid class. So every length is N spacing units
+for some N, and reporting all of them would make this rule fire on practically every arbitrary value
+— which is what `no-arbitrary-value` is for.
+
+The cut is not a number picked here. Every step Tailwind's own scale enumerates (`0`, `0.5`, `1`,
+`1.5`, `2`, `2.5`, `3`, `3.5`, `4`, `5`…`96`) is a multiple of `0.5`, and the precompute derives
+that from the enumerated steps themselves. `w-[140px]` → `w-35` is reported (35 is a whole number of
+steps); `w-[33.7px]` → `w-8.425` is not. Use `step` to go finer.
+
+## Options
+
+### `entryPoint`
+
+`string`, optional. A CSS entry point for this rule alone, overriding
+`settings.tailwindcss.entryPoint`. This rule is DS-dependent — every equivalence comes from the
+design system, so there is no static fallback and a missing entry point is a fatal
+`designSystemUnavailable` diagnostic.
+
+### `step`
+
+`number`, optional. Defaults to the granularity derived from your theme's enumerated scale (`0.5`
+with Tailwind's default `--spacing`). Lower it to report finer values:
+
+```jsonc
+// also report w-[33px] → w-8.25
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
+Raising it makes the rule quieter (`step: 1` stops reporting `p-[10px]` → `p-2.5`). It has no effect
+on named theme tokens: those match by value, not by granularity.
+
+### `allow`
+
+`string[]`, default `[]`. Utility prefixes to skip, matched with `startsWith` against the bare
+utility — the same shape as `no-arbitrary-value`'s option.
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "allow": ["grid-cols-", "bg-[url("] }] }
+```
+
+## Examples
+
+### ✗ Incorrect
+
+```tsx
+// Values that are whole steps of the spacing scale
+<div className="p-[10px] gap-[4px] mt-[6px]" />
+//              ~~~~~~~~ ~~~~~~~~~ ~~~~~~~~  → p-2.5 gap-1 mt-1.5
+
+// Off the enumerated scale but still a whole step — Tailwind compiles w-35
+<div className="w-[140px]" />
+//              ~~~~~~~~~  → w-35
+
+// A named theme token, matched by its value
+<div className="rounded-[0.5rem] basis-[28rem]" />
+//              ~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~  → rounded-lg basis-md
+
+// Variants and `!` travel with the class
+<div className="hover:p-[10px] p-[10px]!" />
+```
+
+### ✓ Correct
+
+```tsx
+// The token itself
+<div className="p-2.5 rounded-lg w-35" />
+
+// Finer than the granularity Tailwind's own scale uses
+<div className="w-[33px] w-[33.7px]" />
+
+// Byte-identical to a named class — no-unnecessary-arbitrary-value's business
+<div className="w-[100%] z-[10] p-[0px]" />
+
+// text-sm also sets line-height, so it is not what text-[14px] says
+<div className="text-[14px]" />
+
+// A variable reference has no literal to compare — prefer-theme-tokens looks at these
+<div className="p-(--gutter) p-[var(--gutter)]" />
+
+// Not a length, or on a prefix that does not read the scale
+<div className="w-[50%] grid-cols-[18rem_1fr] bg-[#ff0000]" />
+```
+
+## Interactions with other rules
+
+- **`enforce-canonical`**: this rule is the report-only half of what that one gave up in #78. They
+  cannot both fire on the same class: anything `enforce-canonical` rewrites is byte-identical, and
+  this rule's `getNamedEquivalent` guard skips exactly those.
+- **`no-unnecessary-arbitrary-value`**: owns the byte-identical cases (`w-[100%]` → `w-full`). Same
+  guard, same reason.
+- **`prefer-theme-tokens`**: owns the cases where the user wrote a variable reference
+  (`bg-(--primary)`), matched by NAME. This rule only looks at literals.
+- **`no-arbitrary-value`**: a superset in spirit — it bans arbitrary values outright. If you run
+  that, this rule adds the specific "and there is a token for this exact value" message.
+
+The four-way boundary is locked down in `tests/integration/prefer-theme-tokens-coexistence.test.ts`.
+
+## When to disable it
+
+- **You deliberately use pixel values** for a subsystem where the scale is the wrong unit (a chart,
+  a canvas overlay, an embedded third-party widget). Prefer `allow` with those prefixes.
+- **You don't want the nudge at all.** This rule is off unless you enable it: the equivalence is
+  real but acting on it is a convention, not a correctness fix.

--- a/packages/docs/rules/enforce-canonical.md
+++ b/packages/docs/rules/enforce-canonical.md
@@ -78,6 +78,11 @@ for the whole project instead of per-rule whenever possible.
   What stays here is everything that is current-but-not-canonical: `-m-0` → `m-0`, `start-2` →
   `inset-s-2`, and arbitrary-valued forms like `flex-grow-[2]` → `grow-2` (the rename list holds
   spellings, not values). Keep both rules on — with only this one enabled the renames go unreported.
+- **`prefer-scale-token`**: the report-only half of what this rule gave up in #78. A rewrite whose
+  emitted CSS differs textually (`p-[10px]` → `p-2.5`, where the token resolves through
+  `var(--spacing)`) is not autofixed here and never will be; that rule reports it with a suggestion
+  instead. The two can never both fire: this one only rewrites byte-identical pairs, which is
+  exactly what the other one skips.
 - **`enforce-consistent-important-position`**: this rule preserves the `!` position you wrote
   (prefix vs suffix vs none). `enforce-consistent-important-position` is the single source of truth
   for enforcing a particular position.

--- a/packages/docs/rules/index.md
+++ b/packages/docs/rules/index.md
@@ -20,10 +20,12 @@ These rules catch problems that would generate invalid or unexpected CSS.
 - [no-deprecated-classes](./no-deprecated-classes) — `flex-grow` → `grow`, etc.
 - [enforce-canonical](./enforce-canonical) — `-m-0` → `m-0`, `bg-gradient-to-r` → `bg-linear-to-r`,
   etc.
-- [no-unnecessary-arbitrary-value](./no-unnecessary-arbitrary-value) — `w-[200px]` → `w-50` when the
-  named value exists.
+- [no-unnecessary-arbitrary-value](./no-unnecessary-arbitrary-value) — `w-[100%]` → `w-full` when
+  the named class emits identical CSS.
 - [prefer-theme-tokens](./prefer-theme-tokens) — `border-(--border)` → `border-border` when a named
   utility maps to the same theme variable.
+- [prefer-scale-token](./prefer-scale-token) — `p-[10px]` → `p-2.5`, `w-[200px]` → `w-50` when the
+  token is the same VALUE (report-only; the CSS differs textually).
 - [enforce-negative-arbitrary-values](./enforce-negative-arbitrary-values) — `-top-[5px]` →
   `top-[-5px]`.
 
@@ -77,6 +79,7 @@ These rules require `settings.tailwindcss.entryPoint` to be set; they emit a fat
 | `no-conflicting-classes`         | `{ reportRedundant: true }`             |
 | `no-unknown-classes`             | `{ allowlist: [], ignorePrefixes: [] }` |
 | `no-unnecessary-arbitrary-value` | `{}`                                    |
+| `prefer-scale-token`             | `{}`                                    |
 | `prefer-theme-tokens`            | `{}`                                    |
 
 ### DS-optional rules

--- a/packages/docs/rules/prefer-scale-token.md
+++ b/packages/docs/rules/prefer-scale-token.md
@@ -1,0 +1,151 @@
+# prefer-scale-token
+
+> Prefer the scale step or theme token a hardcoded value is numerically equal to
+
+## What this rule does
+
+Reports a hardcoded value that is **numerically equal** to something your design system already
+names, and suggests the name — `p-[10px]` → `p-2.5`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` →
+`rounded-lg`.
+
+It exists because the other three arbitrary→named rules each key on something this case does not
+satisfy:
+
+| Rule                             | Fires on                               | Keyed on               |
+| -------------------------------- | -------------------------------------- | ---------------------- |
+| `no-unnecessary-arbitrary-value` | `w-[100%]` → `w-full`                  | byte-identical CSS     |
+| `enforce-canonical`              | what `canonicalizeCandidates` proposes | the same, since #78    |
+| `prefer-theme-tokens`            | `bg-(--primary)` → `bg-primary`        | the NAME of a variable |
+| **this rule**                    | `p-[10px]` → `p-2.5`                   | **numeric equality**   |
+
+`p-2.5` compiles to `padding: calc(var(--spacing) * 2.5)` and `p-[10px]` to `padding: 10px`. Same
+length, different text — so no rule that requires identical CSS can report it, which is exactly what
+changed in [#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78) when the autofixer was
+made conservative.
+
+### Report-only, on purpose
+
+**There is no autofix.** The equivalence holds in _this_ theme: the token reaches its value through
+a CSS variable, so a `:root` override or a different root font size makes the two diverge. Rewriting
+that automatically is the bug #78 fixed. The rule reports, offers the replacement as an editor
+suggestion, and says so in the message.
+
+### What counts as "equal"
+
+Two families, both derived from your design system — there is no name table in this rule:
+
+- **The spacing scale.** `--spacing` is read from your theme, and the utility prefixes that use it
+  are found by asking what `<prefix>-1` compiles to. `p-[10px]` ÷ `0.25rem` = 2.5 steps → `p-2.5`.
+- **Named theme tokens, by value.** For every class that emits exactly one declaration whose whole
+  value is one `var(--x)`, the theme says what `--x` is worth: `0.5rem` → `rounded-lg`. Two
+  restrictions come out of that shape and matter:
+  - a class that declares MORE than the literal is not an equivalent, so `text-[14px]` → `text-sm`
+    is **not** reported (`text-sm` also sets `line-height`);
+  - a colour token can never match a value a human typed, so the ~7 000 colour classes are simply
+    not candidates.
+
+### Why there is a granularity at all
+
+Tailwind v4 compiles _any_ number: `w-8.425` is a valid class. So every length is N spacing units
+for some N, and reporting all of them would make this rule fire on practically every arbitrary value
+— which is what `no-arbitrary-value` is for.
+
+The cut is not a number picked here. Every step Tailwind's own scale enumerates (`0`, `0.5`, `1`,
+`1.5`, `2`, `2.5`, `3`, `3.5`, `4`, `5`…`96`) is a multiple of `0.5`, and the precompute derives
+that from the enumerated steps themselves. `w-[140px]` → `w-35` is reported (35 is a whole number of
+steps); `w-[33.7px]` → `w-8.425` is not. Use `step` to go finer.
+
+## Options
+
+### `entryPoint`
+
+`string`, optional. A CSS entry point for this rule alone, overriding
+`settings.tailwindcss.entryPoint`. This rule is DS-dependent — every equivalence comes from the
+design system, so there is no static fallback and a missing entry point is a fatal
+`designSystemUnavailable` diagnostic.
+
+### `step`
+
+`number`, optional. Defaults to the granularity derived from your theme's enumerated scale (`0.5`
+with Tailwind's default `--spacing`). Lower it to report finer values:
+
+```jsonc
+// also report w-[33px] → w-8.25
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
+Raising it makes the rule quieter (`step: 1` stops reporting `p-[10px]` → `p-2.5`). It has no effect
+on named theme tokens: those match by value, not by granularity.
+
+### `allow`
+
+`string[]`, default `[]`. Utility prefixes to skip, matched with `startsWith` against the bare
+utility — the same shape as `no-arbitrary-value`'s option.
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "allow": ["grid-cols-", "bg-[url("] }] }
+```
+
+## Examples
+
+### ✗ Incorrect
+
+```tsx
+// Values that are whole steps of the spacing scale
+<div className="p-[10px] gap-[4px] mt-[6px]" />
+//              ~~~~~~~~ ~~~~~~~~~ ~~~~~~~~  → p-2.5 gap-1 mt-1.5
+
+// Off the enumerated scale but still a whole step — Tailwind compiles w-35
+<div className="w-[140px]" />
+//              ~~~~~~~~~  → w-35
+
+// A named theme token, matched by its value
+<div className="rounded-[0.5rem] basis-[28rem]" />
+//              ~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~  → rounded-lg basis-md
+
+// Variants and `!` travel with the class
+<div className="hover:p-[10px] p-[10px]!" />
+```
+
+### ✓ Correct
+
+```tsx
+// The token itself
+<div className="p-2.5 rounded-lg w-35" />
+
+// Finer than the granularity Tailwind's own scale uses
+<div className="w-[33px] w-[33.7px]" />
+
+// Byte-identical to a named class — no-unnecessary-arbitrary-value's business
+<div className="w-[100%] z-[10] p-[0px]" />
+
+// text-sm also sets line-height, so it is not what text-[14px] says
+<div className="text-[14px]" />
+
+// A variable reference has no literal to compare — prefer-theme-tokens looks at these
+<div className="p-(--gutter) p-[var(--gutter)]" />
+
+// Not a length, or on a prefix that does not read the scale
+<div className="w-[50%] grid-cols-[18rem_1fr] bg-[#ff0000]" />
+```
+
+## Interactions with other rules
+
+- **`enforce-canonical`**: this rule is the report-only half of what that one gave up in #78. They
+  cannot both fire on the same class: anything `enforce-canonical` rewrites is byte-identical, and
+  this rule's `getNamedEquivalent` guard skips exactly those.
+- **`no-unnecessary-arbitrary-value`**: owns the byte-identical cases (`w-[100%]` → `w-full`). Same
+  guard, same reason.
+- **`prefer-theme-tokens`**: owns the cases where the user wrote a variable reference
+  (`bg-(--primary)`), matched by NAME. This rule only looks at literals.
+- **`no-arbitrary-value`**: a superset in spirit — it bans arbitrary values outright. If you run
+  that, this rule adds the specific "and there is a token for this exact value" message.
+
+The four-way boundary is locked down in `tests/integration/prefer-theme-tokens-coexistence.test.ts`.
+
+## When to disable it
+
+- **You deliberately use pixel values** for a subsystem where the scale is the wrong unit (a chart,
+  a canvas overlay, an embedded third-party widget). Prefer `allow` with those prefixes.
+- **You don't want the nudge at all.** This rule is off unless you enable it: the equivalence is
+  real but acting on it is a convention, not a correctness fix.

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## 1.6.0
+
+### Features
+
+- **New rule `prefer-scale-token`** — reports a hardcoded value that is numerically equal to
+  something your design system already names, and suggests the name: `p-[10px]` → `p-2.5`,
+  `gap-[4px]` → `gap-1`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` → `rounded-lg`. Off unless you
+  enable it. Closes [#91](https://github.com/sergioazoc/oxlint-tailwindcss/issues/91).
+
+  It fills a gap the other three arbitrary→named rules cannot: each keys on something this case does
+  not satisfy — byte-identical CSS (`no-unnecessary-arbitrary-value`), what `canonicalizeCandidates`
+  proposes (`enforce-canonical` since #78), the NAME of a variable the user wrote
+  (`prefer-theme-tokens`). `p-2.5` compiles to `calc(var(--spacing) * 2.5)` and `p-[10px]` to
+  `10px`: same length, different text.
+
+  **Report-only, deliberately.** There is no autofix and there will not be one: the token reaches
+  its value through a CSS variable, so a `:root` override or a different root font size makes the
+  two diverge. Autofixing that is the bug #78 fixed. The rule suggests, and the message says why.
+
+  Both families are derived from the design system, so there is no table to drift: the spacing scale
+  comes from `--spacing` plus a probe of what `<prefix>-1` compiles to, and the named tokens come
+  from the emitted CSS plus the theme. Two consequences fall out of the derivation rather than being
+  special-cased: `text-[14px]` → `text-sm` is NOT reported (`text-sm` also sets `line-height`, so it
+  is not the same declaration), and colour tokens are not candidates at all (a colour can never
+  match a literal numerically). 253 comparable tokens, +8.5 KB on the cache artifact.
+
+  **The granularity is derived, not chosen.** Tailwind compiles any number — `w-8.425` is valid — so
+  every length is N spacing units for some N, and reporting all of them would just be
+  `no-arbitrary-value`. Every step Tailwind's own scale enumerates is a multiple of `0.5`, and the
+  precompute computes that from the steps themselves. `step` only ever makes it finer.
+
+  For the record, correcting the issue's premise: `w-[140px]` → `w-35` was never reported, before or
+  after #78. Tailwind does not propose it, because 35 is not one of the steps it enumerates. What
+  #78 silenced were the values that ARE enumerated (`p-[10px]` → `p-2.5` and friends). Both are
+  covered now.
+
+### Bug fixes
+
+- **The declaration service no longer degrades in silence.** It swallowed its own failures and
+  reported "no information", which was defensible while `no-conflicting-classes` was the only caller
+  — no declarations, no comparison, no diagnostic. Since 1.5.0 `no-unknown-classes` asks it about
+  VALIDITY, and there silence sends the rule back to the tolerant heuristic: a dead worker quietly
+  reinstated exactly the false negatives the service exists to remove, on a run that stayed green.
+  It throws now, like the sort and canonicalize services, and each caller takes the posture that
+  already existed — `no-conflicting-classes` and `no-unknown-classes` surface
+  `designSystemUnavailable`; `no-dark-without-light` (DS-OPTIONAL, which may never emit it) degrades
+  to prefix-only grouping and logs it under `debug`. **A transient worker failure now fails those
+  two rules instead of quietly weakening them.**
+- **`prefer-theme-tokens` no longer proposes a token when the variable is defined in an `@import`.**
+  `definesVar` is what stops a rewrite that would change the design, and it scanned only the entry
+  CSS — so splitting the theme across files (the normal shadcn/ui layout) made
+  `:root { --primary: … }` read as undefined and the rule went back to proposing `bg-primary` for
+  `bg-(--primary)`. The precompute now scans the entry and its resolved imports.
+- **A cache artifact shared by two `DesignSystemCache` instances could produce a false conflict.**
+  Lint-time interning appended values to the artifact's own array while each cache kept its own
+  text→id map, so one value could end up with two ids — and `no-conflicting-classes` compares ids,
+  so two identical values would read as a conflict. Ids are local to the cache now. Unreachable
+  through the loader, which parses the JSON per entry point; fixed because it was one shared object
+  away.
+
+### Docs
+
+- The rule index claimed `no-unnecessary-arbitrary-value` handles `w-[200px]` → `w-50`. It does not,
+  and cannot: those emit different CSS text. That example was the same misconception behind #91, and
+  it now points at `prefer-scale-token`, which does handle it.
+
 ## 1.5.0
 
 The companion to 1.4.0: that release made `no-conflicting-classes` decide from the CSS Tailwind

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/design-system/cache.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/cache.ts
@@ -29,8 +29,11 @@ export class DesignSystemCache {
   private declMemo = new Map<string, readonly CssDeclaration[]>()
   private propsMemo = new Map<string, string[]>()
   private partialSet = new Set<string>()
-  // Reverse of `declIndex.values`, built on first lint-time interning.
+  // Reverse of `declIndex.values`, built on first lint-time interning, plus the
+  // next id to hand out for a value the precompute never saw. Ids live here
+  // rather than in the artifact — see `internDeclarations`.
   private valueIdByText: Map<string, number> | null = null
+  private nextValueId = 0
   private variantOrderMap = new Map<string, number>()
   private variantFactsMap = new Map<string, VariantFacts>()
   private arbitraryEquivMap = new Map<string, string>()
@@ -522,6 +525,7 @@ export class DesignSystemCache {
     if (!index) return EMPTY_DECLARATIONS
     if (!this.valueIdByText) {
       this.valueIdByText = new Map(index.values.map((value, id) => [value, id]))
+      this.nextValueId = index.values.length
     }
     const decls: CssDeclaration[] = []
     let hasElement = false
@@ -530,8 +534,15 @@ export class DesignSystemCache {
     for (const [scopeToken, prop, value] of raws) {
       let valueId = this.valueIdByText.get(value)
       if (valueId === undefined) {
-        valueId = index.values.length
-        index.values.push(value)
+        // Numbered above the precomputed range but NOT appended to
+        // `index.values`: that array belongs to the cache artifact, which is
+        // shared by reference. Two caches built from the same artifact would
+        // each push into it while holding their own text→id map, so the same
+        // value would end up with two different ids — and `decidePair` compares
+        // ids, so two identical values would read as a conflict. Nothing reads
+        // ids back out of the array (the decoder only resolves ids that came
+        // from `index.table`, all precomputed), so keeping them local is free.
+        valueId = this.nextValueId++
         this.valueIdByText.set(value, valueId)
       }
       const facts = valueFacts[value]

--- a/packages/oxlint-tailwindcss/src/design-system/cache.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/cache.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/class-parser'
 
 const EMPTY_DECLARATIONS: readonly CssDeclaration[] = []
+const EMPTY_TOKEN_VALUES: readonly [string, string][] = []
 
 export class DesignSystemCache {
   private canonicalMap = new Map<string, string>()
@@ -49,6 +50,11 @@ export class DesignSystemCache {
   private componentSet = new Set<string>()
   private themeRefs = new Map<string, string[]>()
   private definedVarSet = new Set<string>()
+  // Utility prefix → [literal value, class]. Read by prefer-scale-token; see
+  // `PrecomputedData.tokenValues` for why only single-declaration numeric tokens
+  // are in here.
+  private tokenValuesMap = new Map<string, readonly [string, string][]>()
+  private scaleFacts: { unit: string; step: number; prefixes: Set<string> } | null = null
 
   static fromPrecomputed(data: PrecomputedData): DesignSystemCache {
     const cache = new DesignSystemCache()
@@ -113,6 +119,18 @@ export class DesignSystemCache {
     if (data.themeRefs) {
       for (const [name, refs] of Object.entries(data.themeRefs)) {
         cache.themeRefs.set(name, refs)
+      }
+    }
+
+    for (const [prefix, entries] of Object.entries(data.tokenValues ?? {})) {
+      cache.tokenValuesMap.set(prefix, entries)
+    }
+
+    if (data.scale) {
+      cache.scaleFacts = {
+        unit: data.scale.unit,
+        step: data.scale.step,
+        prefixes: new Set(data.scale.prefixes),
       }
     }
 
@@ -302,6 +320,27 @@ export class DesignSystemCache {
   /** Variant names the design system reports, for suggesting a typo's neighbour. */
   variantNames(): string[] {
     return [...this.variantOrderMap.keys()]
+  }
+
+  /**
+   * The numeric theme tokens this utility prefix can be written with, as
+   * `[literal value, class]`. Empty when the prefix has none.
+   */
+  tokenValuesFor(prefix: string): readonly [string, string][] {
+    return this.tokenValuesMap.get(this.stripProjectPrefix(prefix)) ?? EMPTY_TOKEN_VALUES
+  }
+
+  /**
+   * The spacing scale as the design system describes it: the resolved value of
+   * `--spacing`, the granularity Tailwind's own enumerated steps use, and whether
+   * a given prefix reads it. `null` when the theme has no `--spacing`.
+   */
+  get scale(): { unit: string; step: number } | null {
+    return this.scaleFacts ? { unit: this.scaleFacts.unit, step: this.scaleFacts.step } : null
+  }
+
+  readsScale(prefix: string): boolean {
+    return this.scaleFacts?.prefixes.has(this.stripProjectPrefix(prefix)) ?? false
   }
 
   isValid(className: string): boolean {

--- a/packages/oxlint-tailwindcss/src/design-system/declaration-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/declaration-service.ts
@@ -18,7 +18,6 @@
 import { type DesignSystemCache } from './cache'
 import { DesignSystemWorker, makeWorkerScript } from './ds-worker'
 import { DECL_EXTRACTOR_SOURCE } from './sync-loader'
-import { SortServiceError } from '../utils/fatal'
 
 interface DeclarationRequest {
   classes: string[]
@@ -114,36 +113,40 @@ function answersFor(cache: DesignSystemCache): Map<string, boolean> {
  * Ask the design system about every class there is no answer for yet, intern the
  * declarations it returns, and record which classes produce no CSS at all.
  *
- * Returns false when the service is unavailable. Callers treat that as "no
- * information" rather than as an answer, so a broken worker degrades to the
- * behaviour that predates it instead of to wrong diagnostics. Real failures still
- * surface through the sticky error the worker records.
+ * **Throws `SortServiceError` when the service is unavailable**, like the sort and
+ * canonicalize services do. It used to swallow the failure and report "no
+ * information", which was defensible when `no-conflicting-classes` was the only
+ * caller — no declarations means no comparison, so the rule just went quiet. It
+ * stopped being defensible once `no-unknown-classes` started asking about
+ * VALIDITY: there, silence sends the rule back to the tolerant heuristic, so a
+ * dead worker quietly reinstates the very false negatives the service exists to
+ * remove, with nothing anywhere to say so.
+ *
+ * The caller decides what to do, and the two postures already exist in the
+ * plugin: a DS-dependent rule surfaces it through `safeGetDS` as
+ * `designSystemUnavailable` (what `enforce-canonical` does with the canonicalize
+ * worker), a DS-OPTIONAL rule catches it and degrades.
  */
-function ask(cssPath: string, cache: DesignSystemCache, classes: string[]): boolean {
+function ask(cssPath: string, cache: DesignSystemCache, classes: string[]): void {
   const known = answersFor(cache)
   const pending = [...new Set(classes.filter((cls) => !known.has(cls)))]
-  if (pending.length === 0) return true
+  if (pending.length === 0) return
 
-  let response: DeclarationResponse
-  try {
-    response = declWorker.callSync(cssPath, { classes: pending })
-  } catch (error) {
-    if (error instanceof SortServiceError) return false
-    throw error
-  }
+  const response: DeclarationResponse = declWorker.callSync(cssPath, { classes: pending })
 
   const invalid = new Set(response.invalid)
   for (const cls of pending) known.set(cls, !invalid.has(cls))
   for (const [cls, raws] of Object.entries(response.decls)) {
     cache.internDeclarations(cls, raws, response.values)
   }
-  return true
 }
 
 /**
  * Resolve and intern declarations for `classes` that the precompute doesn't know.
  * They land in the cache, so the caller reads them back through
  * `cache.getCssDeclarations` like any other class.
+ *
+ * Throws `SortServiceError` if the service is unavailable — see `ask`.
  */
 export function resolveDeclarationsSync(
   cssPath: string,
@@ -154,19 +157,19 @@ export function resolveDeclarationsSync(
 }
 
 /**
- * Which of these classes produce CSS. `null` when the service is unavailable, so
- * the caller can fall back instead of reading silence as an answer.
+ * Which of these classes produce CSS.
  *
  * This is what makes validity exact for the classes the precompute cannot
  * enumerate: `w-45` and `bg-red-5000` are shaped identically, and only Tailwind
- * knows that it compiles the first and not the second.
+ * knows that it compiles the first and not the second. Throws
+ * `SortServiceError` if the service is unavailable — see `ask`.
  */
 export function validateClassesSync(
   cssPath: string,
   cache: DesignSystemCache,
   classes: string[],
-): Map<string, boolean> | null {
-  if (!ask(cssPath, cache, classes)) return null
+): Map<string, boolean> {
+  ask(cssPath, cache, classes)
   return answersFor(cache)
 }
 

--- a/packages/oxlint-tailwindcss/src/design-system/sync-loader.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/sync-loader.ts
@@ -89,10 +89,11 @@ export interface PrecomputedData {
    */
   themeRefs?: Record<string, string[]>
   /**
-   * Custom properties the project defines anywhere in the entry CSS. Used to
-   * tell "the variable the user referenced does not exist, so the declaration is
-   * dead and suggesting a token can only improve it" from "it exists and means
-   * something else, so suggesting a token would change the design".
+   * Custom properties the project defines, across the entry CSS and the files it
+   * `@import`s (one level). Used to tell "the variable the user referenced does
+   * not exist, so the declaration is dead and suggesting a token can only improve
+   * it" from "it exists and means something else, so suggesting a token would
+   * change the design".
    */
   definedVars?: string[]
   /**
@@ -351,7 +352,12 @@ function resolveImport(specifier, baseDir) {
   return null;
 }
 
-function extractComponentClasses(cssPath, baseDir) {
+// The entry CSS plus every \`@import\` that resolves, one level deep. Shared by
+// the component-class scan and the \`definedVars\` scan: a custom property declared
+// in an imported file is as real to the browser as one in the entry, and treating
+// it as undefined makes prefer-theme-tokens propose a token that can change the
+// design (the #78 hazard, in miniature).
+function collectCssSources(cssPath, baseDir) {
   let css;
   try { css = readFileSync(cssPath, 'utf-8'); } catch { return []; }
   const files = [css];
@@ -363,6 +369,11 @@ function extractComponentClasses(cssPath, baseDir) {
       try { files.push(readFileSync(resolved, 'utf-8')); } catch {}
     }
   }
+  return files;
+}
+
+function extractComponentClasses(cssPath, baseDir) {
+  const files = collectCssSources(cssPath, baseDir);
   const result = [];
   for (const content of files) {
     // Scan both @layer components AND @layer utilities
@@ -849,15 +860,14 @@ async function main() {
     }
   }
 
-  // Theme variables that dereference to another custom property. Only the
-  // referencing ones are stored (~a handful), and the reference list reuses the
-  // same balanced scanner the declaration values go through.
-  // Custom properties the project defines. The entry file covers the standard
-  // ':root { --x: ... }' pattern; definitions inside @imported files are not
-  // scanned, so an unseen definition reads as "undefined" — which only ever makes
-  // prefer-theme-tokens more willing to suggest, never less accurate about a
-  // definition it can see.
-  const definedVars = [...new Set(css.match(/--[\\w-]+(?=\\s*:)/g) || [])];
+  // Custom properties the project defines, across the entry AND its resolved
+  // @imports — splitting the theme across files is the normal shadcn/ui layout,
+  // and a definition we cannot see reads as "undefined", which is what makes
+  // prefer-theme-tokens propose a token that means something else. One level
+  // deep, same as the component-class scan it shares \`collectCssSources\` with.
+  const definedVars = [...new Set(
+    collectCssSources(cssPath, base).flatMap(src => src.match(/--[\\w-]+(?=\\s*:)/g) || [])
+  )];
 
   const themeRefs = {};
   if (ds.theme && typeof ds.theme.entries === 'function') {

--- a/packages/oxlint-tailwindcss/src/design-system/sync-loader.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/sync-loader.ts
@@ -97,6 +97,32 @@ export interface PrecomputedData {
    */
   definedVars?: string[]
   /**
+   * Utility prefix → the numeric theme tokens it can be written with, as
+   * `[literal, className]` (`rounded` → `[['0.5rem', 'rounded-lg'], …]`).
+   *
+   * Only classes that emit ONE declaration whose whole value is a single `var(--x)`
+   * resolving to a number. Both restrictions are what make a match an equivalence
+   * rather than a guess: a colour token can never match a literal a human typed,
+   * and a class that declares MORE than the original is not the same declaration —
+   * `text-sm` also sets `line-height`, so `text-[14px]` is not it.
+   *
+   * Read by `prefer-scale-token`, which converts both sides to a common unit with
+   * the configured root font size before comparing.
+   */
+  tokenValues?: Record<string, [string, string][]>
+  /**
+   * The spacing scale, for `prefer-scale-token`: the resolved value of
+   * `--spacing`, the utility prefixes whose `<prefix>-1` reads it, and the
+   * granularity Tailwind's own enumerated steps use (the smallest gap between
+   * them — 0.5 in the default theme).
+   *
+   * The granularity is DERIVED rather than chosen: Tailwind compiles any number,
+   * so without it every length would have a "scale equivalent" and the rule would
+   * report `w-[33.7px]` → `w-8.425`. Deriving it from the steps Tailwind itself
+   * enumerates is how the rule stays inside what Tailwind does.
+   */
+  scale?: { unit: string; step: number; prefixes: string[] }
+  /**
    * Tailwind v4 project prefix (e.g. 'tw' for `@import "tailwindcss" prefix(tw)`).
    * Empty string when no prefix is configured. All other fields store class
    * names WITHOUT the prefix; this is the single source of truth for it.
@@ -870,9 +896,11 @@ async function main() {
   )];
 
   const themeRefs = {};
+  const themeValues = new Map();
   if (ds.theme && typeof ds.theme.entries === 'function') {
     for (const [name, entry] of ds.theme.entries()) {
       const value = entry && typeof entry.value === 'string' ? entry.value : '';
+      themeValues.set(name, value);
       if (!value.includes('var(')) continue;
       const reads = scanVarReads(value);
       const all = [...new Set([...reads[0], ...reads[1]])];
@@ -880,7 +908,77 @@ async function main() {
     }
   }
 
-  const json = JSON.stringify({ validClasses, canonical, deprecated, order, cssDeclarations, variantOrder, variantFacts, componentClasses, arbitraryEquivalents, themeRefs, definedVars, prefix });
+  // ── What a literal value could have been written as (for prefer-scale-token) ──
+  //
+  // Two families, both derived. Neither is a name table: the emitted CSS says
+  // which variable a class reads and the theme says what that variable is worth.
+
+  // A single declaration whose whole value is one \`var(--x)\` that the theme
+  // resolves to a NUMBER. Numeric because that is the only thing the rule can
+  // compare — a colour token could never match a literal the user typed — and
+  // SINGLE because a class that declares more than the original is not an
+  // equivalent: \`text-sm\` sets \`line-height\` too, so \`text-[14px]\` is not it.
+  const NUMERIC_LITERAL = /^-?\\d*\\.?\\d+(rem|px|em|%|s|ms|deg)?$/;
+  const tokenValues = {};
+  for (const cls of validClasses) {
+    if (cls.includes('[') || cls.includes('/')) continue;
+    const css = declCss[cls];
+    if (!css) continue;
+    const open = css.indexOf('{');
+    const close = css.indexOf('}');
+    if (open < 0 || close < 0) continue;
+    const body = css.slice(open + 1, close).replace(/\\s+/g, ' ').replace(/;\\s*$/, '').trim();
+    const m = /^([a-z-]+):\\s*var\\((--[\\w-]+)\\)$/.exec(body);
+    if (!m) continue;
+    const value = themeValues.get(m[2]);
+    if (!value || !NUMERIC_LITERAL.test(value)) continue;
+    const dash = cls.lastIndexOf('-');
+    if (dash <= 0) continue;
+    const prefix = unpfx(cls).slice(0, unpfx(cls).lastIndexOf('-'));
+    if (!prefix) continue;
+    if (!tokenValues[prefix]) tokenValues[prefix] = [];
+    tokenValues[prefix].push([value, unpfx(cls)]);
+  }
+
+  // The spacing scale: its unit, which prefixes read it, and the granularity
+  // Tailwind's own enumerated steps use. Every step getClassList() lists is a
+  // multiple of that granularity, so deriving it is how the rule stays inside
+  // what Tailwind does instead of inventing a threshold.
+  const scaleUnit = themeValues.get('--spacing') || '';
+  const scalePrefixes = [];
+  if (scaleUnit) {
+    const probes = [...knownPrefixes];
+    const probeResults = ds.candidatesToCss(probes.map(p => pfx(p + '-1')));
+    for (let i = 0; i < probes.length; i++) {
+      const css = probeResults[i];
+      if (!css) continue;
+      // \`size-1\` emits width AND height, both reading the unit — one match is enough.
+      if (css.includes('var(--spacing)')) scalePrefixes.push(probes[i]);
+    }
+  }
+  let scaleStep = 0;
+  if (scalePrefixes.length > 0) {
+    const steps = new Set();
+    const scaleSet = new Set(scalePrefixes);
+    for (const cls of validClasses) {
+      const dash = cls.lastIndexOf('-');
+      if (dash <= 0) continue;
+      if (!scaleSet.has(cls.slice(0, dash))) continue;
+      const suffix = cls.slice(dash + 1);
+      if (!/^\\d*\\.?\\d+$/.test(suffix)) continue;
+      steps.add(parseFloat(suffix));
+    }
+    const sorted = [...steps].sort((a, b) => a - b);
+    for (let i = 1; i < sorted.length; i++) {
+      const gap = Math.round((sorted[i] - sorted[i - 1]) * 1000) / 1000;
+      if (gap > 0 && (scaleStep === 0 || gap < scaleStep)) scaleStep = gap;
+    }
+  }
+  const scale = scaleUnit && scalePrefixes.length > 0
+    ? { unit: scaleUnit, step: scaleStep || 1, prefixes: scalePrefixes.sort() }
+    : undefined;
+
+  const json = JSON.stringify({ validClasses, canonical, deprecated, order, cssDeclarations, variantOrder, variantFacts, componentClasses, arbitraryEquivalents, themeRefs, definedVars, tokenValues, scale, prefix });
   // Atomic write: write to a unique temp path then rename, so a peer isolate
   // busy-waiting on the cache file never observes a half-written JSON.
   writeFileSync(WD_TMP_PATH, json);

--- a/packages/oxlint-tailwindcss/src/index.ts
+++ b/packages/oxlint-tailwindcss/src/index.ts
@@ -22,6 +22,7 @@ import { consistentVariantOrder } from './rules/consistent-variant-order'
 import { enforceConsistentLineWrapping } from './rules/enforce-consistent-line-wrapping'
 import { noUnnecessaryArbitraryValue } from './rules/no-unnecessary-arbitrary-value'
 import { preferThemeTokens } from './rules/prefer-theme-tokens'
+import { preferScaleToken } from './rules/prefer-scale-token'
 
 const plugin = definePlugin({
   meta: { name: 'tailwindcss' },
@@ -49,6 +50,7 @@ const plugin = definePlugin({
     'enforce-consistent-line-wrapping': enforceConsistentLineWrapping,
     'no-unnecessary-arbitrary-value': noUnnecessaryArbitraryValue,
     'prefer-theme-tokens': preferThemeTokens,
+    'prefer-scale-token': preferScaleToken,
   },
 })
 

--- a/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes.ts
@@ -234,7 +234,21 @@ export const noConflictingClasses = defineRule({
           const unknown = variantClasses
             .map((cls) => splitImportant(extractUtility(cls)).bare)
             .filter((bare) => cache.getCssDeclarations(bare).length === 0 && isUserValued(bare))
-          if (unknown.length > 0) resolveDeclarationsSync(ds.entryPoint, cache, unknown)
+          // A dead worker is fatal here, not something to lint through: without
+          // the declarations this rule compares nothing, and going quiet about a
+          // whole class of pairs while the run stays green is the failure mode
+          // the service was added to remove.
+          if (unknown.length > 0) {
+            const resolved = safeGetDS(
+              () => {
+                resolveDeclarationsSync(ds.entryPoint, cache, unknown)
+                return true
+              },
+              context,
+              loc.node,
+            )
+            if (!resolved) return
+          }
 
           const facts: ClassFacts[] = variantClasses.map((cls) => {
             const utility = extractUtility(cls)

--- a/packages/oxlint-tailwindcss/src/rules/no-dark-without-light.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-dark-without-light.ts
@@ -9,7 +9,8 @@ import {
 } from '../utils/class-parser'
 import { createLazyLoader } from '../design-system/loader'
 import { resolveDeclarationsSync } from '../design-system/declaration-service'
-import { softGetDS } from '../utils/fatal'
+import { isFatalError, softGetDS } from '../utils/fatal'
+import { debugLog } from '../design-system/debug'
 import { createLazyOptions } from '../utils/context'
 
 interface Options {
@@ -170,7 +171,18 @@ export const noDarkWithoutLight = defineRule({
             if (!unresolved) unresolved = []
             unresolved.push(bare)
           }
-          if (unresolved) resolveDeclarationsSync(ds.entryPoint, cache, unresolved)
+          if (unresolved) {
+            try {
+              resolveDeclarationsSync(ds.entryPoint, cache, unresolved)
+            } catch (error) {
+              // DS-OPTIONAL: this rule may never emit `designSystemUnavailable`,
+              // so a dead worker degrades to prefix-only grouping for the classes
+              // it could not resolve. Logged rather than swallowed, because the
+              // difference is invisible from the diagnostics alone.
+              if (!isFatalError(error)) throw error
+              debugLog(`declaration service unavailable, grouping by prefix only: ${String(error)}`)
+            }
+          }
         }
 
         // A base is a class with no watched variant. Two ways to be the base for

--- a/packages/oxlint-tailwindcss/src/rules/no-unknown-classes.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-unknown-classes.ts
@@ -12,7 +12,7 @@ import { createLazyLoader } from '../design-system/loader'
 import { validateClassesSync } from '../design-system/declaration-service'
 import type { DesignSystemCache } from '../design-system/cache'
 import { createLazyOptions } from '../utils/context'
-import { DS_UNAVAILABLE_MESSAGE, safeGetDS } from '../utils/fatal'
+import { DS_UNAVAILABLE_MESSAGE, reportFatalDsError, safeGetDS } from '../utils/fatal'
 
 interface Options {
   entryPoint?: string
@@ -117,8 +117,7 @@ export const noUnknownClasses = defineRule({
       const memo = chainAnswers.get(key)
       if (memo !== undefined) return memo
       const probe = `${chain}${PROBE_UTILITY}`
-      const answers = validateClassesSync(entryPoint, cache, [probe])
-      const verdict = answers ? (answers.get(probe) ?? null) : null
+      const verdict = validateClassesSync(entryPoint, cache, [probe]).get(probe) ?? null
       chainAnswers.set(key, verdict)
       return verdict
     }
@@ -159,6 +158,24 @@ export const noUnknownClasses = defineRule({
       if (!ds) return
       const { cache, entryPoint } = ds
 
+      try {
+        checkLocations(locations, cache, entryPoint)
+      } catch (error) {
+        // The declaration service is what makes this rule's answers exact. If it
+        // is unavailable, going back to the tolerant heuristic in silence would
+        // reinstate exactly the false negatives it exists to remove, on a run
+        // that stays green — so it surfaces like any other design-system failure
+        // and the rule stops. One diagnostic per visitor call, not per class.
+        if (reportFatalDsError(context, error, locations[0].node)) return
+        throw error
+      }
+    }
+
+    function checkLocations(
+      locations: ClassLocation[],
+      cache: DesignSystemCache,
+      entryPoint: string,
+    ) {
       for (const loc of locations) {
         const split = splitClassesWithSeparators(loc.value)
         const classes = split.classes

--- a/packages/oxlint-tailwindcss/src/rules/prefer-scale-token.ts
+++ b/packages/oxlint-tailwindcss/src/rules/prefer-scale-token.ts
@@ -1,0 +1,203 @@
+import { defineRule } from '@oxlint/plugins'
+import { createExtractorVisitors, preserveSpaces, type ClassLocation } from '../utils/extractors'
+import { rebuildClassString, splitClassesWithSeparators } from '../utils/class-splitter'
+import {
+  getArbitraryValue,
+  reattachImportant,
+  splitImportant,
+  splitUtilityAndVariant,
+  utilityHasDynamicValue,
+} from '../utils/class-parser'
+import { createLazyLoader, rootFontSizeFromSettings } from '../design-system/loader'
+import type { DesignSystemCache } from '../design-system/cache'
+import { createLazyOptions, safeSettings } from '../utils/context'
+import { DS_UNAVAILABLE_MESSAGE, safeGetDS } from '../utils/fatal'
+
+interface Options {
+  entryPoint?: string
+  step?: number
+  allow?: string[]
+}
+
+/** A length or plain number. Anything else can't be compared arithmetically. */
+const LENGTH_RE = /^(-?\d*\.?\d+)(rem|px|em)?$/
+
+/**
+ * Convert a CSS length to px. `em` is treated as `rem`, which is what it is at
+ * the root and the only interpretation available without a layout.
+ */
+function toPx(value: string, rootFontSize: number): number | null {
+  const match = LENGTH_RE.exec(value.trim())
+  if (!match) return null
+  const n = Number.parseFloat(match[1])
+  if (!Number.isFinite(n)) return null
+  switch (match[2]) {
+    case 'rem':
+    case 'em':
+      return n * rootFontSize
+    case 'px':
+    case undefined:
+      return n
+    default:
+      return null
+  }
+}
+
+/** Same length, allowing for float noise (`0.875rem` × 16 = 13.999999999999998). */
+function sameLength(a: number, b: number): boolean {
+  return Math.abs(a - b) < 0.0001
+}
+
+/**
+ * Is `n` a whole number of `step`s? `10 / 0.5` is exact in binary, `0.3 / 0.1`
+ * is not, so the remainder is compared with a tolerance rather than to zero.
+ */
+function isOnStep(n: number, step: number): boolean {
+  if (step <= 0) return false
+  const steps = n / step
+  return Math.abs(steps - Math.round(steps)) < 0.0001
+}
+
+/** Trailing zeros make `p-2.50`, which is not what Tailwind calls the class. */
+function formatStep(n: number): string {
+  return String(Number.parseFloat(n.toFixed(4)))
+}
+
+export const preferScaleToken = defineRule({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer the scale step or theme token a hardcoded value is numerically equal to',
+    },
+    // Deliberately NOT fixable. The equivalence is numeric, not textual: the
+    // token resolves through `var()`, so a `:root` override or a different root
+    // font size makes the two diverge. Autofixing that is the mistake #78 fixed;
+    // this rule only ever suggests.
+    hasSuggestions: true,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          entryPoint: { type: 'string' },
+          step: { type: 'number' },
+          allow: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{}],
+    messages: {
+      preferToken:
+        '"{{className}}" is the same value as "{{replacement}}". Use the token — but check it first: the token resolves through a CSS variable, so the two are equal in this theme, not by construction.',
+      suggestReplace: 'Replace "{{className}}" with "{{replacement}}".',
+      ...DS_UNAVAILABLE_MESSAGE,
+    },
+  },
+  createOnce(context) {
+    const getDS = createLazyLoader(context)
+    const getOptions = createLazyOptions<Options, { step: number | null; allow: string[] }>(
+      context,
+      (o) => ({ step: typeof o?.step === 'number' ? o.step : null, allow: o?.allow ?? [] }),
+    )
+
+    let _rem: number | null = null
+    function rootFontSize(): number {
+      if (_rem === null) _rem = rootFontSizeFromSettings(safeSettings(context))
+      return _rem
+    }
+
+    /**
+     * The class this literal could have been written as, or null.
+     *
+     * Two families, in order of preference: a named theme token whose value
+     * matches (`rounded-[0.5rem]` → `rounded-lg`), then a step of the spacing
+     * scale (`p-[10px]` → `p-2.5`). Both come from data the precompute derived
+     * from the design system, so neither is a name table.
+     */
+    function equivalentOf(cache: DesignSystemCache, bare: string): string | null {
+      const { step: stepOverride, allow } = getOptions()
+      if (allow.some((prefix) => bare.startsWith(prefix))) return null
+
+      // A byte-identical named form is `no-unnecessary-arbitrary-value`'s
+      // business (and `enforce-canonical`'s, which rewrites exactly those). One
+      // check keeps this rule off both.
+      if (cache.getNamedEquivalent(bare)) return null
+
+      const value = getArbitraryValue(bare)
+      if (value === null) return null
+      const px = toPx(value, rootFontSize())
+      if (px === null) return null
+
+      const open = bare.indexOf('[')
+      if (open <= 0) return null
+      const prefix = bare.slice(0, open - 1)
+      if (!prefix) return null
+
+      for (const [literal, className] of cache.tokenValuesFor(prefix)) {
+        const tokenPx = toPx(literal, rootFontSize())
+        if (tokenPx !== null && sameLength(px, tokenPx)) return className
+      }
+
+      if (!cache.readsScale(prefix)) return null
+      const scale = cache.scale
+      if (!scale) return null
+      const unitPx = toPx(scale.unit, rootFontSize())
+      if (unitPx === null || unitPx <= 0) return null
+
+      const steps = px / unitPx
+      if (steps < 0) return null
+      // Tailwind compiles any number, so without a granularity every length
+      // would have an "equivalent" and this would just be `no-arbitrary-value`.
+      // The default is the granularity Tailwind's own enumerated steps use,
+      // derived by the precompute; `step` only ever makes it finer.
+      if (!isOnStep(steps, stepOverride ?? scale.step)) return null
+
+      const candidate = `${prefix}-${formatStep(steps)}`
+      return cache.isValid(candidate) ? candidate : null
+    }
+
+    function check(locations: ClassLocation[]) {
+      if (locations.length === 0) return
+      const ds = safeGetDS(getDS, context, locations[0].node)
+      if (!ds) return
+      const { cache } = ds
+
+      for (const loc of locations) {
+        const split = splitClassesWithSeparators(loc.value)
+        for (const cls of split.classes) {
+          if (!utilityHasDynamicValue(cls)) continue
+          const { utility, variant } = splitUtilityAndVariant(cls)
+          const { bare, position } = splitImportant(utility)
+
+          const equivalent = equivalentOf(cache, bare)
+          if (!equivalent) continue
+
+          const replacement = variant + reattachImportant(equivalent, position)
+          // Rebuilt through the splitter so the `\n` + indent
+          // `enforce-consistent-line-wrapping` introduces survives the suggestion.
+          const fixedValue = rebuildClassString(
+            split,
+            split.classes.map((c) => (c === cls ? replacement : c)),
+          )
+
+          context.report({
+            node: loc.node,
+            messageId: 'preferToken',
+            data: { className: cls, replacement },
+            suggest: [
+              {
+                messageId: 'suggestReplace',
+                data: { className: cls, replacement },
+                fix(fixer) {
+                  return fixer.replaceTextRange(loc.range, preserveSpaces(loc, fixedValue))
+                },
+              },
+            ],
+          })
+        }
+      }
+    }
+
+    return createExtractorVisitors(context, check)
+  },
+})

--- a/packages/oxlint-tailwindcss/src/rules/prefer-scale-token.ts
+++ b/packages/oxlint-tailwindcss/src/rules/prefer-scale-token.ts
@@ -23,10 +23,23 @@ interface Options {
 const LENGTH_RE = /^(-?\d*\.?\d+)(rem|px|em)?$/
 
 /**
- * Convert a CSS length to px. `em` is treated as `rem`, which is what it is at
- * the root and the only interpretation available without a layout.
+ * A comparable value: a magnitude, plus whether it carried a unit at all.
+ *
+ * The flag is not bookkeeping. `p-[10]` compiles to `padding: 10` — no unit,
+ * which is not a length — while `p-2.5` is `padding: 10px`. Treating the bare
+ * number as px would have this rule "helpfully" suggest a class that means
+ * something else.
  */
-function toPx(value: string, rootFontSize: number): number | null {
+interface Measure {
+  px: number
+  unitless: boolean
+}
+
+/**
+ * Parse a CSS length. `em` is treated as `rem`, which is what it is at the root
+ * and the only interpretation available without a layout.
+ */
+function measure(value: string, rootFontSize: number): Measure | null {
   const match = LENGTH_RE.exec(value.trim())
   if (!match) return null
   const n = Number.parseFloat(match[1])
@@ -34,18 +47,22 @@ function toPx(value: string, rootFontSize: number): number | null {
   switch (match[2]) {
     case 'rem':
     case 'em':
-      return n * rootFontSize
+      return { px: n * rootFontSize, unitless: false }
     case 'px':
+      return { px: n, unitless: false }
     case undefined:
-      return n
+      return { px: n, unitless: true }
     default:
       return null
   }
 }
 
-/** Same length, allowing for float noise (`0.875rem` × 16 = 13.999999999999998). */
-function sameLength(a: number, b: number): boolean {
-  return Math.abs(a - b) < 0.0001
+/**
+ * Same value, allowing for float noise (`0.875rem` × 16 = 13.999999999999998).
+ * A unitless number and a length are never the same value, whatever the digits.
+ */
+function sameMeasure(a: Measure, b: Measure): boolean {
+  return a.unitless === b.unitless && Math.abs(a.px - b.px) < 0.0001
 }
 
 /**
@@ -125,26 +142,30 @@ export const preferScaleToken = defineRule({
 
       const value = getArbitraryValue(bare)
       if (value === null) return null
-      const px = toPx(value, rootFontSize())
-      if (px === null) return null
+      const written = measure(value, rootFontSize())
+      if (written === null) return null
 
       const open = bare.indexOf('[')
-      if (open <= 0) return null
+      // The utility and its value are joined by a dash: `p-[10px]`. Anything else
+      // is not this shape — an arbitrary property (`[color:red]`) starts at 0.
+      if (open <= 0 || bare[open - 1] !== '-') return null
       const prefix = bare.slice(0, open - 1)
       if (!prefix) return null
 
       for (const [literal, className] of cache.tokenValuesFor(prefix)) {
-        const tokenPx = toPx(literal, rootFontSize())
-        if (tokenPx !== null && sameLength(px, tokenPx)) return className
+        const token = measure(literal, rootFontSize())
+        if (token !== null && sameMeasure(written, token)) return className
       }
 
       if (!cache.readsScale(prefix)) return null
       const scale = cache.scale
       if (!scale) return null
-      const unitPx = toPx(scale.unit, rootFontSize())
-      if (unitPx === null || unitPx <= 0) return null
+      const unit = measure(scale.unit, rootFontSize())
+      // Same kind of quantity on both sides, or the division is meaningless:
+      // `p-[10]` is `padding: 10`, which is not 2.5 × `0.25rem`.
+      if (unit === null || unit.px <= 0 || unit.unitless !== written.unitless) return null
 
-      const steps = px / unitPx
+      const steps = written.px / unit.px
       if (steps < 0) return null
       // Tailwind compiles any number, so without a granularity every length
       // would have an "equivalent" and this would just be `no-arbitrary-value`.

--- a/packages/oxlint-tailwindcss/tests/design-system/cache.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/cache.test.ts
@@ -322,3 +322,67 @@ describe('project prefix', () => {
     expect(variant! > base!).toBe(true)
   })
 })
+
+/**
+ * Lint-time interning must not write into the cache artifact.
+ *
+ * `PrecomputedData.cssDeclarations` is held by reference, so a value appended to
+ * its `values` array would be visible to every cache built from the same object
+ * — while each cache keeps its OWN text→id map. The second cache would not see
+ * the first one's append, hand out a fresh id for the same text, and then
+ * `decidePair` (which compares ids, not strings) would read two identical values
+ * as a conflict.
+ *
+ * Unreachable through the loader today, which parses the JSON per entry point,
+ * but it is one shared object away from being a false positive nobody could
+ * explain.
+ */
+describe('internDeclarations isolation', () => {
+  const RAWS: [string, string, string][] = [['', 'padding', '5px']]
+  const FACTS = { '5px': { p: [], f: [], u: false } }
+
+  it('does not append to the shared value table', () => {
+    const data = makeData()
+    const before = data.cssDeclarations.values.length
+    const cache = DesignSystemCache.fromPrecomputed(data)
+
+    cache.internDeclarations('p-[5px]', RAWS, FACTS)
+
+    expect(data.cssDeclarations.values.length).toBe(before)
+  })
+
+  it('gives the same value the same id in each cache built from one artifact', () => {
+    const data = makeData()
+    const a = DesignSystemCache.fromPrecomputed(data)
+    const b = DesignSystemCache.fromPrecomputed(data)
+
+    // Interleaved on purpose. Each cache has to have built its text→id map, and
+    // to have interned something of its own, BEFORE they meet on a shared value —
+    // that is the ordering in which a shared, appended array hands out two
+    // different ids for one text. Interning in both caches back to back would
+    // pass either way, because the second cache builds its map lazily and would
+    // simply see the first one's append.
+    b.internDeclarations('mt-[7px]', [['', 'margin-top', '7px']], {
+      '7px': { p: [], f: [], u: false },
+    })
+    a.internDeclarations('mb-[9px]', [['', 'margin-bottom', '9px']], {
+      '9px': { p: [], f: [], u: false },
+    })
+
+    const fromB = b.internDeclarations('p-[5px]', RAWS, FACTS)
+    const fromA = a.internDeclarations('p-[5px]', RAWS, FACTS)
+
+    expect(fromA[0].valueId).toBe(fromB[0].valueId)
+  })
+
+  it('still shares ids with the precomputed values it interns against', () => {
+    const cache = DesignSystemCache.fromPrecomputed(makeData())
+    // `p-4` is precomputed with this exact value; the lint-time class has to land
+    // on the SAME id or the two would never compare equal.
+    const precomputed = cache.getCssDeclarations('p-4')[0]
+    const interned = cache.internDeclarations('p-[1rem]', [['', 'padding', precomputed.value]], {
+      [precomputed.value]: { p: [], f: [], u: false },
+    })
+    expect(interned[0].valueId).toBe(precomputed.valueId)
+  })
+})

--- a/packages/oxlint-tailwindcss/tests/design-system/precompute-worker.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/precompute-worker.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect } from 'vitest'
 import { resolve } from 'node:path'
 import { existsSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { basename, dirname } from 'node:path'
 import {
   cacheArtifactPaths,
   loadDesignSystemSync,
@@ -71,7 +71,13 @@ describe('precompute via worker_thread', () => {
     expect(parsed.validClasses.length).toBe(result.validClasses.length)
 
     // The atomic write (tmp → rename) leaves no `.tmp.*` straggler.
-    const leftovers = readdirSync(dirname(json)).filter((f) => f.includes('.tmp.'))
+    //
+    // Scoped to THIS artifact's temp names (`<cache file>.tmp.<pid>.<thread>.<n>`).
+    // The cache dir is shared by every isolate in the run, so scanning it for any
+    // `.tmp.` caught a peer mid-write and failed for something this test does not
+    // claim anything about.
+    const own = `${basename(json)}.tmp.`
+    const leftovers = readdirSync(dirname(json)).filter((f) => f.startsWith(own))
     expect(leftovers).toEqual([])
 
     rmSync(css, { force: true })

--- a/packages/oxlint-tailwindcss/tests/design-system/precomputed-snapshot.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/precomputed-snapshot.test.ts
@@ -262,3 +262,56 @@ describe('Precomputed Data Snapshot', () => {
     })
   })
 })
+
+/**
+ * The two derivations `prefer-scale-token` rests on.
+ *
+ * Neither is a table anyone maintains: the spacing granularity comes from the
+ * steps Tailwind itself enumerates, and the token values come from the emitted
+ * CSS plus the theme. If a Tailwind release changes either, the rule silently
+ * starts reporting more or less — so the derived shape is pinned here.
+ */
+describe('derived scale and token values', () => {
+  it('derives the spacing unit, its granularity and which prefixes read it', () => {
+    expect(data.scale).toBeDefined()
+    expect(data.scale!.unit).toBe('0.25rem')
+    // Every step getClassList() enumerates (0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4,
+    // 5…96) is a multiple of this. It is what keeps the rule from reporting
+    // `w-[33.7px]` → `w-8.425`, which Tailwind compiles but never proposes.
+    expect(data.scale!.step).toBe(0.5)
+    // Utilities whose `<prefix>-1` reads `var(--spacing)`.
+    expect(data.scale!.prefixes).toContain('w')
+    expect(data.scale!.prefixes).toContain('p')
+    expect(data.scale!.prefixes).toContain('gap')
+    expect(data.scale!.prefixes).toContain('size')
+    expect(data.scale!.prefixes).toContain('scroll-mt')
+    // …and not the ones whose `-1` is a plain number or a length of its own.
+    expect(data.scale!.prefixes).not.toContain('z')
+    expect(data.scale!.prefixes).not.toContain('opacity')
+    expect(data.scale!.prefixes).not.toContain('border')
+    expect(data.scale!.prefixes).not.toContain('order')
+  })
+
+  it('maps numeric theme tokens back to their literal value', () => {
+    const rounded = new Map(data.tokenValues?.rounded ?? [])
+    expect(rounded.get('0.5rem')).toBe('rounded-lg')
+    expect(rounded.get('0.125rem')).toBe('rounded-xs')
+
+    const basis = new Map(data.tokenValues?.basis ?? [])
+    expect(basis.get('28rem')).toBe('basis-md')
+  })
+
+  it('excludes tokens whose class declares more than the literal would', () => {
+    // `text-sm` sets `font-size` AND `line-height`, so `text-[14px]` is not it —
+    // the single-declaration requirement drops the whole `text` family without
+    // anyone having to list it.
+    expect(data.tokenValues?.text).toBeUndefined()
+  })
+
+  it('excludes non-numeric tokens, which no literal could match', () => {
+    // 7 000 of the ~7 200 pure-`var()` classes are colours; none can be compared
+    // against a value a human typed, so none are stored.
+    expect(data.tokenValues?.['accent-amber']).toBeUndefined()
+    expect(data.tokenValues?.['bg-red']).toBeUndefined()
+  })
+})

--- a/packages/oxlint-tailwindcss/tests/fixtures/imported-tokens.css
+++ b/packages/oxlint-tailwindcss/tests/fixtures/imported-tokens.css
@@ -1,0 +1,8 @@
+/*
+ * Imported by `with-imported-theme.css`. The point is that `--primary` is
+ * declared HERE and nowhere else: the browser sees it, so anything that decides
+ * whether a variable is defined has to look past the entry file.
+ */
+:root {
+  --primary: #ff0000;
+}

--- a/packages/oxlint-tailwindcss/tests/fixtures/with-imported-theme.css
+++ b/packages/oxlint-tailwindcss/tests/fixtures/with-imported-theme.css
@@ -1,0 +1,16 @@
+@import 'tailwindcss';
+@import './imported-tokens.css';
+
+/*
+ * `unrelated-theme-vars.css` with the project variable moved into an @import.
+ *
+ * Same hazard, one file further away: `--color-primary` is a literal theme token
+ * and `--primary` is an unrelated project variable, so rewriting `bg-(--primary)`
+ * to `bg-primary` would change the colour. The precompute scans the entry AND its
+ * imports for `--x:` declarations, so `definesVar('--primary')` is true here and
+ * prefer-theme-tokens refuses the rewrite — exactly as it does when the two live
+ * in the same file.
+ */
+@theme {
+  --color-primary: oklch(0.55 0.2 260);
+}

--- a/packages/oxlint-tailwindcss/tests/global-setup.ts
+++ b/packages/oxlint-tailwindcss/tests/global-setup.ts
@@ -32,6 +32,7 @@ const FIXTURES = [
   'with-foreign-vars.css',
   'axis-namespaces.css',
   'custom-utility.css',
+  'with-imported-theme.css',
 ]
 
 export function setup() {

--- a/packages/oxlint-tailwindcss/tests/integration/fatal-errors.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/fatal-errors.test.ts
@@ -12,7 +12,18 @@ import {
   resetCanonicalizeService,
 } from '../../src/design-system/canonicalize-service'
 import { sortClassesSync, resetSortService } from '../../src/design-system/sort-service'
-import { SortServiceError } from '../../src/utils/fatal'
+import {
+  resolveDeclarationsSync,
+  resetDeclarationService,
+  validateClassesSync,
+} from '../../src/design-system/declaration-service'
+import { DesignSystemCache } from '../../src/design-system/cache'
+import { type PrecomputedData } from '../../src/design-system/sync-loader'
+import { makeDeclarations } from '../utils/declarations'
+import { DS_UNAVAILABLE_MESSAGE_ID, SortServiceError } from '../../src/utils/fatal'
+import { noDarkWithoutLight } from '../../src/rules/no-dark-without-light'
+import { noConflictingClasses } from '../../src/rules/no-conflicting-classes'
+import { noUnknownClasses } from '../../src/rules/no-unknown-classes'
 
 const NONEXISTENT_CSS = '/tmp/this-css-does-not-exist-for-fatal-test.css'
 
@@ -57,5 +68,65 @@ describe('canonicalize service — fail-loud', () => {
       expect(err).toBeInstanceOf(SortServiceError)
       expect((err as SortServiceError).hint).toBeTruthy()
     }
+  })
+})
+
+/**
+ * The declaration service used to swallow its own failures.
+ *
+ * It returned "no information" instead of throwing, which was defensible while
+ * `no-conflicting-classes` was the only caller — no declarations, no comparison,
+ * no diagnostic. It stopped being defensible when `no-unknown-classes` started
+ * asking it about VALIDITY: there, silence sends the rule back to the tolerant
+ * heuristic, so a dead worker quietly reinstates the false negatives the service
+ * exists to remove and the run still passes.
+ */
+describe('declaration service — fail-loud', () => {
+  beforeEach(() => resetDeclarationService())
+
+  function bareCache(): DesignSystemCache {
+    const data: PrecomputedData = {
+      validClasses: ['flex'],
+      canonical: {},
+      order: { flex: '100' },
+      cssDeclarations: makeDeclarations({ flex: [['', 'display', 'flex']] }),
+      variantOrder: {},
+      componentClasses: [],
+      arbitraryEquivalents: {},
+      prefix: '',
+    }
+    return DesignSystemCache.fromPrecomputed(data)
+  }
+
+  test('resolveDeclarationsSync throws when the worker cannot load the CSS', () => {
+    expect(() => resolveDeclarationsSync(NONEXISTENT_CSS, bareCache(), ['p-[5px]'])).toThrow(
+      SortServiceError,
+    )
+  })
+
+  test('validateClassesSync throws instead of answering "unknown"', () => {
+    expect(() => validateClassesSync(NONEXISTENT_CSS, bareCache(), ['bg-red-5000'])).toThrow(
+      SortServiceError,
+    )
+  })
+
+  test('the error carries a hint, like the other two services', () => {
+    try {
+      validateClassesSync(NONEXISTENT_CSS, bareCache(), ['bg-red-5000'])
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(SortServiceError)
+      expect((err as SortServiceError).hint).toBeTruthy()
+    }
+  })
+
+  test('the DS-dependent callers can surface it, and the DS-optional one cannot', () => {
+    // Which posture each rule takes is not a matter of taste: a rule that may
+    // report `designSystemUnavailable` declares that messageId, and one that may
+    // not simply does not have it. oxlint rejects reporting an undeclared
+    // messageId, so this is the guarantee itself, not a proxy for it.
+    expect(noConflictingClasses.meta?.messages).toHaveProperty(DS_UNAVAILABLE_MESSAGE_ID)
+    expect(noUnknownClasses.meta?.messages).toHaveProperty(DS_UNAVAILABLE_MESSAGE_ID)
+    expect(noDarkWithoutLight.meta?.messages).not.toHaveProperty(DS_UNAVAILABLE_MESSAGE_ID)
   })
 })

--- a/packages/oxlint-tailwindcss/tests/integration/prefer-theme-tokens-coexistence.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/prefer-theme-tokens-coexistence.test.ts
@@ -1,6 +1,6 @@
 /**
- * Coexistence matrix between prefer-theme-tokens and the two related rules
- * (enforce-canonical, no-unnecessary-arbitrary-value).
+ * Coexistence matrix between prefer-theme-tokens and the three related rules
+ * (enforce-canonical, no-unnecessary-arbitrary-value, prefer-scale-token).
  *
  * Each input class is run against every rule separately, asserting which rule
  * fires and which stays silent. The goal is to lock in the boundary so future
@@ -52,6 +52,7 @@ import { makeFixtureRunner } from '../utils/with-fixture'
 import { preferThemeTokens } from '../../src/rules/prefer-theme-tokens'
 import { enforceCanonical } from '../../src/rules/enforce-canonical'
 import { noUnnecessaryArbitraryValue } from '../../src/rules/no-unnecessary-arbitrary-value'
+import { preferScaleToken } from '../../src/rules/prefer-scale-token'
 import { getLoadedDesignSystem, resetDesignSystem } from '../../src/design-system/loader'
 import { resetCanonicalizeService } from '../../src/design-system/canonicalize-service'
 
@@ -229,3 +230,68 @@ describe('prefer-theme-tokens coexistence (shadcn-style theme)', () => {
 // intermediate (`border-(--border)`) and the input (`border-[var(--border)]`)
 // shapes, so any future regression that breaks convergence will fail one of
 // those test cases.
+
+/**
+ * The fourth rule joins on a premise none of the other three can host.
+ *
+ * Each of them keys on something different — byte-identical CSS
+ * (no-unnecessary-arbitrary-value), what canonicalizeCandidates proposes
+ * (enforce-canonical), the NAME of a variable the user wrote
+ * (prefer-theme-tokens) — and a literal that is only NUMERICALLY equal to a token
+ * satisfies none of those. That is the gap #91 reported.
+ *
+ *   ┌──────────────────────┬───────┬──────────┬───────────┬─────────────┐
+ *   │ input                │ canon │ no-unnec │ prefer-tt │ prefer-scale│
+ *   ├──────────────────────┼───────┼──────────┼───────────┼─────────────┤
+ *   │ w-[100%]             │ fires │ fires    │ silent    │ silent      │
+ *   │ p-[10px]             │ silent│ silent   │ silent    │ FIRES       │
+ *   │ w-[140px]            │ silent│ silent   │ silent    │ FIRES       │
+ *   │ rounded-[0.5rem]     │ silent│ silent   │ silent    │ FIRES       │
+ *   │ bg-(--red-500)       │ silent│ silent   │ fires     │ silent      │
+ *   └──────────────────────┴───────┴──────────┴───────────┴─────────────┘
+ *
+ * `w-[100%]` is the line that matters most: byte-identical, so it belongs to
+ * no-unnecessary-arbitrary-value, and prefer-scale-token's getNamedEquivalent
+ * guard keeps it out even though 100% would also resolve on the scale.
+ */
+describe('prefer-scale-token coexistence (default theme)', () => {
+  const run = makeFixtureRunner(DEFAULT_FIXTURE)
+  beforeAll(() => {
+    resetDesignSystem()
+    resetCanonicalizeService()
+    getLoadedDesignSystem(DEFAULT_FIXTURE)
+  })
+  afterAll(() => {
+    resetDesignSystem()
+    resetCanonicalizeService()
+  })
+
+  const NUMERIC_ONLY = ['p-[10px]', 'w-[140px]', 'rounded-[0.5rem]']
+
+  run('prefer-scale-token owns the numeric equivalences', preferScaleToken, {
+    valid: [
+      { code: '<div className="w-[100%]" />', filename: 'test.tsx' },
+      { code: '<div className="bg-(--red-500)" />', filename: 'test.tsx' },
+      { code: '<div className="rounded-[var(--radius-sm)]" />', filename: 'test.tsx' },
+    ],
+    invalid: NUMERIC_ONLY.map((code) => ({
+      code: `<div className="${code}" />`,
+      filename: 'test.tsx',
+      errors: [{ messageId: 'preferToken' as const }],
+    })),
+  })
+
+  // The other three stay silent on all of them — that is what makes this a gap
+  // rather than a duplicate.
+  const silentOn = NUMERIC_ONLY.map((code) => ({
+    code: `<div className="${code}" />`,
+    filename: 'test.tsx',
+  }))
+
+  run('enforce-canonical stays silent', enforceCanonical, { valid: silentOn, invalid: [] })
+  run('no-unnecessary-arbitrary-value stays silent', noUnnecessaryArbitraryValue, {
+    valid: silentOn,
+    invalid: [],
+  })
+  run('prefer-theme-tokens stays silent', preferThemeTokens, { valid: silentOn, invalid: [] })
+})

--- a/packages/oxlint-tailwindcss/tests/rules/prefer-scale-token.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/prefer-scale-token.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The gap #91 reported, and the boundary that keeps it from being noise.
+ *
+ * Since #78, `enforce-canonical` only rewrites when the emitted CSS is
+ * byte-identical, which is right for an autofixer and silently dropped the
+ * consistency signal for every value whose token resolves through `var()`. This
+ * rule is that signal, report-only.
+ *
+ * The other half of the file is the boundary. Tailwind compiles ANY number
+ * (`w-8.425` is valid CSS), so "has a scale equivalent" is true for practically
+ * every length — reporting all of them would just be `no-arbitrary-value` with
+ * extra steps. The cut is the granularity Tailwind's own enumerated steps use,
+ * derived by the precompute rather than chosen here.
+ */
+
+import { resolve } from 'node:path'
+import { beforeAll, describe } from 'vitest'
+import { RuleTester } from 'oxlint/plugins-dev'
+import { preferScaleToken } from '../../src/rules/prefer-scale-token'
+import { getLoadedDesignSystem, resetDesignSystem } from '../../src/design-system/loader'
+import { makeFixtureRunner, runWithFixture } from '../utils/with-fixture'
+
+const ENTRY_POINT = resolve(__dirname, '../fixtures/default.css')
+const run = makeFixtureRunner(ENTRY_POINT)
+
+beforeAll(() => {
+  resetDesignSystem()
+  getLoadedDesignSystem(ENTRY_POINT)
+})
+
+/** `[written, suggested]` — reported, with the suggestion applied by the editor. */
+const SCALE: [string, string][] = [
+  // The enumerated steps `enforce-canonical` stopped reporting after #78.
+  ['p-[10px]', 'p-2.5'],
+  ['gap-[4px]', 'gap-1'],
+  ['h-[2rem]', 'h-8'],
+  ['mt-[6px]', 'mt-1.5'],
+  // The issue's own example. Tailwind compiles `w-35` but never proposes it (35
+  // is not one of the steps it enumerates), which is why nothing reported this
+  // before — not #78.
+  ['w-[140px]', 'w-35'],
+  // Whole numbers well past the enumerated range still land on the scale.
+  ['top-[400px]', 'top-100'],
+]
+
+const TOKENS: [string, string][] = [
+  // A named token whose value matches, read off the emitted CSS + the theme.
+  ['rounded-[0.5rem]', 'rounded-lg'],
+  ['rounded-[2px]', 'rounded-xs'],
+  ['basis-[28rem]', 'basis-md'],
+]
+
+describe('values that equal a scale step', () => {
+  run('prefer-scale-token (scale)', preferScaleToken, {
+    valid: [],
+    invalid: SCALE.map(([written, suggested]) => ({
+      code: `<div className="${written}" />`,
+      filename: 'test.tsx',
+      errors: [
+        {
+          messageId: 'preferToken' as const,
+          data: { className: written, replacement: suggested },
+          suggestions: [
+            {
+              messageId: 'suggestReplace' as const,
+              data: { className: written, replacement: suggested },
+              output: `<div className="${suggested}" />`,
+            },
+          ],
+        },
+      ],
+    })),
+  })
+})
+
+describe('values that equal a named theme token', () => {
+  run('prefer-scale-token (tokens)', preferScaleToken, {
+    valid: [],
+    invalid: TOKENS.map(([written, suggested]) => ({
+      code: `<div className="${written}" />`,
+      filename: 'test.tsx',
+      errors: [
+        {
+          messageId: 'preferToken' as const,
+          data: { className: written, replacement: suggested },
+        },
+      ],
+    })),
+  })
+})
+
+describe('the boundary', () => {
+  run('prefer-scale-token (valid)', preferScaleToken, {
+    valid: [
+      // Finer than the granularity Tailwind's own scale uses. Both compile
+      // (`w-8.25`, `w-8.425`), and reporting them would make this rule fire on
+      // essentially every length.
+      { code: '<div className="w-[33px]" />', filename: 'test.tsx' },
+      { code: '<div className="w-[33.7px]" />', filename: 'test.tsx' },
+      // Byte-identical to a named class → `no-unnecessary-arbitrary-value`'s.
+      { code: '<div className="w-[100%]" />', filename: 'test.tsx' },
+      { code: '<div className="z-[10]" />', filename: 'test.tsx' },
+      { code: '<div className="p-[0px]" />', filename: 'test.tsx' },
+      // Not a length, or not on a prefix that reads the scale.
+      { code: '<div className="w-[50%]" />', filename: 'test.tsx' },
+      { code: '<div className="grid-cols-[18rem_1fr]" />', filename: 'test.tsx' },
+      { code: '<div className="content-[attr(data-x)]" />', filename: 'test.tsx' },
+      { code: '<div className="bg-[#ff0000]" />', filename: 'test.tsx' },
+      // A variable reference has no literal to compare — `prefer-theme-tokens`
+      // is the rule that looks at those.
+      { code: '<div className="p-(--gutter)" />', filename: 'test.tsx' },
+      { code: '<div className="p-[var(--gutter)]" />', filename: 'test.tsx' },
+      // Already a token.
+      { code: '<div className="p-2.5 rounded-lg" />', filename: 'test.tsx' },
+      // `text-sm` also sets `line-height`, so it is NOT what `text-[14px]` says.
+      // The precompute drops the whole family for that reason; this locks it.
+      { code: '<div className="text-[14px]" />', filename: 'test.tsx' },
+    ],
+    invalid: [],
+  })
+})
+
+describe('variants and the ! modifier travel with the class', () => {
+  run('prefer-scale-token (modifiers)', preferScaleToken, {
+    valid: [],
+    invalid: [
+      {
+        code: '<div className="hover:p-[10px]" />',
+        filename: 'test.tsx',
+        errors: [
+          {
+            messageId: 'preferToken',
+            data: { className: 'hover:p-[10px]', replacement: 'hover:p-2.5' },
+          },
+        ],
+      },
+      {
+        code: '<div className="!p-[10px]" />',
+        filename: 'test.tsx',
+        errors: [
+          { messageId: 'preferToken', data: { className: '!p-[10px]', replacement: '!p-2.5' } },
+        ],
+      },
+      {
+        code: '<div className="p-[10px]!" />',
+        filename: 'test.tsx',
+        errors: [
+          { messageId: 'preferToken', data: { className: 'p-[10px]!', replacement: 'p-2.5!' } },
+        ],
+      },
+      // Multiline class strings keep their shape through the suggestion.
+      {
+        code: '<div className={`flex\n  p-[10px]\n  gap-[4px]`} />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'preferToken' }, { messageId: 'preferToken' }],
+      },
+    ],
+  })
+})
+
+describe('options', () => {
+  run('prefer-scale-token (step)', preferScaleToken, {
+    valid: [
+      // Coarser: 2.5 is no longer a whole number of steps.
+      { code: '<div className="p-[10px]" />', filename: 'test.tsx', options: [{ step: 1 }] },
+      // Allowed away by prefix.
+      {
+        code: '<div className="p-[10px]" />',
+        filename: 'test.tsx',
+        options: [{ allow: ['p-'] }],
+      },
+    ],
+    invalid: [
+      // Finer: quarter steps opt in, which is the extension the option exists for.
+      {
+        code: '<div className="w-[33px]" />',
+        filename: 'test.tsx',
+        options: [{ step: 0.25 }],
+        errors: [
+          { messageId: 'preferToken', data: { className: 'w-[33px]', replacement: 'w-8.25' } },
+        ],
+      },
+      // A coarser step never suppresses a NAMED token: that match is by value,
+      // not by granularity.
+      {
+        code: '<div className="rounded-[0.5rem]" />',
+        filename: 'test.tsx',
+        options: [{ step: 1 }],
+        errors: [
+          {
+            messageId: 'preferToken',
+            data: { className: 'rounded-[0.5rem]', replacement: 'rounded-lg' },
+          },
+        ],
+      },
+    ],
+  })
+})
+
+describe('without an entry point', () => {
+  // DS-dependent: the equivalences come entirely from the design system, so
+  // there is no static fallback to degrade to.
+  runWithFixture(new RuleTester(), 'prefer-scale-token (no DS)', preferScaleToken, '', {
+    valid: [],
+    invalid: [
+      {
+        code: '<div className="p-[10px]" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'designSystemUnavailable' }],
+      },
+    ],
+  })
+})

--- a/packages/oxlint-tailwindcss/tests/rules/prefer-scale-token.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/prefer-scale-token.test.ts
@@ -101,6 +101,11 @@ describe('the boundary', () => {
       { code: '<div className="w-[100%]" />', filename: 'test.tsx' },
       { code: '<div className="z-[10]" />', filename: 'test.tsx' },
       { code: '<div className="p-[0px]" />', filename: 'test.tsx' },
+      // A bare number is not a length: `p-[10]` compiles to `padding: 10`, which
+      // is not what `p-2.5` (`padding: 10px`) says. Suggesting it would change the
+      // meaning, not just the spelling.
+      { code: '<div className="p-[10]" />', filename: 'test.tsx' },
+      { code: '<div className="w-[140]" />', filename: 'test.tsx' },
       // Not a length, or not on a prefix that reads the scale.
       { code: '<div className="w-[50%]" />', filename: 'test.tsx' },
       { code: '<div className="grid-cols-[18rem_1fr]" />', filename: 'test.tsx' },

--- a/packages/oxlint-tailwindcss/tests/rules/prefer-theme-tokens-unsafe.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/prefer-theme-tokens-unsafe.test.ts
@@ -23,3 +23,29 @@ describe('prefer-theme-tokens with unrelated variables', () => {
     invalid: [],
   })
 })
+
+/**
+ * The same hazard with the project variable one `@import` away.
+ *
+ * `definesVar` is what stops the rewrite, and it was scanning only the entry
+ * file's text — so moving `:root { --primary: … }` into an imported file (the
+ * normal shadcn/ui layout) made the variable read as undefined, and the rule went
+ * back to proposing `bg-primary`, silently changing the colour. The precompute
+ * scans the entry AND its resolved imports now.
+ */
+describe('prefer-theme-tokens with variables defined in an @import', () => {
+  const IMPORTED = resolve(__dirname, '../fixtures/with-imported-theme.css')
+
+  beforeAll(() => {
+    resetDesignSystem()
+    getLoadedDesignSystem(IMPORTED)
+  })
+
+  runWithFixture(new RuleTester(), 'prefer-theme-tokens (imported)', preferThemeTokens, IMPORTED, {
+    valid: [
+      { code: '<div className="bg-(--primary)" />', filename: 'test.tsx' },
+      { code: '<div className="bg-[var(--primary)]" />', filename: 'test.tsx' },
+    ],
+    invalid: [],
+  })
+})


### PR DESCRIPTION
Closes #91, plus the three reliability findings the 1.5.0 review left documented and unfixed — one of which 1.5.0 itself made worse.

## `prefer-scale-token` (#91)

A new rule that reports a hardcoded value **numerically equal** to something the design system already names, and suggests the name. It fills a gap the other three arbitrary→named rules structurally cannot, because each keys on something this case does not satisfy:

| Rule | Fires on | Keyed on |
|---|---|---|
| `no-unnecessary-arbitrary-value` | `w-[100%]` → `w-full` | byte-identical CSS |
| `enforce-canonical` | what `canonicalizeCandidates` proposes | the same, since #78 |
| `prefer-theme-tokens` | `bg-(--primary)` → `bg-primary` | the NAME of a variable |
| **`prefer-scale-token`** | `p-[10px]` → `p-2.5` | **numeric equality** |

`p-2.5` compiles to `calc(var(--spacing) * 2.5)` and `p-[10px]` to `10px`: same length, different text.

**Report-only, and it will stay that way.** No `fixable` — the token reaches its value through `var()`, so a `:root` override or a different `rootFontSize` makes the equivalence false. Autofixing that is the bug #78 fixed. The message says so.

### Correcting the issue's premise

`w-[140px]` → `w-35` was **never** reported, before or after #78: `canonicalizeCandidates` doesn't propose it, because 35 isn't one of the steps Tailwind enumerates. What #78 silenced were the enumerated ones (`p-[10px]` → `p-2.5`, `gap-[4px]` → `gap-1`, `h-[2rem]` → `h-8`) plus the theme tokens (`rounded-[0.5rem]` → `rounded-lg`). Both are covered now, including the reporter's example — Tailwind compiles `w-35`, so it counts.

### Two families, both derived

`--spacing` comes from the theme; the prefixes that read it are found by asking what `<prefix>-1` compiles to; named tokens come from the emitted CSS plus the theme values. No namespace table exists to drift, and two things fall out of the derivation rather than being special-cased:

- **`text-[14px]` → `text-sm` is NOT reported.** `text-sm` also sets `line-height`, so it isn't the same declaration. Requiring one declaration drops the whole family on its own.
- Colour tokens aren't candidates — a colour can't match a literal numerically. ~7 000 of the ~7 200 pure-`var()` classes gone, 253 comparable ones left, **+8.5 KB** on the cache artifact.

### The granularity is derived, not chosen

Tailwind compiles any number (`w-8.425` is valid), so every length is N spacing units for some N — reporting all of them would be `no-arbitrary-value` with extra steps. Every step Tailwind's own scale enumerates is a multiple of `0.5`, and the precompute computes that from the steps themselves. `w-[140px]` → `w-35` passes; `w-[33.7px]` → `w-8.425` doesn't. `step` only ever makes it finer.

## Three reliability fixes

- **The declaration service degraded in silence.** It swallowed its own failures, which was defensible when `no-conflicting-classes` was the only caller. Since #95 `no-unknown-classes` asks it about VALIDITY, and there silence sends the rule back to the tolerant heuristic: a dead worker quietly reinstated the false negatives the service exists to remove, on a run that stayed green. It throws now, and each caller takes a posture that already existed — the two DS-dependent rules surface `designSystemUnavailable`, `no-dark-without-light` (which may never emit it) degrades and logs under `debug`. **A transient worker failure now fails those two rules instead of weakening them quietly.**
- **`prefer-theme-tokens` proposed a colour-changing rewrite when the theme lived in an `@import`.** `definesVar` is the guard that stops it, and it scanned only the entry CSS — so the normal shadcn/ui layout made `:root { --primary: … }` read as undefined. Reproduced with a fixture, then fixed.
- **Two caches over one artifact could produce a false conflict.** Lint-time interning appended to the artifact's own array while each cache kept its own text→id map, so one value could get two ids — and conflicts are decided by comparing ids. Ids are local now.

## Testing

- Every fix has a test that **fails on the old code** — verified by reverting each one, not assumed.
- `prefer-scale-token`: 33 cases, and the valid half is the important one (the boundary, byte-identical hand-offs, `text-[14px]`, variable references, bare numbers).
- The coexistence matrix goes from three rules to four: for each input, exactly one rule fires.
- The derived data is pinned in `precomputed-snapshot.test.ts`, so a Tailwind release that changes the granularity or the token set shows up as a failure rather than silently moving the rule.
- 1661 tests green, plus lint, format, typecheck, and both builds. Precompute cost of the new probe measured at **15 ms** (+0.7%).

## Found while reviewing my own diff

`p-[10]` compiles to `padding: 10` — no unit, not a length — and the rule treated the bare number as px, so it suggested `p-2.5` (`padding: 10px`). A change of meaning dressed as a change of spelling, which matters even without an autofix because editors apply suggestions on a click. Values now carry whether they had a unit.

Also fixes a doc error the same misconception produced: the rule index claimed `no-unnecessary-arbitrary-value` handles `w-[200px]` → `w-50`. It can't — `getNamedEquivalent('w-[200px]')` is null — and that example now points at the rule that does.

Version bumped to **1.6.0**: new rule (off by default, no presets exist), plus the behaviour change above.
