### PR TITLE
fix(no-unknown-classes): named group/peer markers (#102), and the component-class scan — v1.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,30 @@ AST visitors: `JSXAttribute`, `CallExpression`, `TaggedTemplateExpression`, `Var
   that styles both itself and its descendants (`prose`) advertises only its own box, and is flagged
   `partial` so it is never called redundant.
 - **Modifier class detection**: Classes referenced via `[class~="..."]` attribute selectors in CSS
-  output (e.g. `not-prose`) are added to `componentClasses` so `no-unknown-classes` recognizes them.
+  output (e.g. `not-prose`) are added to `componentClasses` so `no-unknown-classes` recognizes them,
+  interned in a `Set` (typography names `not-prose` from ~230 selectors).
+- **`extractComponentClasses` reads SELECTORS ONLY** (`sync-loader.ts`). Everything it returns lands
+  in `validitySet`, so a false entry there is a class the plugin silently accepts. It used to regex
+  whole files, which harvested identifiers from Tailwind's own preflight comments (`mozilla`, `org`,
+  `com`, `cgi`, `chromium`, `webkit`, `css` — all from URLs) and from declaration values
+  (`padding: 0.5rem` → `5rem`). A selector is the text between the last `{`, `}` or `;` and the next
+  `{`, so scanning only what precedes a `{` skips declaration bodies by construction; comments and
+  strings are stepped over, and a CSS identifier start (never a digit) is the second line of defence
+  for a decimal in an at-rule prelude. **Statement at-rules are the deliberate exception**: the
+  class named by `@custom-variant sidebar-open (&:where(.sidebar-open *))` is load-bearing exactly
+  the way `group`/`peer` are, so a prelude starting with `@` is scanned before its `;` discards it.
+- **Named group/peer markers** (`cache.isMarkerClass`, issue #102): `group/menu-item` /
+  `peer/menu-button` emit NO CSS — the CSS lives in the consumer, whose selector hard-codes the
+  marker (`:is(:where(.group\/menu-item):hover *)`), so the marker is required markup and "does it
+  compile?" is the wrong question. `no-unknown-classes` calls the predicate in its pre-pass and
+  again **after** the `missing-prefix` branch (under a prefix the marker Tailwind wants IS
+  `tw:group/menu-item`, so an unprefixed one is genuinely dead CSS and must stay reported). The
+  predicate is derived — a precomputed, non-component class with ZERO declarations, which resolves
+  to exactly `group` and `peer` on every fixture — so it self-prunes, self-extends, and excludes
+  `@container/main` for free. Splits at the FIRST slash (`peer//x`, `group/a/b` are legal names);
+  only the EMPTY name is rejected. **Do not seed named markers into `validClasses`**: the `/name` is
+  user-chosen and unbounded, `ds.parseCandidate('peer/menu-button')` returns `[]`, and it would feed
+  unbounded strings to the Levenshtein scan.
 - **`no-conflicting-classes` decides from the emitted CSS**
   (`rules/no-conflicting-classes/decide.ts`): a shared `(box, property)` is a conflict only when the
   declaration that LOSES the cascade carries something the winner does not reproduce — equal value

--- a/packages/docs/es/rules/_extras/no-unknown-classes.md
+++ b/packages/docs/es/rules/_extras/no-unknown-classes.md
@@ -38,6 +38,30 @@ así que la respuesta es la de Tailwind y no una conjetura.
 `w-[garbage]` sigue siendo válida a propósito: Tailwind toma un valor arbitrario tal cual y emite
 `width: garbage`. Si ese CSS tiene sentido o no, no es asunto de esta regla.
 
+### Los marcadores group/peer con nombre son válidos
+
+`group/menu-item` y `peer/menu-button` son el idioma de v4 para atar una variante a **un** ancestro
+o hermano concreto cuando hay varios en juego — el patrón sobre el que está construido el sidebar de
+shadcn/ui. El marcador no emite CSS propio, y eso es justamente el punto: el CSS vive en el
+consumidor que lo lee. `group-hover/menu-item:underline` compila a
+
+```css
+.group-hover\/menu-item\:underline:is(:where(.group\/menu-item):hover *) { text-decoration-line: underline; }
+```
+
+Un selector de clase CSS casa tokens completos del atributo `class`, así que `group` a secas **no**
+satisface `:where(.group\/menu-item)`. El marcador es markup obligatorio: si lo quitas, todos sus
+consumidores dejan de casar en silencio.
+
+El nombre es tuyo y Tailwind nunca comprueba que exista, así que se acepta cualquier nombre no
+vacío, incluidas formas que solo un modificador arbitrario en el consumidor puede alcanzar
+(`group/*`, `group/a/b`, `peer//x`). La única grafía realmente muerta es el nombre **vacío**:
+`peer/` no compila nada y se reporta.
+
+Una clase nombrada por el selector de un `@custom-variant` funciona igual y sigue siendo válida:
+`@custom-variant sidebar-open (&:where(.sidebar-open *))` hace que `sidebar-open` sea load-bearing
+aunque nada la declare.
+
 ## Prefijo de proyecto (`prefix(...)`)
 
 Si tu entry point declara un prefijo de Tailwind v4 — `@import "tailwindcss" prefix(tw)` — cada
@@ -49,6 +73,10 @@ del prefijo:
   como que le falta el prefijo, con un quick-fix que lo agrega (`flex` → `tw:flex`).
 - Las component classes de `@layer components` (`btn`, `card`) no llevan prefijo y siguen siendo
   válidas en cualquier caso — solo las utilities generadas por Tailwind lo requieren.
+- Los marcadores con nombre también necesitan el prefijo, porque es lo que Tailwind pone en el
+  selector: `tw:group-hover/menu-item:underline` compila a
+  `:is(:where(.tw\:group\/menu-item):hover *)`, así que `tw:group/menu-item` es válida y un
+  `group/menu-item` sin prefijo se reporta como que le falta.
 
 El prefijo se detecta automáticamente desde tu `entryPoint`; no hay nada extra que configurar.
 
@@ -125,6 +153,10 @@ de mantener.
 
 // Todas las formas de variant, funcionales y arbitrarias
 <div className="group-hover:flex data-[state=open]:grid @md:block [&>svg]:size-4" />
+
+// Marcadores group/peer con nombre, y los consumidores que los leen
+<div className="group/menu-item peer/menu-button" />
+<div className="group-hover/menu-item:underline peer-data-[size=sm]/menu-button:top-1" />
 
 // Clase de runtime allowlisteada
 <div className={"hover:" + dynamicSuffix} />

--- a/packages/docs/es/rules/no-unknown-classes.md
+++ b/packages/docs/es/rules/no-unknown-classes.md
@@ -42,6 +42,30 @@ así que la respuesta es la de Tailwind y no una conjetura.
 `w-[garbage]` sigue siendo válida a propósito: Tailwind toma un valor arbitrario tal cual y emite
 `width: garbage`. Si ese CSS tiene sentido o no, no es asunto de esta regla.
 
+### Los marcadores group/peer con nombre son válidos
+
+`group/menu-item` y `peer/menu-button` son el idioma de v4 para atar una variante a **un** ancestro
+o hermano concreto cuando hay varios en juego — el patrón sobre el que está construido el sidebar de
+shadcn/ui. El marcador no emite CSS propio, y eso es justamente el punto: el CSS vive en el
+consumidor que lo lee. `group-hover/menu-item:underline` compila a
+
+```css
+.group-hover\/menu-item\:underline:is(:where(.group\/menu-item):hover *) { text-decoration-line: underline; }
+```
+
+Un selector de clase CSS casa tokens completos del atributo `class`, así que `group` a secas **no**
+satisface `:where(.group\/menu-item)`. El marcador es markup obligatorio: si lo quitas, todos sus
+consumidores dejan de casar en silencio.
+
+El nombre es tuyo y Tailwind nunca comprueba que exista, así que se acepta cualquier nombre no
+vacío, incluidas formas que solo un modificador arbitrario en el consumidor puede alcanzar
+(`group/*`, `group/a/b`, `peer//x`). La única grafía realmente muerta es el nombre **vacío**:
+`peer/` no compila nada y se reporta.
+
+Una clase nombrada por el selector de un `@custom-variant` funciona igual y sigue siendo válida:
+`@custom-variant sidebar-open (&:where(.sidebar-open *))` hace que `sidebar-open` sea load-bearing
+aunque nada la declare.
+
 ## Prefijo de proyecto (`prefix(...)`)
 
 Si tu entry point declara un prefijo de Tailwind v4 — `@import "tailwindcss" prefix(tw)` — cada
@@ -53,6 +77,10 @@ del prefijo:
   como que le falta el prefijo, con un quick-fix que lo agrega (`flex` → `tw:flex`).
 - Las component classes de `@layer components` (`btn`, `card`) no llevan prefijo y siguen siendo
   válidas en cualquier caso — solo las utilities generadas por Tailwind lo requieren.
+- Los marcadores con nombre también necesitan el prefijo, porque es lo que Tailwind pone en el
+  selector: `tw:group-hover/menu-item:underline` compila a
+  `:is(:where(.tw\:group\/menu-item):hover *)`, así que `tw:group/menu-item` es válida y un
+  `group/menu-item` sin prefijo se reporta como que le falta.
 
 El prefijo se detecta automáticamente desde tu `entryPoint`; no hay nada extra que configurar.
 
@@ -129,6 +157,10 @@ de mantener.
 
 // Todas las formas de variant, funcionales y arbitrarias
 <div className="group-hover:flex data-[state=open]:grid @md:block [&>svg]:size-4" />
+
+// Marcadores group/peer con nombre, y los consumidores que los leen
+<div className="group/menu-item peer/menu-button" />
+<div className="group-hover/menu-item:underline peer-data-[size=sm]/menu-button:top-1" />
 
 // Clase de runtime allowlisteada
 <div className={"hover:" + dynamicSuffix} />

--- a/packages/docs/rules/_extras/no-unknown-classes.md
+++ b/packages/docs/rules/_extras/no-unknown-classes.md
@@ -38,6 +38,30 @@ guess.
 `w-[garbage]` stays valid on purpose: Tailwind takes an arbitrary value verbatim and emits
 `width: garbage`. Whether that CSS is meaningful is not this rule's call.
 
+### Named group/peer markers are valid
+
+`group/menu-item` and `peer/menu-button` are the v4 idiom for binding a variant to **one specific**
+ancestor or sibling when several are in play — the pattern shadcn/ui's sidebar is built on. The
+marker emits no CSS of its own, which is the whole point: the CSS lives in the consumer that reads
+it. `group-hover/menu-item:underline` compiles to
+
+```css
+.group-hover\/menu-item\:underline:is(:where(.group\/menu-item):hover *) { text-decoration-line: underline; }
+```
+
+A CSS class selector matches whole tokens of the `class` attribute, so bare `group` does **not**
+satisfy `:where(.group\/menu-item)`. The marker is required markup — remove it and every consumer
+silently stops matching.
+
+The name is yours and Tailwind never checks that it exists, so any non-empty name is accepted,
+including shapes only an arbitrary modifier on the consumer can reach (`group/*`, `group/a/b`,
+`peer//x`). The one spelling that is genuinely dead is the **empty** name: `peer/` compiles to
+nothing and is reported.
+
+A class named by a `@custom-variant` selector works the same way and stays valid:
+`@custom-variant sidebar-open (&:where(.sidebar-open *))` makes `sidebar-open` load-bearing even
+though nothing declares it.
+
 ## Project prefix (`prefix(...)`)
 
 If your entry point declares a Tailwind v4 prefix — `@import "tailwindcss" prefix(tw)` — every
@@ -49,6 +73,9 @@ prefix-aware:
   needing the prefix, with a quick-fix that adds it (`flex` → `tw:flex`).
 - Component classes from `@layer components` (`btn`, `card`) carry no prefix and stay valid either
   way — only Tailwind-generated utilities require it.
+- Named markers need the prefix too, because that is what Tailwind puts in the selector:
+  `tw:group-hover/menu-item:underline` compiles to `:is(:where(.tw\:group\/menu-item):hover *)`, so
+  `tw:group/menu-item` is valid and a bare `group/menu-item` is reported as needing the prefix.
 
 The prefix is detected automatically from your `entryPoint`; there is nothing extra to configure.
 
@@ -124,6 +151,10 @@ maintain.
 
 // Every variant shape, functional and arbitrary alike
 <div className="group-hover:flex data-[state=open]:grid @md:block [&>svg]:size-4" />
+
+// Named group/peer markers, and the consumers that read them
+<div className="group/menu-item peer/menu-button" />
+<div className="group-hover/menu-item:underline peer-data-[size=sm]/menu-button:top-1" />
 
 // Allowlisted runtime class
 <div className={"hover:" + dynamicSuffix} />

--- a/packages/docs/rules/no-unknown-classes.md
+++ b/packages/docs/rules/no-unknown-classes.md
@@ -42,6 +42,30 @@ guess.
 `w-[garbage]` stays valid on purpose: Tailwind takes an arbitrary value verbatim and emits
 `width: garbage`. Whether that CSS is meaningful is not this rule's call.
 
+### Named group/peer markers are valid
+
+`group/menu-item` and `peer/menu-button` are the v4 idiom for binding a variant to **one specific**
+ancestor or sibling when several are in play — the pattern shadcn/ui's sidebar is built on. The
+marker emits no CSS of its own, which is the whole point: the CSS lives in the consumer that reads
+it. `group-hover/menu-item:underline` compiles to
+
+```css
+.group-hover\/menu-item\:underline:is(:where(.group\/menu-item):hover *) { text-decoration-line: underline; }
+```
+
+A CSS class selector matches whole tokens of the `class` attribute, so bare `group` does **not**
+satisfy `:where(.group\/menu-item)`. The marker is required markup — remove it and every consumer
+silently stops matching.
+
+The name is yours and Tailwind never checks that it exists, so any non-empty name is accepted,
+including shapes only an arbitrary modifier on the consumer can reach (`group/*`, `group/a/b`,
+`peer//x`). The one spelling that is genuinely dead is the **empty** name: `peer/` compiles to
+nothing and is reported.
+
+A class named by a `@custom-variant` selector works the same way and stays valid:
+`@custom-variant sidebar-open (&:where(.sidebar-open *))` makes `sidebar-open` load-bearing even
+though nothing declares it.
+
 ## Project prefix (`prefix(...)`)
 
 If your entry point declares a Tailwind v4 prefix — `@import "tailwindcss" prefix(tw)` — every
@@ -53,6 +77,9 @@ prefix-aware:
   needing the prefix, with a quick-fix that adds it (`flex` → `tw:flex`).
 - Component classes from `@layer components` (`btn`, `card`) carry no prefix and stay valid either
   way — only Tailwind-generated utilities require it.
+- Named markers need the prefix too, because that is what Tailwind puts in the selector:
+  `tw:group-hover/menu-item:underline` compiles to `:is(:where(.tw\:group\/menu-item):hover *)`, so
+  `tw:group/menu-item` is valid and a bare `group/menu-item` is reported as needing the prefix.
 
 The prefix is detected automatically from your `entryPoint`; there is nothing extra to configure.
 
@@ -128,6 +155,10 @@ maintain.
 
 // Every variant shape, functional and arbitrary alike
 <div className="group-hover:flex data-[state=open]:grid @md:block [&>svg]:size-4" />
+
+// Named group/peer markers, and the consumers that read them
+<div className="group/menu-item peer/menu-button" />
+<div className="group-hover/menu-item:underline peer-data-[size=sm]/menu-button:top-1" />
 
 // Allowlisted runtime class
 <div className={"hover:" + dynamicSuffix} />

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## 1.7.0
+
+Two false-positive families in `no-unknown-classes`, both found by asking what the design system
+actually knows rather than what its class names look like. One was reported; the other came out of
+auditing the first.
+
+### Breaking-ish
+
+- **`no-unknown-classes` stops accepting nine class names it never should have.** The scan that
+  collects the classes your own CSS declares read whole files — comments and declaration bodies
+  included — so the URLs in Tailwind's preflight comments arrived as class names (`mozilla`, `org`,
+  `com`, `cgi`, `chromium`, `webkit`, `css`) and so did the decimals in values (`padding: 0.5rem` →
+  `5rem`, `0.25rem` → `25rem`). Those went into the validity set, which means **every project using
+  this plugin has been accepting `com`, `org`, `css` and `5rem` as valid Tailwind classes**. It now
+  reads selectors only, so those nine report like any other unknown class. If your code contains one
+  of them it will newly fail — which is the point.
+
+  Kept deliberately: the class a statement at-rule names is still valid.
+  `@custom-variant sidebar-open (&:where(.sidebar-open *))` makes `sidebar-open` load-bearing in
+  exactly the way `group`/`peer` are, so it is read from the at-rule's selector instead of falling
+  out with the noise.
+
+### Bug fixes
+
+- **`no-unknown-classes` no longer reports named group/peer markers.** `group/menu-item` and
+  `peer/menu-button` bind a variant to ONE specific ancestor or sibling, and the consumer's compiled
+  selector hard-codes the marker as a class selector — `group-hover/menu-item:underline` emits
+  `:is(:where(.group\/menu-item):hover *)`. A class selector matches whole tokens, so bare `group`
+  does not satisfy it: the named marker is required markup, not decoration. Tailwind emits no CSS
+  for the marker itself, so the exact validation added in 1.5.0 asked "does this compile?" and got
+  the honest answer "nothing" — and every named marker in a shadcn/ui sidebar became a diagnostic.
+
+  Worse than noise, for short names: `peer/a` got a quick-fix that rewrote it to `peer`, silently
+  dropping the name and leaving every `peer-*/a:` consumer matching nothing.
+
+  Markers are now recognized as what they are, derived rather than listed — a precomputed class that
+  emits ZERO declarations, which across every fixture resolves to exactly `group` and `peer` (2 of
+  ~23.6k classes). It self-prunes if Tailwind drops the variants, self-extends if a new CSS-less
+  marker appears, and excludes `@container/main` for free, because that one has declarations. Any
+  non-empty name is accepted, including the shapes only an arbitrary modifier on the consumer can
+  reach (`group/*`, `group/a/b`, `peer//x`); Tailwind never checks that a marker name exists either.
+  `peer/` keeps reporting — the empty name is the one spelling that really compiles to nothing.
+
+  Under a project prefix the marker Tailwind requires IS the prefixed form
+  (`:is(:where(.tw\:group\/menu-item):hover *)`), so an unprefixed `peer/menu-button` still reports
+  `missingPrefix` with its quick-fix. Closes
+  [#102](https://github.com/sergioazoc/oxlint-tailwindcss/issues/102).
+
+- **The cache artifact no longer stores one entry per reference for `[class~="…"]` classes.**
+  Typography references `not-prose` from ~230 selectors and each one was pushed separately.
+
+### Dependencies
+
+- `oxlint` 1.74.0 → 1.76.0, `oxfmt` 0.59.0 → 0.61.0, and `@oxlint/plugins` moved to 1.76.0 so the
+  plugin API and the linter no longer sit on different versions — the catalog had bumped `oxlint`
+  while leaving `@oxlint/plugins` behind, which left the root workspace on 1.76 and the package
+  itself (including the test runner) on 1.74.
+
 ## 1.6.0
 
 ### Features

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/design-system/cache.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/cache.ts
@@ -317,6 +317,43 @@ export class DesignSystemCache {
     return this.validitySet.has(this.stripProjectPrefix(className))
   }
 
+  /**
+   * Is this a NAMED group/peer marker — `group/menu-item`, `peer/menu-button`?
+   *
+   * A marker binds a variant to one specific ancestor or sibling, and the
+   * consumer's compiled selector hard-codes it as a class selector:
+   * `group-hover/menu-item:underline` emits
+   * `:is(:where(.group\/menu-item):hover *)`. A class selector matches whole
+   * tokens, so bare `group` does not satisfy it — the named marker is required
+   * markup. Tailwind emits no CSS for the marker itself, which is why
+   * `no-unknown-classes` cannot ask "does it compile?" about one.
+   *
+   * Derived, not listed: the base must be a precomputed class that emits ZERO
+   * declarations, which across every fixture resolves to exactly `group` and
+   * `peer` (2 of ~23.6k). It self-prunes if Tailwind drops the variants,
+   * self-extends if a new CSS-less marker appears, and excludes `@container/main`
+   * for free — that one HAS declarations. The component set is subtracted
+   * because a class referenced only through `[class~="…"]` (`not-prose`) also has
+   * no declarations of its own, and `not-prose/x` is not Tailwind syntax.
+   *
+   * The name is user-chosen and Tailwind never checks that it exists, so any
+   * NON-EMPTY name is accepted — including the shapes only an arbitrary modifier
+   * can reach (`group/*`, `group/a/b`, `peer//x`), which is why this splits at
+   * the FIRST slash rather than the last one `isValid` uses. The empty name is
+   * the one genuinely dead spelling: `group-hover/` compiles to nothing.
+   */
+  isMarkerClass(className: string): boolean {
+    const bare = this.stripProjectPrefix(className)
+    const slash = bare.indexOf('/')
+    if (slash <= 0 || slash === bare.length - 1) return false
+    const base = bare.slice(0, slash)
+    return (
+      this.validitySet.has(base) &&
+      !this.componentSet.has(base) &&
+      this.getCssDeclarations(base).length === 0
+    )
+  }
+
   /** Variant names the design system reports, for suggesting a typo's neighbour. */
   variantNames(): string[] {
     return [...this.variantOrderMap.keys()]

--- a/packages/oxlint-tailwindcss/src/design-system/sync-loader.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/sync-loader.ts
@@ -398,31 +398,68 @@ function collectCssSources(cssPath, baseDir) {
   return files;
 }
 
+// Class names the project writes in its own CSS, read from the SELECTORS only.
+//
+// This used to scan whole files with two regexes, which harvested identifiers
+// from places that are not selectors at all: the URLs in Tailwind's own preflight
+// comments (\`developer.mozilla.org\` → \`mozilla\`, \`org\`; \`bugs.chromium.org\`;
+// \`-webkit-\`) and the decimals in declaration values (\`padding: 0.5rem\` →
+// \`5rem\`). Everything here reaches \`validitySet\`, so every project accepted
+// \`com\`, \`org\`, \`css\` and \`5rem\` as valid Tailwind classes.
+//
+// A selector is the text between the last \`{\`, \`}\` or \`;\` and the next \`{\`, so
+// scanning only what precedes a \`{\` skips declaration bodies by construction —
+// a declaration ends in \`;\` or \`}\` and never reaches one. Comments and strings
+// are stepped over. Requiring a CSS identifier start (never a digit) is the
+// second line of defence, for a decimal inside an at-rule prelude
+// (\`@media (min-width: 40.5rem)\`).
 function extractComponentClasses(cssPath, baseDir) {
   const files = collectCssSources(cssPath, baseDir);
-  const result = [];
+  const result = new Set();
+  const classRe = /\\.(-?[a-zA-Z_][\\w-]*)/g;
   for (const content of files) {
-    // Scan both @layer components AND @layer utilities
-    const layerRe = /@layer\\s+(?:components|utilities)\\s*\\{/g;
-    let lm;
-    while ((lm = layerRe.exec(content)) !== null) {
-      let depth = 1, i = lm.index + lm[0].length;
-      while (i < content.length && depth > 0) {
-        if (content[i] === '{') depth++;
-        if (content[i] === '}') depth--;
-        i++;
+    let prelude = '';
+    for (let i = 0; i < content.length; i++) {
+      const c = content[i];
+      if (c === '/' && content[i + 1] === '*') {
+        const end = content.indexOf('*/', i + 2);
+        i = end === -1 ? content.length : end + 1;
+        continue;
       }
-      const block = content.slice(lm.index + lm[0].length, i - 1);
-      const selRe = /\\.([\\w-]+)/g;
-      let sm;
-      while ((sm = selRe.exec(block)) !== null) result.push(sm[1]);
+      if (c === '"' || c === "'") {
+        const quote = c;
+        i++;
+        while (i < content.length && content[i] !== quote) {
+          if (content[i] === '\\\\') i++;
+          i++;
+        }
+        continue;
+      }
+      if (c === '{') {
+        classRe.lastIndex = 0;
+        let m;
+        while ((m = classRe.exec(prelude)) !== null) result.add(m[1]);
+        prelude = '';
+        continue;
+      }
+      if (c === '}' || c === ';') {
+        // A statement at-rule carries a selector even though it has no block:
+        // \`@custom-variant sidebar-open (&:where(.sidebar-open *));\` makes that
+        // class load-bearing exactly the way \`group\`/\`peer\` are, so it has to
+        // stay valid. Plain declarations never start with \`@\`, so this readmits
+        // the selector without readmitting \`padding: 0.5rem\`.
+        if (c === ';' && prelude.trimStart().charCodeAt(0) === 64) {
+          classRe.lastIndex = 0;
+          let m;
+          while ((m = classRe.exec(prelude)) !== null) result.add(m[1]);
+        }
+        prelude = '';
+        continue;
+      }
+      prelude += c;
     }
-    // Scan all class selectors anywhere in the file (.class-name)
-    const classSelRe = /\\.([a-zA-Z_][\\w-]*)/g;
-    let cs;
-    while ((cs = classSelRe.exec(content)) !== null) result.push(cs[1]);
   }
-  return [...new Set(result)];
+  return [...result];
 }
 
 ${DECL_EXTRACTOR_SOURCE}
@@ -827,11 +864,13 @@ async function main() {
   }
 
   // Component classes from @layer components
-  const componentClasses = extractComponentClasses(cssPath, base);
+  const componentSet = new Set(extractComponentClasses(cssPath, base));
 
   // Extract class names from attribute selectors [class~="..."] in CSS output.
   // Plugins like @tailwindcss/typography use these for modifier classes (e.g. "not-prose")
   // that don't generate their own CSS but are referenced in other classes' selectors.
+  // Interned in a Set: typography references \`not-prose\` from ~230 selectors, and
+  // pushing one entry per occurrence only inflated the cache artifact.
   const attrClassRe = /\\[class~="([^"]+)"\\]/g;
   for (let i = 0; i < cssResults.length; i++) {
     if (cssResults[i]) {
@@ -839,10 +878,11 @@ async function main() {
       attrClassRe.lastIndex = 0;
       while ((acm = attrClassRe.exec(cssResults[i])) !== null) {
         // Typography-style plugins emit \`[class~="tw:not-prose"]\` under a prefix.
-        componentClasses.push(unpfx(acm[1]));
+        componentSet.add(unpfx(acm[1]));
       }
     }
   }
+  const componentClasses = [...componentSet];
 
   // Arbitrary equivalents: map arbitrary forms to named equivalents.
   // Enumerate every dash split point so multi-segment utilities (e.g.

--- a/packages/oxlint-tailwindcss/src/rules/no-unknown-classes.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-unknown-classes.ts
@@ -188,6 +188,9 @@ export const noUnknownClasses = defineRule({
           if (shouldIgnore(cls)) continue
           const bare = strippedUtility(cls).bare
           if (cache.isKnownClass(bare)) continue
+          // A marker emits no CSS by design, so asking the service about one
+          // costs a roundtrip to learn nothing.
+          if (cache.isMarkerClass(bare)) continue
           if (!toVerify) toVerify = []
           toVerify.push(bare)
         }
@@ -224,6 +227,20 @@ export const noUnknownClasses = defineRule({
               { className: cls, prefix: cache.prefix, suggestion: fixed },
               split,
             )
+            continue
+          }
+
+          // A named group/peer marker (#102). It produces no CSS on purpose — the
+          // CSS lives in the consumer that references it (`group-hover/menu-item:`
+          // compiles to `:is(:where(.group\/menu-item):hover *)`), so "does it
+          // compile?" is the wrong question and both terms of `utilityIsUnknown`
+          // would answer it wrongly. Deliberately AFTER the missing-prefix branch:
+          // under `prefix(tw)` the marker Tailwind requires is `tw:group/menu-item`,
+          // so an unprefixed one is genuinely dead CSS and must stay reported.
+          if (
+            cache.isMarkerClass(bare) &&
+            (!cache.prefix || variant.startsWith(`${cache.prefix}:`))
+          ) {
             continue
           }
 

--- a/packages/oxlint-tailwindcss/tests/benchmarks/precompute-phases.test.ts
+++ b/packages/oxlint-tailwindcss/tests/benchmarks/precompute-phases.test.ts
@@ -67,27 +67,47 @@ function extractComponentClasses(cssPath, baseDir) {
       try { files.push(readFileSync(resolved, 'utf-8')); } catch {}
     }
   }
-  const result = [];
+  // Mirrors extractComponentClasses in sync-loader.ts — selectors only.
+  const result = new Set();
+  const classRe = /\\.(-?[a-zA-Z_][\\w-]*)/g;
   for (const content of files) {
-    const layerRe = /@layer\\s+(?:components|utilities)\\s*\\{/g;
-    let lm;
-    while ((lm = layerRe.exec(content)) !== null) {
-      let depth = 1, i = lm.index + lm[0].length;
-      while (i < content.length && depth > 0) {
-        if (content[i] === '{') depth++;
-        if (content[i] === '}') depth--;
-        i++;
+    let prelude = '';
+    for (let i = 0; i < content.length; i++) {
+      const c = content[i];
+      if (c === '/' && content[i + 1] === '*') {
+        const end = content.indexOf('*/', i + 2);
+        i = end === -1 ? content.length : end + 1;
+        continue;
       }
-      const block = content.slice(lm.index + lm[0].length, i - 1);
-      const selRe = /\\.([\\w-]+)/g;
-      let sm;
-      while ((sm = selRe.exec(block)) !== null) result.push(sm[1]);
+      if (c === '"' || c === "'") {
+        const quote = c;
+        i++;
+        while (i < content.length && content[i] !== quote) {
+          if (content[i] === '\\\\') i++;
+          i++;
+        }
+        continue;
+      }
+      if (c === '{') {
+        classRe.lastIndex = 0;
+        let m2;
+        while ((m2 = classRe.exec(prelude)) !== null) result.add(m2[1]);
+        prelude = '';
+        continue;
+      }
+      if (c === '}' || c === ';') {
+        if (c === ';' && prelude.trimStart().charCodeAt(0) === 64) {
+          classRe.lastIndex = 0;
+          let m3;
+          while ((m3 = classRe.exec(prelude)) !== null) result.add(m3[1]);
+        }
+        prelude = '';
+        continue;
+      }
+      prelude += c;
     }
-    const classSelRe = /\\.([a-zA-Z_][\\w-]*)/g;
-    let cs;
-    while ((cs = classSelRe.exec(content)) !== null) result.push(cs[1]);
   }
-  return [...new Set(result)];
+  return [...result];
 }
 
 ${DECL_EXTRACTOR_SOURCE}
@@ -223,17 +243,18 @@ async function main() {
 
   // === Phase 7: Component classes ===
   t = performance.now();
-  const componentClasses = extractComponentClasses(cssPath, base);
+  const componentSet = new Set(extractComponentClasses(cssPath, base));
   const attrClassRe = /\\[class~="([^"]+)"\\]/g;
   for (let i = 0; i < cssResults.length; i++) {
     if (cssResults[i]) {
       let acm;
       attrClassRe.lastIndex = 0;
       while ((acm = attrClassRe.exec(cssResults[i])) !== null) {
-        componentClasses.push(acm[1]);
+        componentSet.add(acm[1]);
       }
     }
   }
+  const componentClasses = [...componentSet];
   timings['7_component_classes'] = performance.now() - t;
 
   // === Phase 8: Arbitrary equivalents ===

--- a/packages/oxlint-tailwindcss/tests/design-system/cache.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/cache.test.ts
@@ -5,7 +5,7 @@ import { makeDeclarations } from '../utils/declarations'
 
 function makeData(overrides: Partial<PrecomputedData> = {}): PrecomputedData {
   return {
-    validClasses: ['flex', 'p-4', 'bg-blue-500', 'items-center', 'group', '-m-0'],
+    validClasses: ['flex', 'p-4', 'bg-blue-500', 'items-center', 'group', 'peer', '-m-0'],
     canonical: { '-m-0': 'm-0', 'flex-grow': 'grow' },
     order: {
       flex: '100',
@@ -151,6 +151,64 @@ describe('isValid', () => {
     const cache = DesignSystemCache.fromPrecomputed(makeData())
     expect(cache.isValid('!flex')).toBe(true)
     expect(cache.isValid('flex!')).toBe(true)
+  })
+})
+
+/**
+ * Named group/peer markers (#102).
+ *
+ * Derived rather than listed: a marker is a precomputed class that emits ZERO
+ * declarations. Across every fixture in this suite that resolves to exactly
+ * `group` and `peer` (2 of ~23.6k classes), so the predicate self-prunes if
+ * Tailwind stops shipping the variants and self-extends if a new CSS-less marker
+ * appears — and `@container/main` is excluded for free, because it HAS
+ * declarations.
+ *
+ * The component set has to be subtracted, though: a component class referenced
+ * only through `[class~="…"]` (`not-prose`) also lands in the validity set with
+ * no declarations of its own, and `not-prose/x` is not Tailwind syntax.
+ */
+describe('isMarkerClass', () => {
+  it('recognizes named markers', () => {
+    const cache = DesignSystemCache.fromPrecomputed(makeData())
+    expect(cache.isMarkerClass('group/menu-item')).toBe(true)
+    expect(cache.isMarkerClass('peer/menu-button')).toBe(true)
+    // Any non-empty name: Tailwind never checks the name exists, and an
+    // arbitrary modifier on the consumer can reference shapes the bare syntax
+    // cannot spell.
+    expect(cache.isMarkerClass('group/1')).toBe(true)
+    expect(cache.isMarkerClass('group/*')).toBe(true)
+    expect(cache.isMarkerClass('peer//x')).toBe(true)
+    expect(cache.isMarkerClass('group/a/b')).toBe(true)
+  })
+
+  it('rejects the empty name, which compiles to nothing', () => {
+    const cache = DesignSystemCache.fromPrecomputed(makeData())
+    expect(cache.isMarkerClass('group/')).toBe(false)
+    expect(cache.isMarkerClass('peer/')).toBe(false)
+    expect(cache.isMarkerClass('/menu-item')).toBe(false)
+  })
+
+  it('rejects utilities that merely carry a slash modifier', () => {
+    const cache = DesignSystemCache.fromPrecomputed(makeData())
+    // `bg-blue-500` emits declarations, so it is not a marker.
+    expect(cache.isMarkerClass('bg-blue-500/50')).toBe(false)
+    expect(cache.isMarkerClass('flex')).toBe(false)
+    expect(cache.isMarkerClass('group')).toBe(false)
+    expect(cache.isMarkerClass('grup/menu-item')).toBe(false)
+  })
+
+  it('rejects CSS-less component classes', () => {
+    const cache = DesignSystemCache.fromPrecomputed(makeData())
+    // `not-prose` is in the validity set with zero declarations, exactly like a
+    // marker — but it is a component class, and `not-prose/x` is not syntax.
+    expect(cache.isMarkerClass('not-prose/x')).toBe(false)
+  })
+
+  it('honours the project prefix', () => {
+    const cache = DesignSystemCache.fromPrecomputed(makeData({ prefix: 'tw' }))
+    expect(cache.isMarkerClass('tw:group/menu-item')).toBe(true)
+    expect(cache.isMarkerClass('group/menu-item')).toBe(true)
   })
 })
 

--- a/packages/oxlint-tailwindcss/tests/design-system/precomputed-snapshot.test.ts
+++ b/packages/oxlint-tailwindcss/tests/design-system/precomputed-snapshot.test.ts
@@ -222,6 +222,40 @@ describe('Precomputed Data Snapshot', () => {
     })
   })
 
+  /**
+   * `componentClasses` feeds the validity set, so anything that lands here is a
+   * class `no-unknown-classes` will accept. The scan used to read the whole file
+   * — comments and declaration bodies included — so the URLs in Tailwind's own
+   * preflight comments (`developer.mozilla.org`, `bugs.chromium.org`) and the
+   * decimals in values (`padding: 0.5rem`) arrived as class names, and every
+   * project accepted `com`, `org`, `css` and `5rem` as valid Tailwind classes.
+   */
+  describe('componentClasses', () => {
+    it('does not harvest identifiers from comments or declaration values', () => {
+      const noise = ['com', 'org', 'css', 'cgi', 'webkit', 'mozilla', 'chromium', '5rem', '25rem']
+      for (const name of noise) {
+        expect(data.componentClasses).not.toContain(name)
+      }
+    })
+
+    it('is deduplicated', () => {
+      expect(new Set(data.componentClasses).size).toBe(data.componentClasses.length)
+    })
+
+    // The entry above cannot catch a duplicate on its own: the bare `@import
+    // "tailwindcss"` fixture has no `[class~="…"]` selectors at all. Typography
+    // is where it happened — it references `not-prose` from ~230 selectors, and
+    // each one used to be stored separately.
+    it('interns a repeated [class~] reference once', () => {
+      const typography = loadDesignSystemSync(
+        resolve(__dirname, '../fixtures/with-typography.css'),
+      )!
+      expect(typography.componentClasses).toContain('not-prose')
+      expect(new Set(typography.componentClasses).size).toBe(typography.componentClasses.length)
+      expect(typography.componentClasses.filter((c) => c === 'not-prose')).toHaveLength(1)
+    })
+  })
+
   describe('variantOrder', () => {
     it('contains core variants', () => {
       const coreVariants = ['hover', 'focus', 'active', 'dark', 'sm', 'md', 'lg', 'xl', '2xl']

--- a/packages/oxlint-tailwindcss/tests/fixtures/with-custom-variants.css
+++ b/packages/oxlint-tailwindcss/tests/fixtures/with-custom-variants.css
@@ -13,3 +13,10 @@
  */
 @custom-variant thumb (&::-webkit-slider-thumb);
 @custom-variant child (& > *);
+
+/*
+ * A variant whose selector names a CLASS. The class itself produces no CSS —
+ * it is a marker the variant binds to, the same shape as `group`/`peer` — so it
+ * has to stay valid for `no-unknown-classes` even though nothing declares it.
+ */
+@custom-variant sidebar-open (&:where(.sidebar-open *));

--- a/packages/oxlint-tailwindcss/tests/integration/shadcn.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/shadcn.test.ts
@@ -49,6 +49,11 @@ const SHADCN_CLASS_STRINGS = [
   'bg-sidebar-accent text-sidebar-accent-foreground',
   'ring-sidebar-ring',
   'fill-chart-1 stroke-chart-2 text-chart-3 bg-chart-4 border-chart-5',
+  // sidebar named markers and the consumers that read them (#102). The sidebar
+  // is where shadcn uses the named form pervasively, and it is what the report
+  // came from.
+  'group/menu-item peer/menu-button relative flex w-full items-center',
+  'peer-data-[active=true]/menu-button:bg-sidebar-accent group-data-[collapsible=icon]/menu-item:hidden',
   // card / popover / muted / accent
   'bg-card text-card-foreground rounded-lg border border-border shadow-sm',
   'bg-popover text-popover-foreground rounded-md',

--- a/packages/oxlint-tailwindcss/tests/rules/no-unknown-classes.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-unknown-classes.test.ts
@@ -475,6 +475,11 @@ describe('custom variants', () => {
     valid: [
       { code: '<div className="thumb:size-4" />', filename: 'test.tsx' },
       { code: '<div className="child:mt-4" />', filename: 'test.tsx' },
+      // The class a `@custom-variant` selector names is a marker for that
+      // variant: it declares nothing, but removing it stops `sidebar-open:*`
+      // from matching. Read from the at-rule's selector, so it stays valid.
+      { code: '<div className="sidebar-open" />', filename: 'test.tsx' },
+      { code: '<div className="sidebar-open:flex" />', filename: 'test.tsx' },
     ],
     invalid: [
       // The suggestion comes from the variants the design system reports, so a
@@ -483,6 +488,111 @@ describe('custom variants', () => {
         code: '<div className="thumbb:size-4" />',
         filename: 'test.tsx',
         errors: [{ messageId: 'unknownVariantWithSuggestion' }],
+      },
+    ],
+  })
+})
+
+/**
+ * Named group/peer markers (#102).
+ *
+ * `group/menu-item` binds `group-hover/menu-item:` to ONE specific ancestor, and
+ * the consumer's compiled selector hard-codes the marker as a class selector —
+ * `:is(:where(.group\/menu-item):hover *)`. A class selector matches whole
+ * tokens, so bare `group` does not satisfy it: the named marker is required
+ * markup, not decoration. Tailwind emits no CSS for the marker itself, which is
+ * exactly what made the exact validation of 1.5.0 report it.
+ *
+ * The `/name` half is user-chosen and Tailwind never checks that it exists, so
+ * any NON-EMPTY name is legitimate — including shapes only an arbitrary modifier
+ * can reach (`group/*`, `group/a/b`, `peer//x`). The one genuinely dead spelling
+ * is the EMPTY name: `group-hover/` compiles to nothing.
+ */
+describe('named group/peer markers', () => {
+  runWithFixture(new RuleTester(), 'markers', noUnknownClasses, ENTRY_POINT, {
+    valid: [
+      // Bare markers — the case that already worked, kept as the symmetry anchor.
+      { code: '<div className="peer group" />', filename: 'test.tsx' },
+      // Named markers: the regression.
+      { code: '<div className="peer/menu-button" />', filename: 'test.tsx' },
+      { code: '<div className="group/menu-item" />', filename: 'test.tsx' },
+      { code: '<div className="group/menu-item flex items-center" />', filename: 'test.tsx' },
+      // `!` in both positions, and behind a variant chain.
+      { code: '<div className="!peer/menu-button" />', filename: 'test.tsx' },
+      { code: '<div className="peer/menu-button!" />', filename: 'test.tsx' },
+      { code: '<div className="hover:group/menu-item" />', filename: 'test.tsx' },
+      // A short name must not be "corrected" to the bare marker: the quick-fix
+      // would drop the name and leave every `peer-*/a:` consumer matching
+      // nothing. This is the destructive half of the bug.
+      { code: '<div className="peer/a" />', filename: 'test.tsx' },
+      { code: '<div className="group/1" />', filename: 'test.tsx' },
+      // Names reachable only through an arbitrary modifier on the consumer.
+      { code: '<div className="group/*" />', filename: 'test.tsx' },
+      { code: '<div className="peer//x" />', filename: 'test.tsx' },
+      { code: '<div className="group/a/b" />', filename: 'test.tsx' },
+      // The other half: the consumers that read the marker. These always
+      // compiled, and must keep doing so.
+      { code: '<div className="peer-data-[size=sm]/menu-button:top-1" />', filename: 'test.tsx' },
+      { code: '<div className="group-hover/menu-item:underline" />', filename: 'test.tsx' },
+    ],
+    invalid: [
+      // Empty name: Tailwind compiles nothing for it, so the existing
+      // `Did you mean "peer"?` quick-fix is the right answer.
+      {
+        code: '<div className="peer/" />',
+        filename: 'test.tsx',
+        errors: [
+          {
+            messageId: 'unknownWithSuggestion',
+            suggestions: [
+              {
+                messageId: 'suggestReplace',
+                data: { className: 'peer/', replacement: 'peer' },
+                output: '<div className="peer" />',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        code: '<div className="group/" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'unknownWithSuggestion' }],
+      },
+      // A typo in the marker itself is not a marker.
+      {
+        code: '<div className="peerr/menu-button" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'unknown' }],
+      },
+      // Still the exact answer for a slash modifier that is NOT a marker: the
+      // base produces CSS, so `/foo` has to resolve — and it doesn't.
+      {
+        code: '<div className="bg-red-500/foo" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'unknown' }],
+      },
+    ],
+  })
+
+  /**
+   * A component class with no CSS of its own (`not-prose` is referenced only
+   * through `[class~="not-prose"]` in typography's output) is NOT a marker:
+   * `not-prose/x` is not Tailwind syntax. The predicate has to tell the two
+   * apart, because both are "in the validity set with zero declarations".
+   */
+  const TYPOGRAPHY = resolve(__dirname, '../fixtures/with-typography.css')
+
+  runWithFixture(new RuleTester(), 'markers vs component classes', noUnknownClasses, TYPOGRAPHY, {
+    valid: [
+      { code: '<div className="prose not-prose" />', filename: 'test.tsx' },
+      { code: '<div className="group/menu-item peer/menu-button" />', filename: 'test.tsx' },
+    ],
+    invalid: [
+      {
+        code: '<div className="not-prose/x" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'unknown' }],
       },
     ],
   })

--- a/packages/oxlint-tailwindcss/tests/rules/prefix.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/prefix.test.ts
@@ -47,6 +47,13 @@ run('no-unknown-classes (prefix)', noUnknownClasses, {
     { code: '<div className="tw:bg-[#123456]" />', filename: 'test.tsx' },
     { code: '<div className="tw:bg-blue-500/50" />', filename: 'test.tsx' },
     { code: '<div className="tw:!flex tw:items-center!" />', filename: 'test.tsx' },
+    // Named group/peer markers (#102). Under a prefix the marker Tailwind
+    // requires IS the prefixed form: `tw:group-hover/menu-item:underline`
+    // compiles to `:is(:where(.tw\:group\/menu-item):hover *)`.
+    { code: '<div className="tw:peer/menu-button" />', filename: 'test.tsx' },
+    { code: '<div className="tw:group/menu-item" />', filename: 'test.tsx' },
+    { code: '<div className="tw:hover:group/a/b" />', filename: 'test.tsx' },
+    { code: '<div className="tw:group-hover/menu-item:underline" />', filename: 'test.tsx' },
   ],
   invalid: [
     // Tailwind utility without the required prefix → missing-prefix (dead CSS).
@@ -77,6 +84,32 @@ run('no-unknown-classes (prefix)', noUnknownClasses, {
       code: '<div className="tw:not-a-real-class" />',
       filename: 'test.tsx',
       errors: [{ messageId: 'unknown' }],
+    },
+    // A named marker written WITHOUT the prefix is genuinely dead CSS: the
+    // consumer's selector references `.tw\:peer\/menu-button`, so the unprefixed
+    // spelling binds to nothing. This case is the guard that keeps the marker
+    // exemption from being "simplified" into an early blanket skip, which would
+    // turn a correct loud diagnostic into silence (#102).
+    {
+      code: '<div className="peer/menu-button" />',
+      filename: 'test.tsx',
+      errors: [
+        {
+          messageId: 'missingPrefix',
+          data: {
+            className: 'peer/menu-button',
+            prefix: 'tw',
+            suggestion: 'tw:peer/menu-button',
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplace',
+              data: { className: 'peer/menu-button', replacement: 'tw:peer/menu-button' },
+              output: '<div className="tw:peer/menu-button" />',
+            },
+          ],
+        },
+      ],
     },
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,14 @@ settings:
 catalogs:
   default:
     '@oxlint/plugins':
-      specifier: ^1.74.0
-      version: 1.74.0
+      specifier: ^1.76.0
+      version: 1.76.0
     oxfmt:
-      specifier: ^0.59.0
-      version: 0.59.0
+      specifier: ^0.61.0
+      version: 0.61.0
     oxlint:
-      specifier: ^1.74.0
-      version: 1.74.0
+      specifier: ^1.76.0
+      version: 1.76.0
 
 importers:
 
@@ -22,10 +22,10 @@ importers:
     devDependencies:
       oxfmt:
         specifier: 'catalog:'
-        version: 0.59.0
+        version: 0.61.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.74.0
+        version: 1.76.0
 
   packages/docs:
     devDependencies:
@@ -47,7 +47,7 @@ importers:
     devDependencies:
       '@oxlint/plugins':
         specifier: 'catalog:'
-        version: 1.74.0
+        version: 1.76.0
       '@tailwindcss/typography':
         specifier: ^0.5.20
         version: 0.5.20(tailwindcss@4.3.3)
@@ -56,7 +56,7 @@ importers:
         version: 26.1.1
       oxlint:
         specifier: 'catalog:'
-        version: 1.74.0
+        version: 1.76.0
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.3.3)
@@ -150,252 +150,252 @@ packages:
   '@oxc-project/types@0.140.0':
     resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
 
-  '@oxfmt/binding-android-arm-eabi@0.59.0':
-    resolution: {integrity: sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA==}
+  '@oxfmt/binding-android-arm-eabi@0.61.0':
+    resolution: {integrity: sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.59.0':
-    resolution: {integrity: sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q==}
+  '@oxfmt/binding-android-arm64@0.61.0':
+    resolution: {integrity: sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.59.0':
-    resolution: {integrity: sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw==}
+  '@oxfmt/binding-darwin-arm64@0.61.0':
+    resolution: {integrity: sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.59.0':
-    resolution: {integrity: sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w==}
+  '@oxfmt/binding-darwin-x64@0.61.0':
+    resolution: {integrity: sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.59.0':
-    resolution: {integrity: sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ==}
+  '@oxfmt/binding-freebsd-x64@0.61.0':
+    resolution: {integrity: sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.59.0':
-    resolution: {integrity: sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.61.0':
+    resolution: {integrity: sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.59.0':
-    resolution: {integrity: sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.61.0':
+    resolution: {integrity: sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.59.0':
-    resolution: {integrity: sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ==}
+  '@oxfmt/binding-linux-arm64-gnu@0.61.0':
+    resolution: {integrity: sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.59.0':
-    resolution: {integrity: sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw==}
+  '@oxfmt/binding-linux-arm64-musl@0.61.0':
+    resolution: {integrity: sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.59.0':
-    resolution: {integrity: sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
+    resolution: {integrity: sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.59.0':
-    resolution: {integrity: sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
+    resolution: {integrity: sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.59.0':
-    resolution: {integrity: sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw==}
+  '@oxfmt/binding-linux-riscv64-musl@0.61.0':
+    resolution: {integrity: sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.59.0':
-    resolution: {integrity: sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw==}
+  '@oxfmt/binding-linux-s390x-gnu@0.61.0':
+    resolution: {integrity: sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.59.0':
-    resolution: {integrity: sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA==}
+  '@oxfmt/binding-linux-x64-gnu@0.61.0':
+    resolution: {integrity: sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.59.0':
-    resolution: {integrity: sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g==}
+  '@oxfmt/binding-linux-x64-musl@0.61.0':
+    resolution: {integrity: sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.59.0':
-    resolution: {integrity: sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA==}
+  '@oxfmt/binding-openharmony-arm64@0.61.0':
+    resolution: {integrity: sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.59.0':
-    resolution: {integrity: sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g==}
+  '@oxfmt/binding-win32-arm64-msvc@0.61.0':
+    resolution: {integrity: sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.59.0':
-    resolution: {integrity: sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw==}
+  '@oxfmt/binding-win32-ia32-msvc@0.61.0':
+    resolution: {integrity: sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.59.0':
-    resolution: {integrity: sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w==}
+  '@oxfmt/binding-win32-x64-msvc@0.61.0':
+    resolution: {integrity: sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.74.0':
-    resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
+  '@oxlint/binding-android-arm-eabi@1.76.0':
+    resolution: {integrity: sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.74.0':
-    resolution: {integrity: sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==}
+  '@oxlint/binding-android-arm64@1.76.0':
+    resolution: {integrity: sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.74.0':
-    resolution: {integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==}
+  '@oxlint/binding-darwin-arm64@1.76.0':
+    resolution: {integrity: sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.74.0':
-    resolution: {integrity: sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==}
+  '@oxlint/binding-darwin-x64@1.76.0':
+    resolution: {integrity: sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.74.0':
-    resolution: {integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==}
+  '@oxlint/binding-freebsd-x64@1.76.0':
+    resolution: {integrity: sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
-    resolution: {integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.76.0':
+    resolution: {integrity: sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
-    resolution: {integrity: sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.76.0':
+    resolution: {integrity: sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.74.0':
-    resolution: {integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==}
+  '@oxlint/binding-linux-arm64-gnu@1.76.0':
+    resolution: {integrity: sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.74.0':
-    resolution: {integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==}
+  '@oxlint/binding-linux-arm64-musl@1.76.0':
+    resolution: {integrity: sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
-    resolution: {integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==}
+  '@oxlint/binding-linux-ppc64-gnu@1.76.0':
+    resolution: {integrity: sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
-    resolution: {integrity: sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==}
+  '@oxlint/binding-linux-riscv64-gnu@1.76.0':
+    resolution: {integrity: sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.74.0':
-    resolution: {integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==}
+  '@oxlint/binding-linux-riscv64-musl@1.76.0':
+    resolution: {integrity: sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.74.0':
-    resolution: {integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==}
+  '@oxlint/binding-linux-s390x-gnu@1.76.0':
+    resolution: {integrity: sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.74.0':
-    resolution: {integrity: sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==}
+  '@oxlint/binding-linux-x64-gnu@1.76.0':
+    resolution: {integrity: sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.74.0':
-    resolution: {integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==}
+  '@oxlint/binding-linux-x64-musl@1.76.0':
+    resolution: {integrity: sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.74.0':
-    resolution: {integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==}
+  '@oxlint/binding-openharmony-arm64@1.76.0':
+    resolution: {integrity: sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.74.0':
-    resolution: {integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==}
+  '@oxlint/binding-win32-arm64-msvc@1.76.0':
+    resolution: {integrity: sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.74.0':
-    resolution: {integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==}
+  '@oxlint/binding-win32-ia32-msvc@1.76.0':
+    resolution: {integrity: sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.74.0':
-    resolution: {integrity: sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==}
+  '@oxlint/binding-win32-x64-msvc@1.76.0':
+    resolution: {integrity: sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/plugins@1.74.0':
-    resolution: {integrity: sha512-3tQlMDPt5hrRYedKl+M+Xq+fRjAEocMCRJaXH6ypLWu8+Oui5GMj51vjaYf/rzj6HT+JzQoUlY/I7Im2VNXzbw==}
+  '@oxlint/plugins@1.76.0':
+    resolution: {integrity: sha512-twmbsVrYAjkaOw6I2pDiYSAxVLNOV8kcqMzajJ599SpqXzea+GjDCZVad1VUqNR/4thWjM4PER5n+3/TQtTkZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@quansync/fs@1.0.0':
@@ -1310,8 +1310,8 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
-  oxfmt@0.59.0:
-    resolution: {integrity: sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w==}
+  oxfmt@0.61.0:
+    resolution: {integrity: sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1323,12 +1323,12 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint@1.74.0:
-    resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
+  oxlint@1.76.0:
+    resolution: {integrity: sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.24.0'
+      oxlint-tsgolint: '>=7.0.2001'
       vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
@@ -1767,121 +1767,121 @@ snapshots:
 
   '@oxc-project/types@0.140.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.59.0':
+  '@oxfmt/binding-android-arm-eabi@0.61.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.59.0':
+  '@oxfmt/binding-android-arm64@0.61.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.59.0':
+  '@oxfmt/binding-darwin-arm64@0.61.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.59.0':
+  '@oxfmt/binding-darwin-x64@0.61.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.59.0':
+  '@oxfmt/binding-freebsd-x64@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.59.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.59.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.59.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.59.0':
+  '@oxfmt/binding-linux-arm64-musl@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.59.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.59.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.59.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.59.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.59.0':
+  '@oxfmt/binding-linux-x64-gnu@0.61.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.59.0':
+  '@oxfmt/binding-linux-x64-musl@0.61.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.59.0':
+  '@oxfmt/binding-openharmony-arm64@0.61.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.59.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.61.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.59.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.61.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.59.0':
+  '@oxfmt/binding-win32-x64-msvc@0.61.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.74.0':
+  '@oxlint/binding-android-arm-eabi@1.76.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.74.0':
+  '@oxlint/binding-android-arm64@1.76.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.74.0':
+  '@oxlint/binding-darwin-arm64@1.76.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.74.0':
+  '@oxlint/binding-darwin-x64@1.76.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.74.0':
+  '@oxlint/binding-freebsd-x64@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+  '@oxlint/binding-linux-arm64-gnu@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.74.0':
+  '@oxlint/binding-linux-arm64-musl@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+  '@oxlint/binding-linux-riscv64-musl@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+  '@oxlint/binding-linux-s390x-gnu@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.74.0':
+  '@oxlint/binding-linux-x64-gnu@1.76.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.74.0':
+  '@oxlint/binding-linux-x64-musl@1.76.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.74.0':
+  '@oxlint/binding-openharmony-arm64@1.76.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+  '@oxlint/binding-win32-arm64-msvc@1.76.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+  '@oxlint/binding-win32-ia32-msvc@1.76.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.74.0':
+  '@oxlint/binding-win32-x64-msvc@1.76.0':
     optional: true
 
-  '@oxlint/plugins@1.74.0': {}
+  '@oxlint/plugins@1.76.0': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -2553,51 +2553,51 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  oxfmt@0.59.0:
+  oxfmt@0.61.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.59.0
-      '@oxfmt/binding-android-arm64': 0.59.0
-      '@oxfmt/binding-darwin-arm64': 0.59.0
-      '@oxfmt/binding-darwin-x64': 0.59.0
-      '@oxfmt/binding-freebsd-x64': 0.59.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.59.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.59.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.59.0
-      '@oxfmt/binding-linux-arm64-musl': 0.59.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.59.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.59.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.59.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.59.0
-      '@oxfmt/binding-linux-x64-gnu': 0.59.0
-      '@oxfmt/binding-linux-x64-musl': 0.59.0
-      '@oxfmt/binding-openharmony-arm64': 0.59.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.59.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.59.0
-      '@oxfmt/binding-win32-x64-msvc': 0.59.0
+      '@oxfmt/binding-android-arm-eabi': 0.61.0
+      '@oxfmt/binding-android-arm64': 0.61.0
+      '@oxfmt/binding-darwin-arm64': 0.61.0
+      '@oxfmt/binding-darwin-x64': 0.61.0
+      '@oxfmt/binding-freebsd-x64': 0.61.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.61.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.61.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.61.0
+      '@oxfmt/binding-linux-arm64-musl': 0.61.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.61.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.61.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.61.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.61.0
+      '@oxfmt/binding-linux-x64-gnu': 0.61.0
+      '@oxfmt/binding-linux-x64-musl': 0.61.0
+      '@oxfmt/binding-openharmony-arm64': 0.61.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.61.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.61.0
+      '@oxfmt/binding-win32-x64-msvc': 0.61.0
 
-  oxlint@1.74.0:
+  oxlint@1.76.0:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.74.0
-      '@oxlint/binding-android-arm64': 1.74.0
-      '@oxlint/binding-darwin-arm64': 1.74.0
-      '@oxlint/binding-darwin-x64': 1.74.0
-      '@oxlint/binding-freebsd-x64': 1.74.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.74.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.74.0
-      '@oxlint/binding-linux-arm64-gnu': 1.74.0
-      '@oxlint/binding-linux-arm64-musl': 1.74.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.74.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.74.0
-      '@oxlint/binding-linux-riscv64-musl': 1.74.0
-      '@oxlint/binding-linux-s390x-gnu': 1.74.0
-      '@oxlint/binding-linux-x64-gnu': 1.74.0
-      '@oxlint/binding-linux-x64-musl': 1.74.0
-      '@oxlint/binding-openharmony-arm64': 1.74.0
-      '@oxlint/binding-win32-arm64-msvc': 1.74.0
-      '@oxlint/binding-win32-ia32-msvc': 1.74.0
-      '@oxlint/binding-win32-x64-msvc': 1.74.0
+      '@oxlint/binding-android-arm-eabi': 1.76.0
+      '@oxlint/binding-android-arm64': 1.76.0
+      '@oxlint/binding-darwin-arm64': 1.76.0
+      '@oxlint/binding-darwin-x64': 1.76.0
+      '@oxlint/binding-freebsd-x64': 1.76.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.76.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.76.0
+      '@oxlint/binding-linux-arm64-gnu': 1.76.0
+      '@oxlint/binding-linux-arm64-musl': 1.76.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.76.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.76.0
+      '@oxlint/binding-linux-riscv64-musl': 1.76.0
+      '@oxlint/binding-linux-s390x-gnu': 1.76.0
+      '@oxlint/binding-linux-x64-gnu': 1.76.0
+      '@oxlint/binding-linux-x64-musl': 1.76.0
+      '@oxlint/binding-openharmony-arm64': 1.76.0
+      '@oxlint/binding-win32-arm64-msvc': 1.76.0
+      '@oxlint/binding-win32-ia32-msvc': 1.76.0
+      '@oxlint/binding-win32-x64-msvc': 1.76.0
 
   pathe@2.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,9 @@
 packages:
   - 'packages/*'
 catalog:
-  '@oxlint/plugins': ^1.74.0
-  oxfmt: ^0.59.0
-  oxlint: ^1.74.0
+  '@oxlint/plugins': ^1.76.0
+  oxfmt: ^0.61.0
+  oxlint: ^1.76.0
 allowBuilds:
   esbuild: true
   # wrangler-action runs `pnpm add wrangler` for the Cloudflare Pages deploy;


### PR DESCRIPTION
Two false-positive families in `no-unknown-classes`, one reported and one found while auditing it. Ships as **1.7.0** — the second fix turns existing false negatives into new diagnostics.

Closes #102.

## 1. Named group/peer markers were reported (#102)

`group/menu-item` / `peer/menu-button` bind a variant to **one specific** ancestor or sibling. The marker emits no CSS of its own — the CSS lives in the consumer, whose selector hard-codes it:

```css
.group-hover\/menu-item\:underline:is(:where(.group\/menu-item):hover *) { … }
```

A class selector matches whole tokens, so bare `group` does **not** satisfy `:where(.group\/menu-item)`: the named marker is required markup. The exact validation added in #95 asked "does this compile?" and got the honest answer "nothing", so every named marker in a shadcn/ui sidebar became a diagnostic.

**Not report-only.** For short names the quick-fix rewrote `peer/a` → `peer`, silently dropping the name and leaving every `peer-*/a:` consumer matching nothing.

Regression bisects to a single commit: `git log --oneline v1.4.0..v1.5.0` returns only 3238d86 (#95). In 1.4.0 the loop exited on `validity === 'valid'`, and `classValidity('peer/menu-button')` is `'valid'`.

### The fix

`cache.isMarkerClass` — derived, not listed: a precomputed, non-component class emitting **zero** declarations, which across every fixture resolves to exactly `group` and `peer` (2 of ~23.6k classes). Self-prunes if Tailwind drops the variants, self-extends if a new CSS-less marker appears, and excludes `@container/main` for free because that one has declarations.

- Splits at the **first** slash: a consumer's arbitrary modifier can reference names the bare syntax cannot spell (`group/*`, `group/a/b`, `peer//x`), and Tailwind never checks that a marker name exists. Only the **empty** name is rejected — `peer/` really does compile to nothing.
- Consulted in the pre-pass and again **after** the `missing-prefix` branch: under `prefix(tw)` the marker Tailwind wants **is** `tw:group/menu-item`, so an unprefixed one is genuinely dead CSS and stays reported. There is a test pinning exactly that, so the exemption can't later be "simplified" into an early blanket skip.
- Nothing is seeded into `validClasses`: the `/name` is unbounded, `parseCandidate('peer/menu-button')` returns `[]`, and it would feed the Levenshtein scan unbounded user strings.

## 2. The component-class scan harvested non-selectors (breaking-ish)

Auditing the first bug turned this up. `extractComponentClasses` regexed whole files, so it picked up identifiers from Tailwind's own preflight **comments** (`mozilla`, `org`, `com`, `cgi`, `chromium`, `webkit`, `css` — all from URLs) and from **declaration values** (`padding: 0.5rem` → `5rem`, `0.25rem` → `25rem`).

Everything it returns reaches `validitySet`, so **every project using this plugin has been accepting `com`, `org`, `css` and `5rem` as valid Tailwind classes.** Those nine now report like any other unknown class — a run that passes today can newly fail, which is the point.

It reads selectors only: a selector is the text between the last `{`, `}` or `;` and the next `{`, so scanning what precedes a `{` skips declaration bodies by construction; comments and strings are stepped over; requiring a CSS identifier start covers a decimal in an at-rule prelude.

**Statement at-rules are the deliberate exception.** The class named by `@custom-variant sidebar-open (&:where(.sidebar-open *))` is load-bearing the same way `group`/`peer` are, so a prelude starting with `@` is scanned before its `;` discards it — caught while verifying the fix, since the naive version would have regressed it.

Also: `[class~="…"]` references are interned in a `Set`. Typography names `not-prose` from ~230 selectors and stored one entry per occurrence.

## Dependencies

The catalog had bumped `oxlint` to `^1.76.0` while leaving `@oxlint/plugins` on `^1.74.0`, leaving the lock inconsistent — root workspace on 1.76, the package and its test runner on 1.74 — which would have failed CI's `--frozen-lockfile`. Aligned and reinstalled. The suite was run green on 1.76 **before** any code change, so the bump is isolated from the fixes.

## Verification

- `pnpm lint && pnpm format:check && pnpm typecheck && pnpm build && pnpm test && pnpm pack` — all green. **1709 tests, up from 1661.**
- `pnpm bench` green (the benchmark mirrors the precompute snippet; mirrored there too).
- Tests were written first and confirmed red (22 failures) before either fix.
- Empirical sweep over the regenerated cache artifacts: **0 with noise, 0 with duplicates**, the derived marker set still exactly `{group, peer}`, and `sidebar-open` preserved.
- Canaries left untouched and still green: `precomputed-snapshot.test.ts` (`toEqual(['group','peer'])`) and `enforce-sort-order.test.ts` (null order for markers — this touches validity, not `orderMap`).

Docs updated in EN and ES (`_extras` + regenerated pages), plus `CLAUDE.md`.

## Known limitation, deliberately out of scope

A class referenced only by an arbitrary variant (`in-[.sidebar]:flex` with `sidebar` in the markup) is still reported. It is a real false positive but **not** a regression — 1.4.0 behaved the same — and covering it means reading classes out of arbitrary variant selectors. `allowlist` / `ignorePrefixes` cover it. Separate issue if it comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXt4qAfQNm6Szwc8st5Tfi