### PR TITLE
fix: multiline block convention in the formatting rules (#109, #110, #111)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,7 +409,21 @@ AST visitors: `JSXAttribute`, `CallExpression`, `TaggedTemplateExpression`, `Var
 - **Multiline-safe class string rebuilding**: rules use `splitClassesWithSeparators` +
   `rebuildClassString` from `class-splitter.ts` to preserve `\n` + indent introduced by
   `enforce-consistent-line-wrapping`. The matrix test in
-  `tests/integration/multiline-preservation.test.ts` locks behavior down per rule.
+  `tests/integration/multiline-preservation.test.ts` locks behavior down per rule. Count-changing
+  fixers (`no-duplicate-classes`, `enforce-shorthand`) pass a `sourceIndices` array to
+  `rebuildClassString` so it recovers each output class's original separator (`pickSeparator`) and
+  keeps the block's per-line grouping instead of reflowing to one class per line; the legacy
+  no-mapping degrade branch survives as a fallback.
+- **`enforce-consistent-line-wrapping` block convention (#109/#110/#111)**: `printWidth` measures
+  the **longest individual line** of the class string (not the raw total — a multiline template's
+  raw value includes every `\n`+indent, which made wrapping unsatisfiable). `classesPerLine` counts
+  classes **per line**, not the flat total. Its `classesPerLine` autofix wraps into the **block
+  convention** (leading `\n`, one-level-deeper interior indent, trailing `\n` + base indent) and is
+  **non-destructive** (only over-budget lines are re-wrapped; conforming lines stay verbatim). The
+  base indent is derived from the source line via `safeSourceCode(context)` (`utils/context.ts`) —
+  the first rule to read `context.sourceCode`; `node.loc.start.column` is the backtick column, NOT
+  the base indent. `no-unnecessary-whitespace` must preserve the block's indented closing backtick
+  (`\n` + whitespace-only last line) or the two rules re-enter the #14 cycle.
 - **Worker services lifecycle**: `sort-service.ts` and `canonicalize-service.ts` are thin wrappers
   around `DesignSystemWorker<Req, Res>` (in `design-system/ds-worker.ts`). The class owns the
   SharedArrayBuffer + Atomics protocol, lifecycle (`worker.unref()` so the process can exit), and a

--- a/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
@@ -8,10 +8,13 @@ una sola línea debería cargar. Dos triggers independientes: un print width bas
 DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string
 crudo de clases y no le importa qué significan.
 
-El path de autofix preserva la indentación del nodo host — al partir un template literal en varias
-líneas, la regla inserta `\n` + el offset de columna del backtick de apertura. Las otras reglas
-(`no-unnecessary-whitespace`, `enforce-sort-order`, …) están al tanto de esta forma multilínea y no
-la colapsan de vuelta.
+El autofix envuelve los template literals en la **convención bloque**: el contenido empieza en su
+propia línea, cada línea envuelta se indenta un nivel por debajo de la indentación del statement, y
+el backtick de cierre queda en su propia línea. La indentación base se lee de la línea de código (no
+de la columna del backtick), así que el bloque anida bien incluso dentro de JSX muy indentado. El
+fix es **no destructivo** — un template que ya está envuelto solo re-envuelve sus líneas que exceden
+el budget; las líneas conformes quedan intactas. Las otras reglas (`no-unnecessary-whitespace`,
+`enforce-sort-order`, …) están al tanto de esta forma multilínea y no la colapsan de vuelta.
 
 ## Opciones
 
@@ -19,9 +22,12 @@ la colapsan de vuelta.
 
 `number`, default `80`.
 
-Largo total máximo del string de clases. Cuando se excede, la regla reporta `tooLong` pero **no**
-autofixea — partir un string largo en un literal multilínea es una decisión de criterio (extraer un
-componente vs. solo wrappearlo), así que la regla saca el warning y te deja decidir.
+Largo máximo de cualquier **línea individual** del string de clases. Para un string de una línea es
+su largo completo; para un template multilínea es la línea individual más larga, así que partir un
+string largo en varias líneas sí puede satisfacer la regla. Cuando se excede, la regla reporta
+`tooLong` pero **no** autofixea — partir un string largo en un literal multilínea es una decisión de
+criterio (extraer un componente vs. solo wrappearlo), así que la regla saca el warning y te deja
+decidir.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
@@ -32,9 +38,9 @@ componente vs. solo wrappearlo), así que la regla saca el warning y te deja dec
 `number`, opcional. Sin default.
 
 Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un template literal
-(`` `…` ``), la regla autofixea partiendo las clases en chunks de `classesPerLine` separados por
-`\n` + indent. Dentro de string literals (`"…"`) la regla reporta `tooManyPerLine` pero no autofixea
-— los string literals no pueden cruzar líneas con seguridad sin intervención manual.
+(`` `…` ``), la regla autofixea envolviendo las clases en la convención bloque, en chunks de
+`classesPerLine` por línea. Dentro de string literals (`"…"`) la regla reporta `tooManyPerLine` pero
+no autofixea — los string literals no pueden cruzar líneas con seguridad sin intervención manual.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -49,9 +55,12 @@ Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un tem
 <div className="flex items-center justify-between p-4 m-2 bg-white text-black rounded shadow-lg border w-full" />
 //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tooLong
 
-// 6 clases con classesPerLine: 3 — el template literal autofixea
+// 6 clases con classesPerLine: 3 — el template literal autofixea a un bloque
 const className = `flex items-center justify-between p-4 m-2 bg-white`
-// → `flex items-center justify-between\n        p-4 m-2 bg-white`
+// → const className = `
+//     flex items-center justify-between
+//     p-4 m-2 bg-white
+//   `
 
 // Mismo conteo, string literal — reporta pero no autofixea
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
@@ -63,9 +72,11 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 // Cabe dentro del printWidth
 <div className="flex items-center p-4" />
 
-// Ya wrappeado al classesPerLine
-const className = `flex items-center p-4
-                   bg-white text-black`
+// Ya wrappeado al classesPerLine (convención bloque)
+const className = `
+  flex items-center p-4
+  bg-white text-black
+`
 ```
 
 ## Interacciones con otras reglas

--- a/packages/docs/es/rules/_extras/no-unnecessary-whitespace.md
+++ b/packages/docs/es/rules/_extras/no-unnecessary-whitespace.md
@@ -9,8 +9,10 @@ whitespace.
 
 La regla es **multiline-aware**: a propósito preserva `\n` + la indentación que sigue a cada
 newline. Ese es el formato que produce `enforce-consistent-line-wrapping` con `classesPerLine`, y
-colapsarlo de vuelta armaría un ciclo no fixeable entre las dos reglas (issue #14). Dentro de una
-línea, tabs y dobles espacios siguen colapsando normalmente.
+colapsarlo de vuelta armaría un ciclo no fixeable entre las dos reglas (issue #14). Esto incluye el
+backtick de cierre indentado de la convención bloque (un `\n` + espacios antes del `` ` `` de
+cierre) — esa indentación trailing es formato intencional y nunca se trimea (issue #109). Dentro de
+una línea, tabs y dobles espacios siguen colapsando normalmente.
 
 Los template literals tienen una regla extra: un único espacio trailing antes de una expresión
 (`` `flex ${x}` ``) o un único espacio leading después de una (`` `${x} flex` ``) se preserva — esos
@@ -52,6 +54,12 @@ const className = `flex\titems-center`
 // Multilínea (e.g. de enforce-consistent-line-wrapping): preservado
 const className = `bg-red-500 text-white
                    hover:bg-red-600 focus:ring-2`
+
+// Convención bloque: el backtick de cierre indentado se preserva (#109)
+const className = `
+  bg-red-500 text-white
+  hover:bg-red-600 focus:ring-2
+`
 ```
 
 ## Interacciones con otras reglas

--- a/packages/docs/es/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/enforce-consistent-line-wrapping.md
@@ -12,10 +12,13 @@ una sola línea debería cargar. Dos triggers independientes: un print width bas
 DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string
 crudo de clases y no le importa qué significan.
 
-El path de autofix preserva la indentación del nodo host — al partir un template literal en varias
-líneas, la regla inserta `\n` + el offset de columna del backtick de apertura. Las otras reglas
-(`no-unnecessary-whitespace`, `enforce-sort-order`, …) están al tanto de esta forma multilínea y no
-la colapsan de vuelta.
+El autofix envuelve los template literals en la **convención bloque**: el contenido empieza en su
+propia línea, cada línea envuelta se indenta un nivel por debajo de la indentación del statement, y
+el backtick de cierre queda en su propia línea. La indentación base se lee de la línea de código (no
+de la columna del backtick), así que el bloque anida bien incluso dentro de JSX muy indentado. El
+fix es **no destructivo** — un template que ya está envuelto solo re-envuelve sus líneas que exceden
+el budget; las líneas conformes quedan intactas. Las otras reglas (`no-unnecessary-whitespace`,
+`enforce-sort-order`, …) están al tanto de esta forma multilínea y no la colapsan de vuelta.
 
 ## Opciones
 
@@ -23,9 +26,12 @@ la colapsan de vuelta.
 
 `number`, default `80`.
 
-Largo total máximo del string de clases. Cuando se excede, la regla reporta `tooLong` pero **no**
-autofixea — partir un string largo en un literal multilínea es una decisión de criterio (extraer un
-componente vs. solo wrappearlo), así que la regla saca el warning y te deja decidir.
+Largo máximo de cualquier **línea individual** del string de clases. Para un string de una línea es
+su largo completo; para un template multilínea es la línea individual más larga, así que partir un
+string largo en varias líneas sí puede satisfacer la regla. Cuando se excede, la regla reporta
+`tooLong` pero **no** autofixea — partir un string largo en un literal multilínea es una decisión de
+criterio (extraer un componente vs. solo wrappearlo), así que la regla saca el warning y te deja
+decidir.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
@@ -36,9 +42,9 @@ componente vs. solo wrappearlo), así que la regla saca el warning y te deja dec
 `number`, opcional. Sin default.
 
 Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un template literal
-(`` `…` ``), la regla autofixea partiendo las clases en chunks de `classesPerLine` separados por
-`\n` + indent. Dentro de string literals (`"…"`) la regla reporta `tooManyPerLine` pero no autofixea
-— los string literals no pueden cruzar líneas con seguridad sin intervención manual.
+(`` `…` ``), la regla autofixea envolviendo las clases en la convención bloque, en chunks de
+`classesPerLine` por línea. Dentro de string literals (`"…"`) la regla reporta `tooManyPerLine` pero
+no autofixea — los string literals no pueden cruzar líneas con seguridad sin intervención manual.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -53,9 +59,12 @@ Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un tem
 <div className="flex items-center justify-between p-4 m-2 bg-white text-black rounded shadow-lg border w-full" />
 //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tooLong
 
-// 6 clases con classesPerLine: 3 — el template literal autofixea
+// 6 clases con classesPerLine: 3 — el template literal autofixea a un bloque
 const className = `flex items-center justify-between p-4 m-2 bg-white`
-// → `flex items-center justify-between\n        p-4 m-2 bg-white`
+// → const className = `
+//     flex items-center justify-between
+//     p-4 m-2 bg-white
+//   `
 
 // Mismo conteo, string literal — reporta pero no autofixea
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
@@ -67,9 +76,11 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 // Cabe dentro del printWidth
 <div className="flex items-center p-4" />
 
-// Ya wrappeado al classesPerLine
-const className = `flex items-center p-4
-                   bg-white text-black`
+// Ya wrappeado al classesPerLine (convención bloque)
+const className = `
+  flex items-center p-4
+  bg-white text-black
+`
 ```
 
 ## Interacciones con otras reglas

--- a/packages/docs/es/rules/no-unnecessary-whitespace.md
+++ b/packages/docs/es/rules/no-unnecessary-whitespace.md
@@ -13,8 +13,10 @@ whitespace.
 
 La regla es **multiline-aware**: a propósito preserva `\n` + la indentación que sigue a cada
 newline. Ese es el formato que produce `enforce-consistent-line-wrapping` con `classesPerLine`, y
-colapsarlo de vuelta armaría un ciclo no fixeable entre las dos reglas (issue #14). Dentro de una
-línea, tabs y dobles espacios siguen colapsando normalmente.
+colapsarlo de vuelta armaría un ciclo no fixeable entre las dos reglas (issue #14). Esto incluye el
+backtick de cierre indentado de la convención bloque (un `\n` + espacios antes del `` ` `` de
+cierre) — esa indentación trailing es formato intencional y nunca se trimea (issue #109). Dentro de
+una línea, tabs y dobles espacios siguen colapsando normalmente.
 
 Los template literals tienen una regla extra: un único espacio trailing antes de una expresión
 (`` `flex ${x}` ``) o un único espacio leading después de una (`` `${x} flex` ``) se preserva — esos
@@ -56,6 +58,12 @@ const className = `flex\titems-center`
 // Multilínea (e.g. de enforce-consistent-line-wrapping): preservado
 const className = `bg-red-500 text-white
                    hover:bg-red-600 focus:ring-2`
+
+// Convención bloque: el backtick de cierre indentado se preserva (#109)
+const className = `
+  bg-red-500 text-white
+  hover:bg-red-600 focus:ring-2
+`
 ```
 
 ## Interacciones con otras reglas

--- a/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
@@ -8,10 +8,13 @@ per line (autofix on template literals).
 DS-independent — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
 string and doesn't care what the classes mean.
 
-The autofix path preserves the indentation of the host node — when splitting a template literal
-across lines, the rule inserts `\n` + the column offset of the opening backtick. Other rules
-(`no-unnecessary-whitespace`, `enforce-sort-order`, …) are aware of this multiline shape and won't
-collapse it back.
+The autofix wraps template literals into the **block convention**: the content starts on its own
+line, each wrapped line is indented one level below the statement's own indentation, and the closing
+backtick sits on its own line. The base indentation is read from the source line (not the backtick
+column), so the block nests correctly even inside deeply-indented JSX. The fix is
+**non-destructive** — a template that is already wrapped only has its over-budget lines re-wrapped;
+conforming lines are left untouched. Other rules (`no-unnecessary-whitespace`, `enforce-sort-order`,
+…) are aware of this multiline shape and won't collapse it back.
 
 ## Options
 
@@ -19,9 +22,11 @@ collapse it back.
 
 `number`, default `80`.
 
-Maximum total length of the class string. When exceeded, the rule reports `tooLong` but does **not**
-autofix — splitting a long string into a multiline literal is a judgment call (extract a component
-vs. just wrap it), so the rule surfaces the warning and lets you decide.
+Maximum length of any **single line** of the class string. For a one-line string that is its whole
+length; for a multiline template it is the longest individual line, so splitting a long string
+across lines can actually satisfy the rule. When exceeded, the rule reports `tooLong` but does
+**not** autofix — splitting a long string into a multiline literal is a judgment call (extract a
+component vs. just wrap it), so the rule surfaces the warning and lets you decide.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
@@ -32,8 +37,8 @@ vs. just wrap it), so the rule surfaces the warning and lets you decide.
 `number`, optional. No default.
 
 Maximum number of classes on a single line. When exceeded inside a template literal (`` `…` ``), the
-rule autofixes by splitting the classes into chunks of `classesPerLine` separated by `\n` + indent.
-Inside string literals (`"…"`) the rule reports `tooManyPerLine` but doesn't autofix — string
+rule autofixes by wrapping the classes into the block convention, chunks of `classesPerLine` per
+line. Inside string literals (`"…"`) the rule reports `tooManyPerLine` but doesn't autofix — string
 literals can't safely span lines without manual intervention.
 
 ```jsonc
@@ -49,9 +54,12 @@ literals can't safely span lines without manual intervention.
 <div className="flex items-center justify-between p-4 m-2 bg-white text-black rounded shadow-lg border w-full" />
 //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tooLong
 
-// 6 classes with classesPerLine: 3 — template literal autofixes
+// 6 classes with classesPerLine: 3 — template literal autofixes into a block
 const className = `flex items-center justify-between p-4 m-2 bg-white`
-// → `flex items-center justify-between\n        p-4 m-2 bg-white`
+// → const className = `
+//     flex items-center justify-between
+//     p-4 m-2 bg-white
+//   `
 
 // Same count, string literal — reports but no autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
@@ -63,9 +71,11 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 // Fits within printWidth
 <div className="flex items-center p-4" />
 
-// Already wrapped at classesPerLine
-const className = `flex items-center p-4
-                   bg-white text-black`
+// Already wrapped at classesPerLine (block convention)
+const className = `
+  flex items-center p-4
+  bg-white text-black
+`
 ```
 
 ## Interactions with other rules

--- a/packages/docs/rules/_extras/no-unnecessary-whitespace.md
+++ b/packages/docs/rules/_extras/no-unnecessary-whitespace.md
@@ -8,7 +8,9 @@ DS-independent — works without `settings.tailwindcss.entryPoint`. Pure whitesp
 
 The rule is **multiline-aware**: it deliberately preserves `\n` + the indentation that follows each
 newline. That's the format `enforce-consistent-line-wrapping` produces with `classesPerLine`, and
-collapsing it back would set up an unfixable cycle between the two rules (issue #14). Inside one
+collapsing it back would set up an unfixable cycle between the two rules (issue #14). This includes
+the indented closing backtick of the block convention (a `\n` + spaces before the closing `` ` ``) —
+that trailing indentation is intentional formatting and is never trimmed (issue #109). Inside one
 line, tabs and double spaces still collapse normally.
 
 Template literals get one extra rule: a single trailing space before an expression
@@ -51,6 +53,12 @@ const className = `flex\titems-center`
 // Multiline (e.g. from enforce-consistent-line-wrapping): preserved
 const className = `bg-red-500 text-white
                    hover:bg-red-600 focus:ring-2`
+
+// Block convention: the indented closing backtick is preserved (#109)
+const className = `
+  bg-red-500 text-white
+  hover:bg-red-600 focus:ring-2
+`
 ```
 
 ## Interactions with other rules

--- a/packages/docs/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/enforce-consistent-line-wrapping.md
@@ -12,10 +12,13 @@ per line (autofix on template literals).
 DS-independent — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
 string and doesn't care what the classes mean.
 
-The autofix path preserves the indentation of the host node — when splitting a template literal
-across lines, the rule inserts `\n` + the column offset of the opening backtick. Other rules
-(`no-unnecessary-whitespace`, `enforce-sort-order`, …) are aware of this multiline shape and won't
-collapse it back.
+The autofix wraps template literals into the **block convention**: the content starts on its own
+line, each wrapped line is indented one level below the statement's own indentation, and the closing
+backtick sits on its own line. The base indentation is read from the source line (not the backtick
+column), so the block nests correctly even inside deeply-indented JSX. The fix is
+**non-destructive** — a template that is already wrapped only has its over-budget lines re-wrapped;
+conforming lines are left untouched. Other rules (`no-unnecessary-whitespace`, `enforce-sort-order`,
+…) are aware of this multiline shape and won't collapse it back.
 
 ## Options
 
@@ -23,9 +26,11 @@ collapse it back.
 
 `number`, default `80`.
 
-Maximum total length of the class string. When exceeded, the rule reports `tooLong` but does **not**
-autofix — splitting a long string into a multiline literal is a judgment call (extract a component
-vs. just wrap it), so the rule surfaces the warning and lets you decide.
+Maximum length of any **single line** of the class string. For a one-line string that is its whole
+length; for a multiline template it is the longest individual line, so splitting a long string
+across lines can actually satisfy the rule. When exceeded, the rule reports `tooLong` but does
+**not** autofix — splitting a long string into a multiline literal is a judgment call (extract a
+component vs. just wrap it), so the rule surfaces the warning and lets you decide.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
@@ -36,8 +41,8 @@ vs. just wrap it), so the rule surfaces the warning and lets you decide.
 `number`, optional. No default.
 
 Maximum number of classes on a single line. When exceeded inside a template literal (`` `…` ``), the
-rule autofixes by splitting the classes into chunks of `classesPerLine` separated by `\n` + indent.
-Inside string literals (`"…"`) the rule reports `tooManyPerLine` but doesn't autofix — string
+rule autofixes by wrapping the classes into the block convention, chunks of `classesPerLine` per
+line. Inside string literals (`"…"`) the rule reports `tooManyPerLine` but doesn't autofix — string
 literals can't safely span lines without manual intervention.
 
 ```jsonc
@@ -53,9 +58,12 @@ literals can't safely span lines without manual intervention.
 <div className="flex items-center justify-between p-4 m-2 bg-white text-black rounded shadow-lg border w-full" />
 //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tooLong
 
-// 6 classes with classesPerLine: 3 — template literal autofixes
+// 6 classes with classesPerLine: 3 — template literal autofixes into a block
 const className = `flex items-center justify-between p-4 m-2 bg-white`
-// → `flex items-center justify-between\n        p-4 m-2 bg-white`
+// → const className = `
+//     flex items-center justify-between
+//     p-4 m-2 bg-white
+//   `
 
 // Same count, string literal — reports but no autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
@@ -67,9 +75,11 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 // Fits within printWidth
 <div className="flex items-center p-4" />
 
-// Already wrapped at classesPerLine
-const className = `flex items-center p-4
-                   bg-white text-black`
+// Already wrapped at classesPerLine (block convention)
+const className = `
+  flex items-center p-4
+  bg-white text-black
+`
 ```
 
 ## Interactions with other rules

--- a/packages/docs/rules/no-unnecessary-whitespace.md
+++ b/packages/docs/rules/no-unnecessary-whitespace.md
@@ -12,7 +12,9 @@ DS-independent — works without `settings.tailwindcss.entryPoint`. Pure whitesp
 
 The rule is **multiline-aware**: it deliberately preserves `\n` + the indentation that follows each
 newline. That's the format `enforce-consistent-line-wrapping` produces with `classesPerLine`, and
-collapsing it back would set up an unfixable cycle between the two rules (issue #14). Inside one
+collapsing it back would set up an unfixable cycle between the two rules (issue #14). This includes
+the indented closing backtick of the block convention (a `\n` + spaces before the closing `` ` ``) —
+that trailing indentation is intentional formatting and is never trimmed (issue #109). Inside one
 line, tabs and double spaces still collapse normally.
 
 Template literals get one extra rule: a single trailing space before an expression
@@ -55,6 +57,12 @@ const className = `flex\titems-center`
 // Multiline (e.g. from enforce-consistent-line-wrapping): preserved
 const className = `bg-red-500 text-white
                    hover:bg-red-600 focus:ring-2`
+
+// Block convention: the indented closing backtick is preserved (#109)
+const className = `
+  bg-red-500 text-white
+  hover:bg-red-600 focus:ring-2
+`
 ```
 
 ## Interactions with other rules

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## 1.8.0
+
+Three issues ([#109](https://github.com/sergioazoc/oxlint-tailwindcss/issues/109),
+[#110](https://github.com/sergioazoc/oxlint-tailwindcss/issues/110),
+[#111](https://github.com/sergioazoc/oxlint-tailwindcss/issues/111)) reported that the two
+formatting rules mishandled the **block convention** for multiline template literals — the common
+shape where the classes start and end on their own lines:
+
+```tsx
+const className = `
+  flex items-center justify-between
+  bg-white rounded-lg shadow-sm
+`
+```
+
+The cause was shared: for a template with no expressions, the raw value between the backticks
+includes the leading `\n`, every line's indentation, and the trailing `\n` + indentation before the
+closing backtick. The rules measured, counted, and trimmed that raw value as if it were a single
+line.
+
+### Bug fixes
+
+- **`enforce-consistent-line-wrapping` `printWidth` now measures the longest line, not the raw
+  total.** The check compared the entire raw string length — every `\n` and indent included —
+  against `printWidth`, so splitting a long string across lines only ever made it longer and could
+  never satisfy the rule (it even flagged its own `classesPerLine` output). It now measures the
+  longest individual line, and reports that length. A one-line string is unchanged (its only line is
+  its whole length). Closes [#110](https://github.com/sergioazoc/oxlint-tailwindcss/issues/110).
+
+- **`enforce-consistent-line-wrapping` `classesPerLine` now counts classes per line.** It counted
+  the flat total across all lines, so an already-correctly-wrapped block (say 3 per line, budget 4)
+  was reported as a false positive. It now checks each line independently. Closes
+  [#111](https://github.com/sergioazoc/oxlint-tailwindcss/issues/111).
+
+- **`no-unnecessary-whitespace` no longer strips the indented closing backtick.** When the closing
+  backtick sat on its own indented line (`\n    ` before the `` ` ``), the trailing-edge trim ate
+  one space of that indentation and reported it as unnecessary whitespace. That trailing indentation
+  is intentional block-convention formatting and is now preserved (a whitespace-only last line is
+  never trimmed); a genuine single-line trailing space is still stripped. Closes
+  [#109](https://github.com/sergioazoc/oxlint-tailwindcss/issues/109).
+
+### Changes
+
+- **The `classesPerLine` autofix now wraps into the block convention.** It previously produced a
+  hanging indent aligned to the opening backtick's column (absurdly deep inside nested JSX, and it
+  fought `printWidth`). It now emits the block shape — content on its own lines, one level of
+  indentation below the statement, closing backtick on its own line — with the base indentation read
+  from the source line so it nests correctly at any depth. The fix is **non-destructive**: a
+  template that is already wrapped only has its over-budget lines re-wrapped; conforming lines are
+  left verbatim.
+
+- **`no-duplicate-classes` and `enforce-shorthand` preserve a block's per-line grouping.** Removing
+  a duplicate or collapsing a shorthand pair changes the class count, which used to reflow a
+  multi-class-per-line block down to one class per line. Those fixers now keep each surviving line's
+  grouping (and transfer a line break forward when the class that opened a line is removed), so only
+  the changed classes move.
+
+The precompute is untouched, so the disk cache stays valid across the upgrade.
+
 ## 1.7.1
 
 `no-unknown-classes` was already asking the design system about the classes it could not enumerate,

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
@@ -1,7 +1,7 @@
 import { defineRule } from '@oxlint/plugins'
 import { createExtractorVisitors, preserveSpaces, type ClassLocation } from '../utils/extractors'
 import { splitClasses } from '../utils/class-splitter'
-import { createLazyOptions } from '../utils/context'
+import { createLazyOptions, safeSourceCode } from '../utils/context'
 
 interface Options {
   printWidth?: number
@@ -9,6 +9,18 @@ interface Options {
 }
 
 const DEFAULT_PRINT_WIDTH = 80
+
+/** One indentation level added below the statement's base indent for wrapped lines. */
+const INDENT_UNIT = '  '
+
+/** Group `classes` into chunks of at most `n`, each chunk space-joined. */
+function chunkList(classes: string[], n: number): string[] {
+  const chunks: string[] = []
+  for (let i = 0; i < classes.length; i += n) {
+    chunks.push(classes.slice(i, i + n).join(' '))
+  }
+  return chunks
+}
 
 export const enforceConsistentLineWrapping = defineRule({
   meta: {
@@ -30,7 +42,7 @@ export const enforceConsistentLineWrapping = defineRule({
     defaultOptions: [{ printWidth: DEFAULT_PRINT_WIDTH }],
     messages: {
       tooLong:
-        'Class string is {{length}} characters long, exceeding the print width of {{printWidth}}. Consider splitting into multiple lines or extracting into a component.',
+        'Class string exceeds the print width of {{printWidth}} (longest line is {{length}} characters). Consider splitting into multiple lines or extracting into a component.',
       tooManyPerLine:
         'Too many classes on a single line ({{count}}). Maximum allowed per line is {{max}}.',
     },
@@ -45,44 +57,101 @@ export const enforceConsistentLineWrapping = defineRule({
       (o) => o?.classesPerLine,
     )
 
+    /**
+     * The statement's real base indentation — the leading whitespace of the
+     * source line the opening backtick sits on. NOT `node.loc.start.column`,
+     * which is the backtick's column (e.g. 18 for `const className = ` and
+     * deeper still inside nested JSX). Falls back to `''` when `sourceCode`
+     * is unavailable (block still lands correctly for top-level statements).
+     */
+    function deriveBaseIndent(loc: ClassLocation): string {
+      const sc = safeSourceCode(context)
+      const line = loc.node.loc?.start.line
+      if (sc?.lines && typeof line === 'number' && line >= 1 && line <= sc.lines.length) {
+        const src = sc.lines[line - 1] ?? ''
+        const m = /^[ \t]*/.exec(src)
+        return m ? m[0] : ''
+      }
+      return ''
+    }
+
+    /**
+     * Re-wrap a template literal's classes into the block convention,
+     * non-destructively:
+     *  - single-line → convert to a `\n` + indent block (unless the quasi is
+     *    glued to a `${}`, in which case keep it inline/hanging so adjacency
+     *    survives);
+     *  - already multiline → re-wrap ONLY the lines that exceed the budget,
+     *    reusing each line's own indent; conforming lines are left verbatim.
+     */
+    function rewrapTemplate(loc: ClassLocation, lines: string[], classesPerLine: number): string {
+      const baseIndent = deriveBaseIndent(loc)
+      const interiorIndent = baseIndent + INDENT_UNIT
+
+      if (lines.length === 1) {
+        const chunks = chunkList(splitClasses(loc.value), classesPerLine)
+        const standalone = !loc.preserveLeadingSpace && !loc.preserveTrailingSpace
+        if (standalone) {
+          return '\n' + chunks.map((c) => interiorIndent + c).join('\n') + '\n' + baseIndent
+        }
+        // Fragment adjacent to a `${}`: hanging join, no leading/trailing newline.
+        return chunks.join('\n' + interiorIndent)
+      }
+
+      return lines
+        .map((line) => {
+          const classes = splitClasses(line)
+          if (classes.length <= classesPerLine) return line
+          const m = /^[ \t]*/.exec(line)
+          const lineIndent = m && m[0].length > 0 ? m[0] : interiorIndent
+          return chunkList(classes, classesPerLine)
+            .map((c) => lineIndent + c)
+            .join('\n')
+        })
+        .join('\n')
+    }
+
     function check(locations: ClassLocation[]) {
       const printWidth = getPrintWidth()
       const classesPerLine = getClassesPerLine()
 
       for (const loc of locations) {
-        if (loc.value.length > printWidth) {
+        // #110: measure the LONGEST INDIVIDUAL LINE, not the raw total. The raw
+        // value of a multiline template includes every `\n` and indent, so
+        // comparing its total length made wrapping impossible to satisfy.
+        let maxLine = 0
+        for (const line of loc.value.split('\n')) {
+          if (line.length > maxLine) maxLine = line.length
+        }
+        if (maxLine > printWidth) {
           context.report({
             node: loc.node,
             messageId: 'tooLong',
             data: {
-              length: String(loc.value.length),
+              length: String(maxLine),
               printWidth: String(printWidth),
             },
           })
         }
 
         if (classesPerLine !== undefined) {
-          const classes = splitClasses(loc.value)
-          if (classes.length > classesPerLine) {
-            const isTemplateLiteral = loc.node.type === 'TemplateElement'
-            if (isTemplateLiteral) {
-              // Autofix: split into chunks of classesPerLine
-              const chunks: string[] = []
-              for (let i = 0; i < classes.length; i += classesPerLine) {
-                chunks.push(classes.slice(i, i + classesPerLine).join(' '))
-              }
-              // Compute base indentation from the node's start column
-              const startCol = loc.node.loc?.start.column ?? 0
-              const indent = ' '.repeat(startCol)
-              const fixedValue = chunks.join('\n' + indent)
+          // #111: count classes PER LINE, not the flat total across all lines —
+          // an already-wrapped block must not be flagged.
+          const lines = loc.value.split('\n')
+          let maxPerLine = 0
+          for (const line of lines) {
+            const n = splitClasses(line).length
+            if (n > maxPerLine) maxPerLine = n
+          }
 
+          if (maxPerLine > classesPerLine) {
+            const data = { count: String(maxPerLine), max: String(classesPerLine) }
+            if (loc.node.type === 'TemplateElement') {
+              const fixedValue = rewrapTemplate(loc, lines, classesPerLine)
               context.report({
                 node: loc.node,
                 messageId: 'tooManyPerLine',
-                data: {
-                  count: String(classes.length),
-                  max: String(classesPerLine),
-                },
+                data,
                 fix(fixer) {
                   return fixer.replaceTextRange(loc.range, preserveSpaces(loc, fixedValue))
                 },
@@ -91,10 +160,7 @@ export const enforceConsistentLineWrapping = defineRule({
               context.report({
                 node: loc.node,
                 messageId: 'tooManyPerLine',
-                data: {
-                  count: String(classes.length),
-                  max: String(classesPerLine),
-                },
+                data,
               })
             }
           }

--- a/packages/oxlint-tailwindcss/src/rules/enforce-shorthand.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-shorthand.ts
@@ -279,10 +279,28 @@ export const enforceShorthand = defineRule({
             const matched = family.parts.map((part) => group.byPart.get(part)!)
             const replacement =
               group.variant + reattachImportant(`${family.to}-${group.value}`, group.position)
-            const remaining = classes.filter((cls) => !matched.includes(cls))
+            // Positional walk: keep the non-matched classes (with their original
+            // index) and append the merged shorthand at the end, tagged with the
+            // pair's first index so `rebuildClassString` preserves the multiline
+            // layout instead of reflowing a block to one class per line.
+            const matchedSet = new Set(matched)
+            const remaining: string[] = []
+            const sourceIndices: number[] = []
+            let firstMatchedIdx = -1
+            classes.forEach((cls, i) => {
+              if (matchedSet.has(cls)) {
+                if (firstMatchedIdx === -1) firstMatchedIdx = i
+                return
+              }
+              remaining.push(cls)
+              sourceIndices.push(i)
+            })
             // `mt-2 mb-2 my-2` already carries the shorthand: appending it again
             // would fix one problem into a duplicate class.
-            if (!remaining.includes(replacement)) remaining.push(replacement)
+            if (!remaining.includes(replacement)) {
+              remaining.push(replacement)
+              sourceIndices.push(firstMatchedIdx)
+            }
             for (const part of family.parts) consumed.add(part)
 
             context.report({
@@ -295,7 +313,7 @@ export const enforceShorthand = defineRule({
               fix(fixer) {
                 return fixer.replaceTextRange(
                   loc.range,
-                  preserveSpaces(loc, rebuildClassString(split, remaining)),
+                  preserveSpaces(loc, rebuildClassString(split, remaining, sourceIndices)),
                 )
               },
             })

--- a/packages/oxlint-tailwindcss/src/rules/no-duplicate-classes.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-duplicate-classes.ts
@@ -31,8 +31,16 @@ export const noDuplicateClasses = defineRule({
         }
 
         if (duplicates.length > 0) {
-          const unique = [...new Set(classes)]
-          const fixed = rebuildClassString(split, unique)
+          // Keep the first occurrence of each class, and remember its original
+          // index so `rebuildClassString` can preserve the multiline layout
+          // (a `\n` that the removed dup carried transfers to the next survivor).
+          const firstIdx = new Map<string, number>()
+          classes.forEach((c, i) => {
+            if (!firstIdx.has(c)) firstIdx.set(c, i)
+          })
+          const unique = [...firstIdx.keys()]
+          const sourceIndices = unique.map((c) => firstIdx.get(c)!)
+          const fixed = rebuildClassString(split, unique, sourceIndices)
 
           for (const dup of duplicates) {
             context.report({

--- a/packages/oxlint-tailwindcss/src/rules/no-unnecessary-whitespace.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-unnecessary-whitespace.ts
@@ -43,7 +43,14 @@ export const noUnnecessaryWhitespace = defineRule({
         if (normalized.startsWith(' ') && !loc.preserveLeadingSpace) {
           normalized = normalized.slice(1)
         }
-        if (normalized.endsWith(' ') && !loc.preserveTrailingSpace) {
+        // The trailing whitespace of an indented closing backtick (`\n    ` before
+        // the `` ` ``) is intentional formatting, not a stray trailing space — never
+        // strip it, or a block-convention template gets one indent space eaten (#109).
+        // Detect it as: the last line (after the final `\n`) is whitespace-only.
+        const lastNl = normalized.lastIndexOf('\n')
+        const trailingIsClosingIndent =
+          lastNl !== -1 && /^[ \t]*$/.test(normalized.slice(lastNl + 1))
+        if (normalized.endsWith(' ') && !loc.preserveTrailingSpace && !trailingIsClosingIndent) {
           normalized = normalized.slice(0, -1)
         }
 

--- a/packages/oxlint-tailwindcss/src/utils/class-splitter.ts
+++ b/packages/oxlint-tailwindcss/src/utils/class-splitter.ts
@@ -124,26 +124,72 @@ export function splitClassesWithSeparators(classString: string): ClassSplit {
 }
 
 /**
+ * The separator to place before an output class whose source class sits at
+ * original index `si`, given the previous output class came from `sPrev`.
+ *
+ * - **forward move** (`si > sPrev`): the classes between them were dropped, so
+ *   the effective separator is the LAST newline-bearing separator in that gap
+ *   (it carries the correct indent), else the separator immediately preceding
+ *   `si`. This transfers a line break forward when the class that opened a line
+ *   is removed, so the next survivor keeps its own line.
+ * - **non-forward move** (append / reorder — e.g. `enforce-shorthand` pushes the
+ *   merged replacement to the end): reuse `si`'s own preceding separator if it
+ *   carries a newline, else a single space — never the (possibly empty) leader,
+ *   so output classes never glue together.
+ */
+function pickSeparator(separators: string[], sPrev: number, si: number): string {
+  if (si > sPrev) {
+    let chosen = separators[si] ?? ' '
+    for (let k = sPrev + 1; k <= si; k++) {
+      if (separators[k]?.includes('\n')) chosen = separators[k]
+    }
+    return chosen
+  }
+  const own = separators[si]
+  return own && own.includes('\n') ? own : ' '
+}
+
+/**
  * Reconstruct a class string from a `ClassSplit` and a (possibly transformed)
  * array of classes.
  *
- * - If `newClasses.length === split.classes.length` (1-to-1 transformation:
- *   canonicalize, sort, variant-order, etc.) every separator is preserved
- *   verbatim. This keeps multiline indentation intact.
- * - If lengths differ (shorthand collapses pairs, no-duplicate removes dupes)
- *   the helper degrades gracefully: leading and trailing whitespace are
- *   preserved; classes are joined by the first internal separator that
- *   contains a newline, or a single space if none does.
+ * - If `newClasses.length === split.classes.length` and no `sourceIndices` are
+ *   given (1-to-1 transformation: canonicalize, sort, variant-order, etc.)
+ *   every separator is preserved verbatim. This keeps multiline indentation
+ *   intact.
+ * - If `sourceIndices` is given (count-changing transforms that know where each
+ *   output class came from: no-duplicate removes dupes, shorthand collapses
+ *   pairs) the layout is preserved structurally — leader and trailing stay
+ *   verbatim (edge-safe) and each interior separator is recovered from the
+ *   source via `pickSeparator`, so a multiline block keeps its per-line grouping
+ *   instead of reflowing to one class per line.
+ * - Otherwise (count differs, no mapping) it degrades gracefully: leading and
+ *   trailing whitespace are preserved; classes are joined by the first internal
+ *   separator that contains a newline, or a single space if none does.
  */
-export function rebuildClassString(split: ClassSplit, newClasses: string[]): string {
+export function rebuildClassString(
+  split: ClassSplit,
+  newClasses: string[],
+  sourceIndices?: number[],
+): string {
   const { classes, separators } = split
-  if (newClasses.length === classes.length) {
+
+  if (!sourceIndices && newClasses.length === classes.length) {
     let result = separators[0]
     for (let i = 0; i < newClasses.length; i++) {
       result += newClasses[i] + separators[i + 1]
     }
     return result
   }
+
+  if (sourceIndices && sourceIndices.length === newClasses.length && newClasses.length > 0) {
+    let result = separators[0] + newClasses[0]
+    for (let i = 1; i < newClasses.length; i++) {
+      result += pickSeparator(separators, sourceIndices[i - 1], sourceIndices[i]) + newClasses[i]
+    }
+    return result + separators[separators.length - 1]
+  }
+
   const internal = separators.slice(1, -1)
   const join = internal.find((s) => s.includes('\n')) ?? ' '
   return separators[0] + newClasses.join(join) + separators[separators.length - 1]

--- a/packages/oxlint-tailwindcss/src/utils/context.ts
+++ b/packages/oxlint-tailwindcss/src/utils/context.ts
@@ -12,11 +12,18 @@
  * tree-shaking and makes the module boundary honest.
  */
 
+/** The slice of oxlint's `context.sourceCode` we consume (line-indexed text). */
+export interface SourceCodeLike {
+  lines?: readonly string[]
+  text?: string
+}
+
 interface ContextLike {
   options?: readonly unknown[]
   settings?: Readonly<Record<string, unknown>>
   filename?: string
   cwd?: string
+  sourceCode?: SourceCodeLike
 }
 
 /**
@@ -47,6 +54,23 @@ export function safeSettings(context: ContextLike): Readonly<Record<string, unkn
 export function safeFilename(context: ContextLike): string | undefined {
   try {
     return context.filename ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Safely read `context.sourceCode`. Same try/catch pattern as the other
+ * accessors (the getter may throw inside `createOnce`). Used by
+ * `enforce-consistent-line-wrapping` to derive a statement's real base
+ * indentation (the line's leading whitespace) when wrapping a single-line
+ * template into the block convention — the backtick column
+ * (`node.loc.start.column`) is NOT the base indent. Returns `undefined` if
+ * unavailable; callers fall back to a zero base indent.
+ */
+export function safeSourceCode(context: ContextLike): SourceCodeLike | undefined {
+  try {
+    return context.sourceCode ?? undefined
   } catch {
     return undefined
   }

--- a/packages/oxlint-tailwindcss/tests/integration/multiline-preservation.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/multiline-preservation.test.ts
@@ -9,9 +9,11 @@
  *
  * The fix: those rules now use `splitClassesWithSeparators` + `rebuildClassString`
  * from `class-splitter.ts`, which preserves separators verbatim for 1-to-1
- * transformations and degrades gracefully for length-changing ones (shorthand,
- * no-duplicate). This test pins down that property for every migrated rule:
- * given a multiline input, the autofix MUST keep the `\n` + indent intact.
+ * transformations and preserves the per-line structure for length-changing ones
+ * (shorthand, no-duplicate) via a `sourceIndices` map — so a block keeps its
+ * grouping instead of reflowing to one class per line. This test pins down that
+ * property for every migrated rule: given a multiline input, the autofix MUST
+ * keep the `\n` + indent intact and NOT collapse the block.
  */
 
 import { resolve } from 'node:path'
@@ -158,16 +160,17 @@ describe('multiline preservation under default theme', () => {
     ],
   })
 
-  // Length-shrinking — degrades gracefully to multiline join.
+  // Length-shrinking — preserves the block structure (the surviving line keeps
+  // its multi-class grouping; the merged shorthand lands at the end per the
+  // rule's filter+push order). NOT collapsed to one class per line.
   run('enforce-shorthand keeps multiline', enforceShorthand, {
     valid: [],
     invalid: [
       {
-        code: `const className = \`pl-2 pr-2${NL}text-white\``,
+        code: 'const className = `\n  flex mt-2 mb-2\n  bg-white p-4 text-black\n`',
         filename: 'a.tsx',
         errors: [{ messageId: 'shorthand' }],
-        // 3→2: rebuildClassString picks the newline+indent separator for the join.
-        output: `const className = \`text-white${NL}px-2\``,
+        output: 'const className = `\n  flex\n  bg-white p-4 text-black my-2\n`',
       },
     ],
   })
@@ -185,15 +188,16 @@ describe('multiline preservation under default theme', () => {
     ],
   })
 
-  // Length-shrinking — must preserve the surviving newline.
+  // Length-shrinking — removes the dup, keeps each line's grouping. The `\n`
+  // that the removed dup did NOT carry stays put; line 1 keeps two classes.
   run('no-duplicate-classes keeps multiline', noDuplicateClasses, {
     valid: [],
     invalid: [
       {
-        code: `const className = \`flex flex${NL}p-4\``,
+        code: 'const className = `\n  flex flex items-center\n  bg-white p-4\n`',
         filename: 'a.tsx',
         errors: [{ messageId: 'duplicate' }],
-        output: `const className = \`flex${NL}p-4\``,
+        output: 'const className = `\n  flex items-center\n  bg-white p-4\n`',
       },
     ],
   })

--- a/packages/oxlint-tailwindcss/tests/integration/whitespace-line-wrap-cycle.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/whitespace-line-wrap-cycle.test.ts
@@ -4,16 +4,17 @@
  * an unfixable autofix cycle when both were enabled and `classesPerLine` was
  * configured.
  *
- *   1. line-wrapping splits a long template literal into chunks separated by
- *      `\n` + indent.
+ *   1. line-wrapping splits a long template literal into the block convention
+ *      (`\n` + indent … trailing `\n` + indent).
  *   2. no-unnecessary-whitespace was using `\s+` and collapsed those newlines
  *      back to single spaces.
  *   3. line-wrapping splits again. Loop.
  *
  * The fix changes `no-unnecessary-whitespace` to collapse only horizontal
  * whitespace (spaces and tabs), leaving newlines + their following indent
- * verbatim. This file pins down the convergence:
- *   - line-wrapping fix produces a multiline string.
+ * verbatim — including the indented closing backtick (#109). This file pins
+ * down the convergence:
+ *   - line-wrapping fix produces a block-convention multiline string.
  *   - no-unnecessary-whitespace, run on that exact output, reports nothing.
  */
 
@@ -23,7 +24,7 @@ import { noUnnecessaryWhitespace } from '../../src/rules/no-unnecessary-whitespa
 import { enforceConsistentLineWrapping } from '../../src/rules/enforce-consistent-line-wrapping'
 
 describe('issue #14 — whitespace × line-wrapping no longer cycle', () => {
-  // Step 1: line-wrapping wraps a too-many-classes template literal.
+  // Step 1: line-wrapping wraps a too-many-classes template literal into a block.
   new RuleTester().run('step 1: line-wrapping autofix', enforceConsistentLineWrapping, {
     valid: [],
     invalid: [
@@ -33,12 +34,12 @@ describe('issue #14 — whitespace × line-wrapping no longer cycle', () => {
         options: [{ printWidth: 200, classesPerLine: 3 }],
         errors: [{ messageId: 'tooManyPerLine' }],
         output:
-          'const className = `bg-red-500 text-white hover:bg-red-600\n                  focus:ring-2 focus:ring-red-500 disabled:bg-gray-300`',
+          'const className = `\n  bg-red-500 text-white hover:bg-red-600\n  focus:ring-2 focus:ring-red-500 disabled:bg-gray-300\n`',
       },
     ],
   })
 
-  // Step 2: no-unnecessary-whitespace, fed the multiline output above, must NOT report.
+  // Step 2: no-unnecessary-whitespace, fed the block output above, must NOT report.
   // (Before the fix, it would collapse the newline back to a space, restarting the loop.)
   new RuleTester().run(
     'step 2: whitespace stays silent on wrapped output',
@@ -46,7 +47,39 @@ describe('issue #14 — whitespace × line-wrapping no longer cycle', () => {
     {
       valid: [
         {
-          code: 'const className = `bg-red-500 text-white hover:bg-red-600\n                  focus:ring-2 focus:ring-red-500 disabled:bg-gray-300`',
+          code: 'const className = `\n  bg-red-500 text-white hover:bg-red-600\n  focus:ring-2 focus:ring-red-500 disabled:bg-gray-300\n`',
+          filename: 'a.tsx',
+        },
+      ],
+      invalid: [],
+    },
+  )
+
+  // Step 3: nested JSX — the block's base indent is derived from the source line,
+  // so the closing backtick sits on its own INDENTED line (`\n  ` before `` ` ``).
+  new RuleTester().run('step 3: nested line-wrapping autofix', enforceConsistentLineWrapping, {
+    valid: [],
+    invalid: [
+      {
+        code: 'function C() {\n  return <div className={`bg-red-500 text-white hover:bg-red-600 focus:ring-2`} />\n}',
+        filename: 'a.tsx',
+        options: [{ printWidth: 200, classesPerLine: 3 }],
+        errors: [{ messageId: 'tooManyPerLine' }],
+        output:
+          'function C() {\n  return <div className={`\n    bg-red-500 text-white hover:bg-red-600\n    focus:ring-2\n  `} />\n}',
+      },
+    ],
+  })
+
+  // Step 4: whitespace stays silent on the nested block output — this is the case
+  // #109 fixes: the indented closing backtick (`\n  ` before `` ` ``) must survive.
+  new RuleTester().run(
+    'step 4: whitespace stays silent on nested wrapped output',
+    noUnnecessaryWhitespace,
+    {
+      valid: [
+        {
+          code: 'function C() {\n  return <div className={`\n    bg-red-500 text-white hover:bg-red-600\n    focus:ring-2\n  `} />\n}',
           filename: 'a.tsx',
         },
       ],

--- a/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
@@ -79,3 +79,78 @@ ruleTester.run('enforce-consistent-line-wrapping (classesPerLine)', enforceConsi
     },
   ],
 })
+
+// #110 — printWidth is measured against the LONGEST LINE, not the raw total.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (#110 longest line)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [
+      // Already split: no single line exceeds 80 even though the raw total does.
+      {
+        code: 'const className = `\n  flex items-center justify-between p-4\n  m-2 bg-white text-black rounded shadow-lg\n`',
+        filename: 'test.tsx',
+      },
+    ],
+    invalid: [
+      // Still one long line — reports.
+      {
+        code: `const className = \`${veryLongClass}\``,
+        filename: 'test.tsx',
+        errors: [{ messageId: 'tooLong' }],
+      },
+      // Wrapped, but one line is itself still too long — reports.
+      {
+        code: `const className = \`\n  ${veryLongClass}\n  p-4\n\``,
+        filename: 'test.tsx',
+        errors: [{ messageId: 'tooLong' }],
+      },
+    ],
+  },
+)
+
+// #111 — classesPerLine counts PER LINE, and the autofix wraps into the block
+// convention non-destructively.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (#111 per-line + block autofix)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [
+      // 3 per line, classesPerLine 4 — no line exceeds the budget.
+      {
+        code: 'const className = `\n  class1 class2 class3\n  class4 class5 class6\n`',
+        filename: 'test.tsx',
+        options: [{ classesPerLine: 4 }],
+      },
+    ],
+    invalid: [
+      // Single line → converted to the block convention (exact issue output).
+      {
+        code: 'const className = `class1 class2 class3 class4 class5`',
+        filename: 'test.tsx',
+        options: [{ classesPerLine: 2 }],
+        errors: [{ messageId: 'tooManyPerLine' }],
+        output: 'const className = `\n  class1 class2\n  class3 class4\n  class5\n`',
+      },
+      // Already a block: only the overfull line is re-wrapped; conforming lines
+      // (and the leading/trailing structure) are left verbatim.
+      {
+        code: 'const className = `\n  a b c d e\n  f g\n`',
+        filename: 'test.tsx',
+        options: [{ classesPerLine: 2 }],
+        errors: [{ messageId: 'tooManyPerLine' }],
+        output: 'const className = `\n  a b\n  c d\n  e\n  f g\n`',
+      },
+      // Nested JSX: base indent derived from the source line (exercises
+      // context.sourceCode), so the block nests at the element's indentation.
+      {
+        code: 'function C() {\n  return <div className={`flex items-center justify-between p-4`} />\n}',
+        filename: 'test.tsx',
+        options: [{ classesPerLine: 2 }],
+        errors: [{ messageId: 'tooManyPerLine' }],
+        output:
+          'function C() {\n  return <div className={`\n    flex items-center\n    justify-between p-4\n  `} />\n}',
+      },
+    ],
+  },
+)

--- a/packages/oxlint-tailwindcss/tests/rules/no-unnecessary-whitespace.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-unnecessary-whitespace.test.ts
@@ -28,6 +28,17 @@ ruleTester.run('no-unnecessary-whitespace', noUnnecessaryWhitespace, {
       code: 'const className = `flex items-center\n\t\t\tjustify-between`',
       filename: 'test.tsx',
     },
+    // Indented closing backtick (block convention) — the trailing `\n    ` before
+    // the closing backtick is intentional formatting, not a stray space (#109).
+    {
+      code: 'const className = `\n    bg-red-500 text-white hover:bg-red-600\n    `',
+      filename: 'test.tsx',
+    },
+    // Same, deeper indent + a conforming line above the closing backtick.
+    {
+      code: 'const className = `\n      flex items-center\n      justify-between\n    `',
+      filename: 'test.tsx',
+    },
   ],
   invalid: [
     {
@@ -75,6 +86,14 @@ ruleTester.run('no-unnecessary-whitespace', noUnnecessaryWhitespace, {
       filename: 'test.tsx',
       errors: [{ messageId: 'unnecessaryWhitespace' }],
       output: 'const className = `flex items-center`',
+    },
+    // A genuine trailing space (single line, no newline before it) is still
+    // stripped — the #109 guard only protects a whitespace-only closing line.
+    {
+      code: '<div className={`flex items-center `} />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'unnecessaryWhitespace' }],
+      output: '<div className={`flex items-center`} />',
     },
   ],
 })

--- a/packages/oxlint-tailwindcss/tests/utils/class-splitter.test.ts
+++ b/packages/oxlint-tailwindcss/tests/utils/class-splitter.test.ts
@@ -176,3 +176,50 @@ describe('rebuildClassString', () => {
     expect(rebuildClassString(split, ['a', 'b', 'c'])).toBe('a b c')
   })
 })
+
+describe('rebuildClassString with sourceIndices (structure-preserving)', () => {
+  // no-duplicate: remove a MID-line dup — each line keeps its grouping.
+  it('dedup preserves per-line grouping in a block', () => {
+    const split = splitClassesWithSeparators('\n  flex flex items-center\n  bg-white p-4\n')
+    // unique = [flex, items-center, bg-white, p-4]; first-occurrence indices.
+    expect(
+      rebuildClassString(split, ['flex', 'items-center', 'bg-white', 'p-4'], [0, 2, 3, 4]),
+    ).toBe('\n  flex items-center\n  bg-white p-4\n')
+  })
+
+  // no-duplicate: removing the class that OPENED a line transfers the `\n` to
+  // the next survivor, so it keeps its own line instead of joining the previous.
+  it('dedup transfers the newline when a line-leading class is removed', () => {
+    const split = splitClassesWithSeparators('\n  flex items-center\n  flex bg-white\n')
+    // unique = [flex, items-center, bg-white]; first-occurrence indices.
+    expect(rebuildClassString(split, ['flex', 'items-center', 'bg-white'], [0, 1, 3])).toBe(
+      '\n  flex items-center\n  bg-white\n',
+    )
+  })
+
+  // shorthand: the merged replacement is appended (non-monotonic index). It must
+  // never inherit the empty leader — a single space keeps classes from gluing.
+  it('appended replacement never glues to the previous class (single line)', () => {
+    const split = splitClassesWithSeparators('flex mt-2 mb-2 items-center')
+    // remaining = [flex, items-center] then push my-2 (firstMatchedIdx = 1).
+    expect(rebuildClassString(split, ['flex', 'items-center', 'my-2'], [0, 3, 1])).toBe(
+      'flex items-center my-2',
+    )
+  })
+
+  // shorthand: when the merged pair opened a block line, the appended
+  // replacement inherits that newline+indent and lands on its own line.
+  it('appended replacement inherits the block newline when the pair opened a line', () => {
+    const split = splitClassesWithSeparators('\n  mt-2 mb-2\n  flex\n')
+    // remaining = [flex] then push my-2 (firstMatchedIdx = 0).
+    expect(rebuildClassString(split, ['flex', 'my-2'], [2, 0])).toBe('\n  flex\n  my-2\n')
+  })
+
+  // shorthand on a hanging first line (no leading newline): the appended
+  // replacement gets a space, not the empty leader.
+  it('appended replacement on a hanging first line gets a space', () => {
+    const split = splitClassesWithSeparators('pl-2 pr-2\n   text-white')
+    // remaining = [text-white] then push px-2 (firstMatchedIdx = 0).
+    expect(rebuildClassString(split, ['text-white', 'px-2'], [2, 0])).toBe('text-white px-2')
+  })
+})


### PR DESCRIPTION
## Summary

Three issues reported that the two formatting rules mishandled the **block convention** for
multiline template literals — the common shape where classes start and end on their own lines:

```tsx
const className = `
  flex items-center justify-between
  bg-white rounded-lg shadow-sm
`
```

Shared root cause: for a template with no expressions, the raw value between the backticks includes
the leading `\n`, every line's indentation, and the trailing `\n` + indentation before the closing
backtick. The rules measured, counted, and trimmed that raw value as if it were a single line.

Closes #109 Closes #110 Closes #111

## Bug fixes

- **#110 — `enforce-consistent-line-wrapping` `printWidth`** now measures the **longest individual
  line**, not the raw total (which included every `\n`+indent, so splitting could never satisfy the
  rule — it even flagged its own `classesPerLine` output). One-line strings are unchanged.
- **#111 — `enforce-consistent-line-wrapping` `classesPerLine`** counts classes **per line**, not
  the flat total, so an already-correctly-wrapped block is no longer a false positive.
- **#109 — `no-unnecessary-whitespace`** no longer strips the indented closing backtick (a
  whitespace-only last line is intentional formatting). A genuine single-line trailing space is
  still stripped.

## Behavior changes (why this is a minor bump)

- **The `classesPerLine` autofix now wraps into the block convention** — content on its own lines,
  one indent level below the statement, closing backtick on its own line — instead of the old
  hanging indent aligned to the backtick column. The base indentation is read from the source line
  via a new `safeSourceCode(context)` helper (the first rule to read `context.sourceCode`), so it
  nests correctly inside JSX. The fix is **non-destructive**: an already-wrapped template only has
  its over-budget lines re-wrapped; conforming lines are left verbatim.
- **`no-duplicate-classes` and `enforce-shorthand` preserve a block's per-line grouping** — count
  changes no longer reflow a multi-class-per-line block down to one class per line. Done via a
  `sourceIndices` map passed to `rebuildClassString` (`pickSeparator`); the legacy no-mapping
  degrade branch stays as a fallback.

**#109 is a prerequisite of the block autofix**: a nested block ends in `\n` + indent, which without
#109 would re-enter the #14 whitespace × line-wrapping cycle. The `whitespace-line-wrap-cycle` test
now has a nested case (steps 3–4) that pins both together — and is the empirical check that
`context.sourceCode` works at visitor time.

## Tests

- 17 new regressions across rule tests, `class-splitter` unit tests (the `sourceIndices` branch),
  and the two integration matrices (`multiline-preservation`, `whitespace-line-wrap-cycle`).
- Full suite green: **1756 tests**. `typecheck`, `lint`, `format:check` all clean. Docs regenerated
  (EN + ES).

## Release

- Version bumped to **1.8.0** with a `CHANGELOG.md` entry; `CLAUDE.md` architecture notes updated.
- Everything `release.yml` needs is in this PR. **Post-merge, cut the release with:**
  `git push origin main:release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136xr4bTukJ7E1taRb3xf2U
