### PR TITLE
fix: scope relational rules to final class lists (#117)

### DIFF
--- a/packages/docs/es/rules/_extras/enforce-sort-order.md
+++ b/packages/docs/es/rules/_extras/enforce-sort-order.md
@@ -94,3 +94,12 @@ sub-app). Casi nadie lo necesita — define el entry point una vez en `settings`
 - **Trabajando en un codebase que ordena clases a propósito por intent de autoría** (e.g.
   agrupamiento visual que no matchea la prioridad de Tailwind). Desactívala localmente en vez de
   globalmente si es una preferencia por componente.
+
+> **Caveat de `tailwind-merge`.** `tailwind-merge` resuelve un grupo de conflicto conservando la
+> _última_ aparición en el string. Si un mismo string de clases contiene dos clases del mismo grupo
+> (`cn("pl-4 px-2", …)`), ordenarlas en orden canónico (`px-2 pl-4`) invierte cuál queda última y
+> por lo tanto cuál conserva `twMerge` — un cambio de render, no cosmético. Es el mismo
+> comportamiento que `prettier-plugin-tailwindcss`, así que el fixer se deja tal cual; solo afecta a
+> dos clases en conflicto co-ubicadas en un string, que de por sí es un antipatrón que
+> [`no-conflicting-classes`](./no-conflicting-classes) ya marca. Separar el override en un argumento
+> `cn`/`twMerge` aparte lo evita.

--- a/packages/docs/es/rules/_extras/no-conflicting-classes.md
+++ b/packages/docs/es/rules/_extras/no-conflicting-classes.md
@@ -103,9 +103,13 @@ pasar en silencio.
 
 - **`no-duplicate-classes`**: complementaria. Los duplicados son la misma clase repetida; los
   conflictos son clases distintas que pegan en la misma propiedad. Mantén ambas activas.
-- **`enforce-sort-order`**: aquí es cosmética. Quién gana lo decide el stylesheet generado, no el
-  orden del atributo, así que ordenar no crea ni resuelve un conflicto — solo hace el par más fácil
-  de leer.
+- **`enforce-sort-order`**: cosmética para la **cascada CSS plana** — quién gana lo decide el
+  stylesheet generado, no el orden del atributo, así que ordenar solo hace el par más fácil de leer.
+  La única excepción es **`tailwind-merge`**: resuelve las clases del mismo grupo por _última
+  aparición en el string_, así que reordenar un fragmento puede invertir cuál sobrevive. Eso solo
+  afecta a dos clases en conflicto co-ubicadas en un mismo fragmento de merge — el antipatrón que
+  esta regla ya marca — así que arreglar el conflicto también elimina el riesgo del sort. Mira la
+  nota de esa regla.
 
 - **`no-deprecated-classes`**: un alias deprecado y su equivalente moderno (`flex-grow` + `grow`)
   van a chocar a nivel de propiedad. Arreglar la deprecación suele resolver el conflicto.

--- a/packages/docs/es/rules/_extras/no-contradicting-variants.md
+++ b/packages/docs/es/rules/_extras/no-contradicting-variants.md
@@ -76,9 +76,41 @@ design system.
 - **`no-dark-without-light`**: forma inversa. Esta regla marca `base + variant:misma-utility`; esa
   marca `dark:foo` sin ninguna contraparte en light.
 
+## Composición y helpers de merge (`cn` / `twMerge` / `cva`)
+
+"`hover:flex` es redundante porque `flex` ya aplica" sólo se sostiene cuando el string que se revisa
+es la lista de clases **final y autocontenida** del elemento. En una composición con
+`tailwind-merge` — el patrón `cn`/`twMerge` + `cva` que usan los codebases estilo shadcn — un
+`className` suele ser un **fragmento de override** que se fusiona en runtime con clases aportadas en
+otro lado, muchas veces en otro módulo. Ahí la variante suele ser **load-bearing**: existe para
+ganarle a una clase del mismo grupo que el componente mergea desde su propio `cva`.
+
+Toma `<Button className="bg-transparent hover:bg-transparent" />`, donde `Button` hace
+`twMerge(buttonVariants(), className)` y `buttonVariants()` aporta `hover:bg-accent`.
+`bg-transparent` (sin modificador) y `hover:bg-accent` (un modificador `hover`) están en grupos de
+conflicto distintos de `tailwind-merge`, así que el `bg-transparent` incondicional **no** desaloja a
+`hover:bg-accent` — sólo `hover:bg-transparent` lo hace. Quitar el "redundante"
+`hover:bg-transparent` restaura entonces el hover con accent. La clase parece redundante en
+aislamiento pero es necesaria en contexto (issue #117).
+
+Como la base a la que le gana la variante vive en otro argumento o módulo, la redundancia no es
+decidible desde el fragmento solo sin emular `tailwind-merge`. Por eso la regla sólo evalúa un
+string que puede asegurar que es la lista final: un literal (o template) usado directamente como
+`class`/`className` en un **elemento host nativo** (`<div>`, `<button>`, …). **No** reporta strings
+que sean:
+
+- argumentos de una llamada merge-aware — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
+- el `className`/`class` de un **componente custom** (`<Button …>`, `<Field.Root …>`), que es opaco
+  — el componente puede volver a fusionarlo internamente;
+- asignados a una variable, o emitidos desde un tagged template.
+
+El trade-off es deliberado: acepta algunos falsos negativos (un par genuinamente redundante
+escondido en una de esas posiciones no se atrapa) para eliminar los falsos positivos, que se leen
+como obviamente correctos e invitan a una regresión de render.
+
 ## Cuándo desactivarla
 
-- **Generadores de código / class-name builders** que a propósito emiten una base y una variante con
-  la misma utility (raro, pero pasa cuando un framework mergea listas de clases de distintas fuentes
-  y prefiere no deduplicar).
+- **Generadores de código / class-name builders** en un elemento nativo que a propósito emiten una
+  base y una variante con la misma utility. (Los fragmentos de override que pasan por `cn`/`twMerge`
+  o por un componente custom ya se omiten — mira la sección de arriba.)
 - **Snapshots / fixtures** que necesitan el par redundante para ejercitar tooling downstream.

--- a/packages/docs/es/rules/_extras/no-dark-without-light.md
+++ b/packages/docs/es/rules/_extras/no-dark-without-light.md
@@ -64,9 +64,6 @@ la regla funciona sin él.
 
 // `bg-*` tiene base, pero `text-*` no
 <div className="bg-white dark:bg-gray-900 dark:text-white" />
-
-// Dentro de un helper de class-names — mismo problema, menos visible
-cn("dark:bg-gray-900")
 ```
 
 ### ✓ Correcto
@@ -91,6 +88,12 @@ cn("dark:bg-gray-900")
   className="bg-white contrast-more:bg-black"
   // con options: [{ variants: ["contrast-more"] }]
 />
+
+// Un string sólo-dark dentro de un helper de merge o en un componente custom es
+// un fragmento de override — la base light vive en otro lado, así que NO se
+// reporta. Mira "Composición y helpers de merge" abajo.
+cn("dark:bg-gray-900")
+;<Field className="dark:bg-transparent" />
 ```
 
 ## Interacciones con otras reglas
@@ -105,12 +108,36 @@ cn("dark:bg-gray-900")
 - **`enforce-sort-order`**: no afecta la detección (la regla no mira el orden), pero al ordenar la
   base y la variante dark tienden a quedar pegadas, lo que hace evidente la que falta en review.
 
+## Composición y helpers de merge (`cn` / `twMerge` / `cva`)
+
+"No hay base para esta clase `dark:`" sólo se sostiene cuando el string que se revisa es la lista de
+clases **final y autocontenida** del elemento. En una composición con `tailwind-merge` — el patrón
+`cn`/`twMerge` + `cva` que usan los codebases estilo shadcn — un `className` suele ser un
+**fragmento de override** que se fusiona en runtime con clases aportadas en otro lado, muchas veces
+en otro módulo. Un override sólo-dark como `<Field className="dark:bg-transparent" />` no le falta
+nada: la base light (`bg-white`) vive en el `cva` propio del componente, y `tailwind-merge` conserva
+ambas porque están en scopes de modificador distintos. Reportarlo — y "arreglarlo" agregando una
+base light al override — cambia en silencio el render en light mode (issue #117).
+
+Como esa base vive en otro argumento o módulo, la redundancia no es decidible desde el fragmento
+solo sin emular `tailwind-merge`. Por eso la regla sólo evalúa un string que puede asegurar que es
+la lista final: un literal (o template) usado directamente como `class`/`className` en un **elemento
+host nativo** (`<div>`, `<input>`, …). **No** reporta strings que sean:
+
+- argumentos de una llamada merge-aware — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
+- el `className`/`class` de un **componente custom** (`<Field …>`, `<Card.Body …>`), que es opaco —
+  el componente puede volver a fusionarlo internamente;
+- asignados a una variable, o emitidos desde un tagged template.
+
+El trade-off es deliberado: acepta algunos falsos negativos (una clase genuinamente sólo-dark
+escondida en una de esas posiciones no se atrapa) para eliminar los falsos positivos, que se leen
+como obviamente correctos e invitan a una regresión de render.
+
 ## Cuándo desactivarla
 
 - **Apps con un único color scheme** que igual incluyen algunas clases `dark:` para overrides
   puntuales sobre una base ya correcta en un componente padre. Prefiere angostar `variants` (e.g.
   sacar `dark`) antes que desactivarla.
-- **Design systems / primitives** donde el consumidor se espera que aporte la base vía `className`.
-  Desactiva por archivo y documenta el contrato; si no, cada primitive va a romper la regla.
-- **Strings de clases servidas desde el server** donde la base vive en CSS y sólo el override dark
-  se emite desde JS. Tratalo como el patrón anterior.
+- **Strings de clases servidas desde el server** en un elemento nativo donde la base vive en CSS y
+  sólo el override dark se emite desde JS. (Los fragmentos de override que pasan por `cn`/`twMerge`
+  o por un componente custom ya se omiten — mira la sección de arriba.)

--- a/packages/docs/es/rules/enforce-sort-order.md
+++ b/packages/docs/es/rules/enforce-sort-order.md
@@ -98,3 +98,12 @@ sub-app). Casi nadie lo necesita — define el entry point una vez en `settings`
 - **Trabajando en un codebase que ordena clases a propósito por intent de autoría** (e.g.
   agrupamiento visual que no matchea la prioridad de Tailwind). Desactívala localmente en vez de
   globalmente si es una preferencia por componente.
+
+> **Caveat de `tailwind-merge`.** `tailwind-merge` resuelve un grupo de conflicto conservando la
+> _última_ aparición en el string. Si un mismo string de clases contiene dos clases del mismo grupo
+> (`cn("pl-4 px-2", …)`), ordenarlas en orden canónico (`px-2 pl-4`) invierte cuál queda última y
+> por lo tanto cuál conserva `twMerge` — un cambio de render, no cosmético. Es el mismo
+> comportamiento que `prettier-plugin-tailwindcss`, así que el fixer se deja tal cual; solo afecta a
+> dos clases en conflicto co-ubicadas en un string, que de por sí es un antipatrón que
+> [`no-conflicting-classes`](./no-conflicting-classes) ya marca. Separar el override en un argumento
+> `cn`/`twMerge` aparte lo evita.

--- a/packages/docs/es/rules/index.md
+++ b/packages/docs/es/rules/index.md
@@ -10,9 +10,11 @@ Reglas que atrapan problemas que generarían CSS inválido o inesperado.
 - [no-unknown-classes](./no-unknown-classes) — prohíbe clases que el design system desconoce.
 - [no-conflicting-classes](./no-conflicting-classes) — marca clases que pelean por la misma
   propiedad CSS.
-- [no-contradicting-variants](./no-contradicting-variants) — `flex hover:flex` es redundante.
+- [no-contradicting-variants](./no-contradicting-variants) — `flex hover:flex` es redundante (solo
+  en listas de clases literales en elementos nativos, no en fragmentos de `cn`/`twMerge`).
 - [no-dark-without-light](./no-dark-without-light) — `dark:` debería usualmente tener pareja en modo
-  claro.
+  claro (solo en listas de clases literales en elementos nativos, no en fragmentos de
+  `cn`/`twMerge`).
 - [no-duplicate-classes](./no-duplicate-classes) — la misma clase dos veces es peso muerto.
 
 ## Modernización

--- a/packages/docs/es/rules/no-conflicting-classes.md
+++ b/packages/docs/es/rules/no-conflicting-classes.md
@@ -107,9 +107,13 @@ pasar en silencio.
 
 - **`no-duplicate-classes`**: complementaria. Los duplicados son la misma clase repetida; los
   conflictos son clases distintas que pegan en la misma propiedad. Mantén ambas activas.
-- **`enforce-sort-order`**: aquí es cosmética. Quién gana lo decide el stylesheet generado, no el
-  orden del atributo, así que ordenar no crea ni resuelve un conflicto — solo hace el par más fácil
-  de leer.
+- **`enforce-sort-order`**: cosmética para la **cascada CSS plana** — quién gana lo decide el
+  stylesheet generado, no el orden del atributo, así que ordenar solo hace el par más fácil de leer.
+  La única excepción es **`tailwind-merge`**: resuelve las clases del mismo grupo por _última
+  aparición en el string_, así que reordenar un fragmento puede invertir cuál sobrevive. Eso solo
+  afecta a dos clases en conflicto co-ubicadas en un mismo fragmento de merge — el antipatrón que
+  esta regla ya marca — así que arreglar el conflicto también elimina el riesgo del sort. Mira la
+  nota de esa regla.
 
 - **`no-deprecated-classes`**: un alias deprecado y su equivalente moderno (`flex-grow` + `grow`)
   van a chocar a nivel de propiedad. Arreglar la deprecación suele resolver el conflicto.

--- a/packages/docs/es/rules/no-contradicting-variants.md
+++ b/packages/docs/es/rules/no-contradicting-variants.md
@@ -81,9 +81,41 @@ design system.
 - **`no-dark-without-light`**: forma inversa. Esta regla marca `base + variant:misma-utility`; esa
   marca `dark:foo` sin ninguna contraparte en light.
 
+## Composición y helpers de merge (`cn` / `twMerge` / `cva`)
+
+"`hover:flex` es redundante porque `flex` ya aplica" sólo se sostiene cuando el string que se revisa
+es la lista de clases **final y autocontenida** del elemento. En una composición con
+`tailwind-merge` — el patrón `cn`/`twMerge` + `cva` que usan los codebases estilo shadcn — un
+`className` suele ser un **fragmento de override** que se fusiona en runtime con clases aportadas en
+otro lado, muchas veces en otro módulo. Ahí la variante suele ser **load-bearing**: existe para
+ganarle a una clase del mismo grupo que el componente mergea desde su propio `cva`.
+
+Toma `<Button className="bg-transparent hover:bg-transparent" />`, donde `Button` hace
+`twMerge(buttonVariants(), className)` y `buttonVariants()` aporta `hover:bg-accent`.
+`bg-transparent` (sin modificador) y `hover:bg-accent` (un modificador `hover`) están en grupos de
+conflicto distintos de `tailwind-merge`, así que el `bg-transparent` incondicional **no** desaloja a
+`hover:bg-accent` — sólo `hover:bg-transparent` lo hace. Quitar el "redundante"
+`hover:bg-transparent` restaura entonces el hover con accent. La clase parece redundante en
+aislamiento pero es necesaria en contexto (issue #117).
+
+Como la base a la que le gana la variante vive en otro argumento o módulo, la redundancia no es
+decidible desde el fragmento solo sin emular `tailwind-merge`. Por eso la regla sólo evalúa un
+string que puede asegurar que es la lista final: un literal (o template) usado directamente como
+`class`/`className` en un **elemento host nativo** (`<div>`, `<button>`, …). **No** reporta strings
+que sean:
+
+- argumentos de una llamada merge-aware — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
+- el `className`/`class` de un **componente custom** (`<Button …>`, `<Field.Root …>`), que es opaco
+  — el componente puede volver a fusionarlo internamente;
+- asignados a una variable, o emitidos desde un tagged template.
+
+El trade-off es deliberado: acepta algunos falsos negativos (un par genuinamente redundante
+escondido en una de esas posiciones no se atrapa) para eliminar los falsos positivos, que se leen
+como obviamente correctos e invitan a una regresión de render.
+
 ## Cuándo desactivarla
 
-- **Generadores de código / class-name builders** que a propósito emiten una base y una variante con
-  la misma utility (raro, pero pasa cuando un framework mergea listas de clases de distintas fuentes
-  y prefiere no deduplicar).
+- **Generadores de código / class-name builders** en un elemento nativo que a propósito emiten una
+  base y una variante con la misma utility. (Los fragmentos de override que pasan por `cn`/`twMerge`
+  o por un componente custom ya se omiten — mira la sección de arriba.)
 - **Snapshots / fixtures** que necesitan el par redundante para ejercitar tooling downstream.

--- a/packages/docs/es/rules/no-dark-without-light.md
+++ b/packages/docs/es/rules/no-dark-without-light.md
@@ -68,9 +68,6 @@ la regla funciona sin él.
 
 // `bg-*` tiene base, pero `text-*` no
 <div className="bg-white dark:bg-gray-900 dark:text-white" />
-
-// Dentro de un helper de class-names — mismo problema, menos visible
-cn("dark:bg-gray-900")
 ```
 
 ### ✓ Correcto
@@ -95,6 +92,12 @@ cn("dark:bg-gray-900")
   className="bg-white contrast-more:bg-black"
   // con options: [{ variants: ["contrast-more"] }]
 />
+
+// Un string sólo-dark dentro de un helper de merge o en un componente custom es
+// un fragmento de override — la base light vive en otro lado, así que NO se
+// reporta. Mira "Composición y helpers de merge" abajo.
+cn("dark:bg-gray-900")
+;<Field className="dark:bg-transparent" />
 ```
 
 ## Interacciones con otras reglas
@@ -109,12 +112,36 @@ cn("dark:bg-gray-900")
 - **`enforce-sort-order`**: no afecta la detección (la regla no mira el orden), pero al ordenar la
   base y la variante dark tienden a quedar pegadas, lo que hace evidente la que falta en review.
 
+## Composición y helpers de merge (`cn` / `twMerge` / `cva`)
+
+"No hay base para esta clase `dark:`" sólo se sostiene cuando el string que se revisa es la lista de
+clases **final y autocontenida** del elemento. En una composición con `tailwind-merge` — el patrón
+`cn`/`twMerge` + `cva` que usan los codebases estilo shadcn — un `className` suele ser un
+**fragmento de override** que se fusiona en runtime con clases aportadas en otro lado, muchas veces
+en otro módulo. Un override sólo-dark como `<Field className="dark:bg-transparent" />` no le falta
+nada: la base light (`bg-white`) vive en el `cva` propio del componente, y `tailwind-merge` conserva
+ambas porque están en scopes de modificador distintos. Reportarlo — y "arreglarlo" agregando una
+base light al override — cambia en silencio el render en light mode (issue #117).
+
+Como esa base vive en otro argumento o módulo, la redundancia no es decidible desde el fragmento
+solo sin emular `tailwind-merge`. Por eso la regla sólo evalúa un string que puede asegurar que es
+la lista final: un literal (o template) usado directamente como `class`/`className` en un **elemento
+host nativo** (`<div>`, `<input>`, …). **No** reporta strings que sean:
+
+- argumentos de una llamada merge-aware — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
+- el `className`/`class` de un **componente custom** (`<Field …>`, `<Card.Body …>`), que es opaco —
+  el componente puede volver a fusionarlo internamente;
+- asignados a una variable, o emitidos desde un tagged template.
+
+El trade-off es deliberado: acepta algunos falsos negativos (una clase genuinamente sólo-dark
+escondida en una de esas posiciones no se atrapa) para eliminar los falsos positivos, que se leen
+como obviamente correctos e invitan a una regresión de render.
+
 ## Cuándo desactivarla
 
 - **Apps con un único color scheme** que igual incluyen algunas clases `dark:` para overrides
   puntuales sobre una base ya correcta en un componente padre. Prefiere angostar `variants` (e.g.
   sacar `dark`) antes que desactivarla.
-- **Design systems / primitives** donde el consumidor se espera que aporte la base vía `className`.
-  Desactiva por archivo y documenta el contrato; si no, cada primitive va a romper la regla.
-- **Strings de clases servidas desde el server** donde la base vive en CSS y sólo el override dark
-  se emite desde JS. Tratalo como el patrón anterior.
+- **Strings de clases servidas desde el server** en un elemento nativo donde la base vive en CSS y
+  sólo el override dark se emite desde JS. (Los fragmentos de override que pasan por `cn`/`twMerge`
+  o por un componente custom ya se omiten — mira la sección de arriba.)

--- a/packages/docs/rules/_extras/enforce-sort-order.md
+++ b/packages/docs/rules/_extras/enforce-sort-order.md
@@ -92,3 +92,12 @@ sub-app). Almost nobody needs this — set the entry point once in `settings` an
 - **Working in a codebase that intentionally orders classes by authoring intent** (e.g. visual
   grouping that doesn't match Tailwind's priority). Disable locally rather than globally if it's a
   per-component preference.
+
+> **`tailwind-merge` caveat.** `tailwind-merge` resolves a conflict group by keeping the _last_
+> occurrence in the string. If a single class string contains two classes from the same group
+> (`cn("pl-4 px-2", …)`), sorting them into canonical order (`px-2 pl-4`) flips which one is last
+> and therefore which one `twMerge` keeps — a rendering change, not a cosmetic one. This is the same
+> behavior as `prettier-plugin-tailwindcss`, so the fixer is left as-is; it only bites two
+> conflicting classes co-located in one string, which is itself an anti-pattern
+> [`no-conflicting-classes`](./no-conflicting-classes) already flags. Splitting the override into a
+> separate `cn`/`twMerge` argument avoids it.

--- a/packages/docs/rules/_extras/no-conflicting-classes.md
+++ b/packages/docs/rules/_extras/no-conflicting-classes.md
@@ -101,9 +101,12 @@ rule emits a single fatal `designSystemUnavailable` diagnostic per file instead 
 
 - **`no-duplicate-classes`**: complementary. Duplicates are the exact same class repeated; conflicts
   are different classes that hit the same property. Keep both rules on.
-- **`enforce-sort-order`**: cosmetic here. Which class wins is decided by the generated stylesheet,
-  not by the order of the attribute, so sorting cannot create or resolve a conflict — it only makes
-  the pair easier to read.
+- **`enforce-sort-order`**: cosmetic for the **plain CSS cascade** — which class wins is decided by
+  the generated stylesheet, not by attribute order, so sorting only makes the pair easier to read.
+  The one exception is **`tailwind-merge`**: it resolves same-group classes by _last occurrence in
+  the string_, so reordering a fragment can flip which one survives. That only bites two conflicting
+  classes co-located in a single merge fragment — the anti-pattern this rule already flags — so
+  fixing the conflict removes the sort hazard too. See that rule's own note.
 - **`no-deprecated-classes`**: a deprecated alias and its modern equivalent (`flex-grow` + `grow`)
   will trip this rule on the property level. Fixing the deprecation usually resolves the conflict.
 - **`enforce-canonical`**: rewriting to canonical forms collapses trivially-aliased pairs before

--- a/packages/docs/rules/_extras/no-contradicting-variants.md
+++ b/packages/docs/rules/_extras/no-contradicting-variants.md
@@ -75,9 +75,41 @@ missing design system.
 - **`no-dark-without-light`**: opposite shape. This rule flags `base + variant:same-utility`; that
   one flags `dark:foo` with no light counterpart at all.
 
+## Composition and merge helpers (`cn` / `twMerge` / `cva`)
+
+"`hover:flex` is redundant because `flex` already applies" only holds when the string being checked
+is the element's **final, self-contained class list**. In a `tailwind-merge` composition — the
+`cn`/`twMerge` + `cva` pattern shadcn-style codebases use — a `className` is frequently an
+**override fragment** that gets merged at runtime with classes contributed elsewhere, often in
+another module. There the variant is usually **load-bearing**: it exists to beat a same-group class
+the component merges in from its own `cva`.
+
+Take `<Button className="bg-transparent hover:bg-transparent" />`, where `Button` does
+`twMerge(buttonVariants(), className)` and `buttonVariants()` contributes `hover:bg-accent`.
+`bg-transparent` (no modifier) and `hover:bg-accent` (a `hover` modifier) sit in different
+`tailwind-merge` conflict groups, so the unconditional `bg-transparent` does **not** evict
+`hover:bg-accent` — only `hover:bg-transparent` does. Removing the "redundant"
+`hover:bg-transparent` therefore restores the accent hover. The class looks redundant in isolation
+but is required in context (issue #117).
+
+Because the base the variant defeats lives in another argument or module, redundancy is not
+decidable from the fragment alone without emulating `tailwind-merge`. So the rule only evaluates a
+string it can be sure is the final list: a literal (or template) used directly as
+`class`/`className` on a **native host element** (`<div>`, `<button>`, …). It does **not** report
+strings that are:
+
+- arguments to a merge-aware call — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
+- the `className`/`class` of a **custom component** (`<Button …>`, `<Field.Root …>`), which is
+  opaque — the component may re-merge it internally;
+- assigned to a variable, or emitted from a tagged template.
+
+The trade-off is deliberate: it accepts a few false negatives (a genuinely redundant pair hidden in
+one of those positions is not caught) to eliminate the false positives, which read as obviously
+correct and invite a rendering regression.
+
 ## When to disable it
 
-- **Code generators / class-name builders** that intentionally emit both a base and a same-utility
-  variant (rare, but happens when a framework merges class lists from different sources and prefers
-  not to deduplicate).
+- **Code generators / class-name builders** on a native element that intentionally emit both a base
+  and a same-utility variant. (Override fragments passed through `cn`/`twMerge` or a custom
+  component are already skipped — see the section above.)
 - **Snapshot tests / fixtures** that need the redundant pair to exercise downstream tooling.

--- a/packages/docs/rules/_extras/no-dark-without-light.md
+++ b/packages/docs/rules/_extras/no-dark-without-light.md
@@ -63,9 +63,6 @@ works without it.
 
 // `bg-*` has a base, but `text-*` doesn't
 <div className="bg-white dark:bg-gray-900 dark:text-white" />
-
-// Inside a class-name helper — same problem, just less visible
-cn("dark:bg-gray-900")
 ```
 
 ### ✓ Correct
@@ -90,6 +87,12 @@ cn("dark:bg-gray-900")
   className="bg-white contrast-more:bg-black"
   // with options: [{ variants: ["contrast-more"] }]
 />
+
+// A dark-only string inside a merge helper or on a custom component is an
+// override fragment — the light base lives elsewhere, so it is NOT reported.
+// See "Composition and merge helpers" below.
+cn("dark:bg-gray-900")
+;<Field className="dark:bg-transparent" />
 ```
 
 ## Interactions with other rules
@@ -104,12 +107,36 @@ cn("dark:bg-gray-900")
   sorting tends to put the base and the dark variant adjacent, which makes the missing one obvious
   in review.
 
+## Composition and merge helpers (`cn` / `twMerge` / `cva`)
+
+"There is no base for this `dark:` class" only holds when the string being checked is the element's
+**final, self-contained class list**. In a `tailwind-merge` composition — the `cn`/`twMerge` + `cva`
+pattern shadcn-style codebases use — a `className` is frequently an **override fragment** that gets
+merged at runtime with classes contributed elsewhere, often in another module. A dark-only override
+like `<Field className="dark:bg-transparent" />` is not missing anything: the light base
+(`bg-white`) lives in the component's own `cva`, and `tailwind-merge` keeps both because they sit in
+different modifier scopes. Reporting it — and "fixing" it by adding a light base to the override —
+silently changes light-mode rendering (issue #117).
+
+Because that base lives in another argument or module, redundancy is not decidable from the fragment
+alone without emulating `tailwind-merge`. So the rule only evaluates a string it can be sure is the
+final list: a literal (or template) used directly as `class`/`className` on a **native host
+element** (`<div>`, `<input>`, …). It does **not** report strings that are:
+
+- arguments to a merge-aware call — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
+- the `className`/`class` of a **custom component** (`<Field …>`, `<Card.Body …>`), which is opaque
+  — the component may re-merge it internally;
+- assigned to a variable, or emitted from a tagged template.
+
+The trade-off is deliberate: it accepts a few false negatives (a genuinely dark-only class hidden in
+one of those positions is not caught) to eliminate the false positives, which read as obviously
+correct and invite a rendering regression.
+
 ## When to disable it
 
 - **Apps with a single color scheme** that nevertheless ship a few `dark:` classes for one-off
   overrides on top of a known-correct base in a parent component. Prefer narrowing `variants` (e.g.
   drop `dark`) before disabling.
-- **Design systems / primitives** where the consumer is expected to supply the base via `className`.
-  Disable per-file and document the contract; otherwise every primitive will trip the rule.
-- **Server-driven class strings** where the base lives in CSS and only the dark override is emitted
-  from JS. Treat as the same pattern above.
+- **Server-driven class strings** on a native element where the base lives in CSS and only the dark
+  override is emitted from JS. (Override fragments passed through `cn`/`twMerge` or a custom
+  component are already skipped — see the section above.)

--- a/packages/docs/rules/enforce-sort-order.md
+++ b/packages/docs/rules/enforce-sort-order.md
@@ -96,3 +96,12 @@ sub-app). Almost nobody needs this — set the entry point once in `settings` an
 - **Working in a codebase that intentionally orders classes by authoring intent** (e.g. visual
   grouping that doesn't match Tailwind's priority). Disable locally rather than globally if it's a
   per-component preference.
+
+> **`tailwind-merge` caveat.** `tailwind-merge` resolves a conflict group by keeping the _last_
+> occurrence in the string. If a single class string contains two classes from the same group
+> (`cn("pl-4 px-2", …)`), sorting them into canonical order (`px-2 pl-4`) flips which one is last
+> and therefore which one `twMerge` keeps — a rendering change, not a cosmetic one. This is the same
+> behavior as `prettier-plugin-tailwindcss`, so the fixer is left as-is; it only bites two
+> conflicting classes co-located in one string, which is itself an anti-pattern
+> [`no-conflicting-classes`](./no-conflicting-classes) already flags. Splitting the override into a
+> separate `cn`/`twMerge` argument avoids it.

--- a/packages/docs/rules/index.md
+++ b/packages/docs/rules/index.md
@@ -11,8 +11,10 @@ These rules catch problems that would generate invalid or unexpected CSS.
   about.
 - [no-conflicting-classes](./no-conflicting-classes) — flag classes that fight over the same CSS
   property.
-- [no-contradicting-variants](./no-contradicting-variants) — `flex hover:flex` is redundant.
-- [no-dark-without-light](./no-dark-without-light) — `dark:` should usually have a light-mode pair.
+- [no-contradicting-variants](./no-contradicting-variants) — `flex hover:flex` is redundant (only on
+  literal class lists on native elements, not `cn`/`twMerge` fragments).
+- [no-dark-without-light](./no-dark-without-light) — `dark:` should usually have a light-mode pair
+  (only on literal class lists on native elements, not `cn`/`twMerge` fragments).
 - [no-duplicate-classes](./no-duplicate-classes) — same class twice is dead weight.
 
 ## Modernization

--- a/packages/docs/rules/no-conflicting-classes.md
+++ b/packages/docs/rules/no-conflicting-classes.md
@@ -105,9 +105,12 @@ rule emits a single fatal `designSystemUnavailable` diagnostic per file instead 
 
 - **`no-duplicate-classes`**: complementary. Duplicates are the exact same class repeated; conflicts
   are different classes that hit the same property. Keep both rules on.
-- **`enforce-sort-order`**: cosmetic here. Which class wins is decided by the generated stylesheet,
-  not by the order of the attribute, so sorting cannot create or resolve a conflict — it only makes
-  the pair easier to read.
+- **`enforce-sort-order`**: cosmetic for the **plain CSS cascade** — which class wins is decided by
+  the generated stylesheet, not by attribute order, so sorting only makes the pair easier to read.
+  The one exception is **`tailwind-merge`**: it resolves same-group classes by _last occurrence in
+  the string_, so reordering a fragment can flip which one survives. That only bites two conflicting
+  classes co-located in a single merge fragment — the anti-pattern this rule already flags — so
+  fixing the conflict removes the sort hazard too. See that rule's own note.
 - **`no-deprecated-classes`**: a deprecated alias and its modern equivalent (`flex-grow` + `grow`)
   will trip this rule on the property level. Fixing the deprecation usually resolves the conflict.
 - **`enforce-canonical`**: rewriting to canonical forms collapses trivially-aliased pairs before

--- a/packages/docs/rules/no-contradicting-variants.md
+++ b/packages/docs/rules/no-contradicting-variants.md
@@ -80,9 +80,41 @@ missing design system.
 - **`no-dark-without-light`**: opposite shape. This rule flags `base + variant:same-utility`; that
   one flags `dark:foo` with no light counterpart at all.
 
+## Composition and merge helpers (`cn` / `twMerge` / `cva`)
+
+"`hover:flex` is redundant because `flex` already applies" only holds when the string being checked
+is the element's **final, self-contained class list**. In a `tailwind-merge` composition — the
+`cn`/`twMerge` + `cva` pattern shadcn-style codebases use — a `className` is frequently an
+**override fragment** that gets merged at runtime with classes contributed elsewhere, often in
+another module. There the variant is usually **load-bearing**: it exists to beat a same-group class
+the component merges in from its own `cva`.
+
+Take `<Button className="bg-transparent hover:bg-transparent" />`, where `Button` does
+`twMerge(buttonVariants(), className)` and `buttonVariants()` contributes `hover:bg-accent`.
+`bg-transparent` (no modifier) and `hover:bg-accent` (a `hover` modifier) sit in different
+`tailwind-merge` conflict groups, so the unconditional `bg-transparent` does **not** evict
+`hover:bg-accent` — only `hover:bg-transparent` does. Removing the "redundant"
+`hover:bg-transparent` therefore restores the accent hover. The class looks redundant in isolation
+but is required in context (issue #117).
+
+Because the base the variant defeats lives in another argument or module, redundancy is not
+decidable from the fragment alone without emulating `tailwind-merge`. So the rule only evaluates a
+string it can be sure is the final list: a literal (or template) used directly as
+`class`/`className` on a **native host element** (`<div>`, `<button>`, …). It does **not** report
+strings that are:
+
+- arguments to a merge-aware call — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
+- the `className`/`class` of a **custom component** (`<Button …>`, `<Field.Root …>`), which is
+  opaque — the component may re-merge it internally;
+- assigned to a variable, or emitted from a tagged template.
+
+The trade-off is deliberate: it accepts a few false negatives (a genuinely redundant pair hidden in
+one of those positions is not caught) to eliminate the false positives, which read as obviously
+correct and invite a rendering regression.
+
 ## When to disable it
 
-- **Code generators / class-name builders** that intentionally emit both a base and a same-utility
-  variant (rare, but happens when a framework merges class lists from different sources and prefers
-  not to deduplicate).
+- **Code generators / class-name builders** on a native element that intentionally emit both a base
+  and a same-utility variant. (Override fragments passed through `cn`/`twMerge` or a custom
+  component are already skipped — see the section above.)
 - **Snapshot tests / fixtures** that need the redundant pair to exercise downstream tooling.

--- a/packages/docs/rules/no-dark-without-light.md
+++ b/packages/docs/rules/no-dark-without-light.md
@@ -67,9 +67,6 @@ works without it.
 
 // `bg-*` has a base, but `text-*` doesn't
 <div className="bg-white dark:bg-gray-900 dark:text-white" />
-
-// Inside a class-name helper — same problem, just less visible
-cn("dark:bg-gray-900")
 ```
 
 ### ✓ Correct
@@ -94,6 +91,12 @@ cn("dark:bg-gray-900")
   className="bg-white contrast-more:bg-black"
   // with options: [{ variants: ["contrast-more"] }]
 />
+
+// A dark-only string inside a merge helper or on a custom component is an
+// override fragment — the light base lives elsewhere, so it is NOT reported.
+// See "Composition and merge helpers" below.
+cn("dark:bg-gray-900")
+;<Field className="dark:bg-transparent" />
 ```
 
 ## Interactions with other rules
@@ -108,12 +111,36 @@ cn("dark:bg-gray-900")
   sorting tends to put the base and the dark variant adjacent, which makes the missing one obvious
   in review.
 
+## Composition and merge helpers (`cn` / `twMerge` / `cva`)
+
+"There is no base for this `dark:` class" only holds when the string being checked is the element's
+**final, self-contained class list**. In a `tailwind-merge` composition — the `cn`/`twMerge` + `cva`
+pattern shadcn-style codebases use — a `className` is frequently an **override fragment** that gets
+merged at runtime with classes contributed elsewhere, often in another module. A dark-only override
+like `<Field className="dark:bg-transparent" />` is not missing anything: the light base
+(`bg-white`) lives in the component's own `cva`, and `tailwind-merge` keeps both because they sit in
+different modifier scopes. Reporting it — and "fixing" it by adding a light base to the override —
+silently changes light-mode rendering (issue #117).
+
+Because that base lives in another argument or module, redundancy is not decidable from the fragment
+alone without emulating `tailwind-merge`. So the rule only evaluates a string it can be sure is the
+final list: a literal (or template) used directly as `class`/`className` on a **native host
+element** (`<div>`, `<input>`, …). It does **not** report strings that are:
+
+- arguments to a merge-aware call — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
+- the `className`/`class` of a **custom component** (`<Field …>`, `<Card.Body …>`), which is opaque
+  — the component may re-merge it internally;
+- assigned to a variable, or emitted from a tagged template.
+
+The trade-off is deliberate: it accepts a few false negatives (a genuinely dark-only class hidden in
+one of those positions is not caught) to eliminate the false positives, which read as obviously
+correct and invite a rendering regression.
+
 ## When to disable it
 
 - **Apps with a single color scheme** that nevertheless ship a few `dark:` classes for one-off
   overrides on top of a known-correct base in a parent component. Prefer narrowing `variants` (e.g.
   drop `dark`) before disabling.
-- **Design systems / primitives** where the consumer is expected to supply the base via `className`.
-  Disable per-file and document the contract; otherwise every primitive will trip the rule.
-- **Server-driven class strings** where the base lives in CSS and only the dark override is emitted
-  from JS. Treat as the same pattern above.
+- **Server-driven class strings** on a native element where the base lives in CSS and only the dark
+  override is emitted from JS. (Override fragments passed through `cn`/`twMerge` or a custom
+  component are already skipped — see the section above.)

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.10.0
+
+`no-contradicting-variants` and `no-dark-without-light` decide by looking at the _other_ classes in
+the same string — "the base already applies unconditionally", "there is no light base". That only
+holds when the string is the element's final class list. In the `cn`/`twMerge` + `cva` pattern
+shadcn-style codebases use, a `className` is often an **override fragment** whose sibling (the base
+it defeats, or the light base it pairs with) lives in another argument or another module, so both
+rules fired confident-but-wrong findings that invited a rendering regression when acted on
+([#117](https://github.com/sergioazoc/oxlint-tailwindcss/issues/117)).
+
+### Bug fixes
+
+- **`no-contradicting-variants` and `no-dark-without-light` no longer report composition
+  fragments.** Extracted class strings now carry their origin, and both rules only evaluate a string
+  they can be sure is the element's final class list: a literal (or template) used directly as
+  `class`/ `className` on a **native host element**. Strings passed to a merge-aware call (`cn`,
+  `twMerge`, `cva`, `tv`, …), set on a **custom component's** `className`, assigned to a variable,
+  or emitted from a tagged template are skipped — their base/counterpart routinely lives elsewhere
+  and redundancy isn't decidable there without emulating `tailwind-merge`. This trades a few false
+  negatives for eliminating the false positives. Reports on native-element literals are unchanged.
+
+### Documentation
+
+- Documented the composition limitation on both rules (including the exact reproduction from #117),
+  and noted the narrower scope in the recommended config. Also flagged a bounded `tailwind-merge`
+  caveat on `enforce-sort-order` — reordering two same-conflict-group classes co-located in one
+  string can flip which one `tailwind-merge` keeps (behavior shared with
+  `prettier-plugin-tailwindcss`, so the fixer is unchanged) — and corrected the
+  `no-conflicting-classes` note that claimed sorting can never change a conflict outcome.
+
 ## 1.9.0
 
 The plugin declared `tailwindcss` and `@tailwindcss/node` as dependencies and resolved the engine

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -61,6 +61,7 @@ Add the plugin to your `.oxlintrc.json`:
     "tailwindcss/no-conflicting-classes": "error",
     "tailwindcss/no-deprecated-classes": "error",
     "tailwindcss/no-unnecessary-whitespace": "error",
+    // These two only inspect literal class lists on native elements; cn()/twMerge() fragments and custom-component classNames are skipped (issue #117).
     "tailwindcss/no-dark-without-light": "warn",
     "tailwindcss/no-contradicting-variants": "warn",
     // Style
@@ -476,6 +477,11 @@ Requires a base (light) utility when using the `dark:` variant on the same eleme
 Groups by utility prefix (`bg-`, `text-`, `border-`, etc.) — only checks that a base utility of the
 same type exists.
 
+**Scope (issue #117):** only inspects literal class lists on **native host elements** (`<div>`,
+`<input>`, …). Strings passed to `cn`/`twMerge`/`cva` or set on a custom component's `className` are
+override fragments whose light base commonly lives in another module, so they are skipped to avoid
+false positives.
+
 **Options:**
 
 | Option     | Type       | Default    | Description                          |
@@ -506,6 +512,11 @@ unconditionally.
 Only flags when the exact same utility exists both as base and with a conditional variant. Variants
 that change the selector target (pseudo-elements, child/descendant selectors, arbitrary selectors)
 are not flagged.
+
+**Scope (issue #117):** only inspects literal class lists on **native host elements** (`<div>`,
+`<button>`, …). Strings passed to `cn`/`twMerge`/`cva` or set on a custom component's `className`
+are override fragments where the "redundant" variant is often load-bearing (it beats a same-group
+class the component merges in), so they are skipped to avoid false positives.
 
 **No options.** **No autofix.**
 

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-conflicting-classes.ts
@@ -213,6 +213,14 @@ export const noConflictingClasses = defineRule({
       const { reportRedundant, allowClasses, allowPairs } = getOptions()
 
       for (const loc of locations) {
+        // NO composition guard here, unlike no-contradicting-variants /
+        // no-dark-without-light (issue #117). Those make a whole-element claim
+        // ("the base applies unconditionally" / "no base exists") that a merge
+        // fragment can invalidate. This rule only claims "of these two
+        // co-located classes, one loses" — which is invariant to whatever merges
+        // in: within one string, tailwind-merge (last-wins) or the CSS cascade
+        // genuinely drops the loser regardless of the host or sibling arguments.
+        // Gating on `loc.origin` would suppress correct intra-string reports.
         const classes = splitClasses(loc.value)
         if (classes.length < 2) continue
 

--- a/packages/oxlint-tailwindcss/src/rules/no-contradicting-variants.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-contradicting-variants.ts
@@ -1,5 +1,5 @@
 import { defineRule } from '@oxlint/plugins'
-import { createExtractorVisitors, type ClassLocation } from '../utils/extractors'
+import { createExtractorVisitors, isFinalClassList, type ClassLocation } from '../utils/extractors'
 import { splitClasses } from '../utils/class-splitter'
 import {
   type VariantFacts,
@@ -51,6 +51,10 @@ export const noContradictingVariants = defineRule({
       const factsFor = variantFactsLookup()
 
       for (const loc of locations) {
+        // Composition guard (issue #117): this relational check is only sound on
+        // a final, self-contained class list — not on merge/component fragments.
+        if (!isFinalClassList(loc)) continue
+
         const classes = splitClasses(loc.value)
 
         // Collect base classes (no variants) — store their full utility string

--- a/packages/oxlint-tailwindcss/src/rules/no-dark-without-light.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-dark-without-light.ts
@@ -1,5 +1,5 @@
 import { defineRule } from '@oxlint/plugins'
-import { createExtractorVisitors, type ClassLocation } from '../utils/extractors'
+import { createExtractorVisitors, isFinalClassList, type ClassLocation } from '../utils/extractors'
 import { splitClasses } from '../utils/class-splitter'
 import {
   extractVariants,
@@ -157,6 +157,10 @@ export const noDarkWithoutLight = defineRule({
       const cache = ds ? ds.cache : null
 
       for (const loc of locations) {
+        // Composition guard (issue #117): this relational check is only sound on
+        // a final, self-contained class list — not on merge/component fragments.
+        if (!isFinalClassList(loc)) continue
+
         const classes = splitClasses(loc.value)
 
         // Classes whose value the user wrote have no precomputed declarations;

--- a/packages/oxlint-tailwindcss/src/utils/extractors.ts
+++ b/packages/oxlint-tailwindcss/src/utils/extractors.ts
@@ -2,6 +2,27 @@ import type { ESTree } from '@oxlint/plugins'
 import type { PluginSettings } from '../types'
 import { compileRegexList } from './allowlist'
 
+/**
+ * Where a class string was extracted from. This is the single fact a
+ * *relational* rule needs to know whether the string is the element's FINAL,
+ * self-contained class list or merely an OVERRIDE FRAGMENT that gets merged at
+ * runtime (via `cn`/`twMerge`/`cva`) with classes contributed elsewhere.
+ *
+ * Only `jsx-native` — a literal/template used directly as `class`/`className`
+ * on a native (lowercase) host element — is guaranteed to be the final list.
+ * Every other origin can be a fragment whose siblings live in another argument
+ * or another module, so a rule whose verdict depends on the OTHER classes in
+ * the string (`no-contradicting-variants`, `no-dark-without-light`) must not
+ * fire there (issue #117).
+ */
+export type ClassOrigin =
+  | 'jsx-native'
+  | 'jsx-component'
+  | 'callee'
+  | 'template-tag'
+  | 'variable'
+  | 'jsx-object'
+
 export interface ClassLocation {
   value: string
   node: ESTree.Node
@@ -10,6 +31,27 @@ export interface ClassLocation {
   preserveLeadingSpace?: boolean
   /** Preserve a trailing space (quasi followed by template expression) */
   preserveTrailingSpace?: boolean
+  /**
+   * Extraction site of this string (issue #117). Optional and purely additive:
+   * per-class rules ignore it. Relational rules gate on `jsx-native`.
+   */
+  origin?: ClassOrigin
+}
+
+/**
+ * Whether this string is the element's FINAL, self-contained class list — the
+ * only position where a RELATIONAL rule (one whose verdict for a class depends
+ * on the OTHER classes in the string) can decide safely. Everywhere else the
+ * string may be an override FRAGMENT merged at runtime — by `cn`/`twMerge`/
+ * `cva`, or inside a custom component — with classes contributed in another
+ * argument or another module, where claims like "the base already applies
+ * unconditionally" or "there is no light base" are undecidable without
+ * emulating tailwind-merge (issue #117). The two relational rules
+ * (`no-contradicting-variants`, `no-dark-without-light`) gate on this; it is
+ * the single home for that decision so it can't drift between them.
+ */
+export function isFinalClassList(loc: ClassLocation): boolean {
+  return loc.origin === 'jsx-native'
 }
 
 /**
@@ -190,6 +232,40 @@ export function createExtractorVisitors(
 }
 
 /**
+ * Stamps every location with its extraction origin and returns the array.
+ * Origin is set once at each of the 4 entry points, so the recursive
+ * `extractFromExpression` helpers stay origin-agnostic.
+ */
+function withOrigin(locations: ClassLocation[], origin: ClassOrigin): ClassLocation[] {
+  for (const loc of locations) loc.origin = origin
+  return locations
+}
+
+// A lowercase-initial JSX tag is an intrinsic/host element; capitalized (or
+// member/namespaced) names are components. Compiled once — `jsxHostOrigin` runs
+// on every JSXAttribute node (hot path).
+const NATIVE_JSX_TAG = /^[a-z]/
+
+/**
+ * Classifies the JSX host element of an attribute as a native (lowercase) host
+ * — where the `className` literal IS the element's final class list — or a
+ * custom component, where the string is opaque (it may be re-merged inside the
+ * component with `cva`/`twMerge`). Conservative: unknown parent shapes →
+ * component, so a relational rule under-reports rather than emitting a false
+ * positive.
+ */
+function jsxHostOrigin(node: ESTree.JSXAttribute): ClassOrigin {
+  const parent = node.parent
+  if (parent && parent.type === 'JSXOpeningElement') {
+    const elementName = parent.name
+    if (elementName.type === 'JSXIdentifier' && NATIVE_JSX_TAG.test(elementName.name)) {
+      return 'jsx-native'
+    }
+  }
+  return 'jsx-component'
+}
+
+/**
  * Extracts class locations from a JSXAttribute node.
  * Handles: className="...", className={`...`}, className={cond ? "..." : "..."}
  */
@@ -202,6 +278,8 @@ export function extractFromJSXAttribute(
 
   if (!node.value) return []
 
+  const hostOrigin = jsxHostOrigin(node)
+
   // className="literal string"
   if (node.value.type === 'Literal' && typeof node.value.value === 'string') {
     return [
@@ -209,6 +287,7 @@ export function extractFromJSXAttribute(
         value: node.value.value,
         node: node.value,
         range: [node.value.range[0] + 1, node.value.range[1] - 1],
+        origin: hostOrigin,
       },
     ]
   }
@@ -216,11 +295,13 @@ export function extractFromJSXAttribute(
   // className={expression} or classNames={{ root: "flex" }}
   if (node.value.type === 'JSXExpressionContainer') {
     const expr = node.value.expression
-    // classNames={{ root: "flex flex-col", label: "text-sm" }} — extract string values
+    // classNames={{ root: "flex flex-col", label: "text-sm" }} — extract string values.
+    // Object values are prop payloads, not the host's own final class list, so
+    // they are never `jsx-native`.
     if (expr.type === 'ObjectExpression') {
-      return extractObjectValues(expr as ESTree.ObjectExpression)
+      return withOrigin(extractObjectValues(expr as ESTree.ObjectExpression), 'jsx-object')
     }
-    return extractFromExpression(expr)
+    return withOrigin(extractFromExpression(expr), hostOrigin)
   }
 
   return []
@@ -237,15 +318,18 @@ export function extractFromCallExpression(
   const calleeName = getCalleeName(node.callee)
   if (!calleeName || !config.callees.includes(calleeName)) return []
 
-  if (calleeName === 'cva') return extractFromCvaCall(node)
-  if (calleeName === 'tv') return extractFromTvCall(node)
-  if (calleeName === 'classed') return extractFromClassedCall(node)
+  // Every callee (cn/twMerge/cva/tv/classed/…) produces override FRAGMENTS: each
+  // argument is merged at runtime with the others (and with the host component's
+  // own classes), so no argument is a final, self-contained class list.
+  if (calleeName === 'cva') return withOrigin(extractFromCvaCall(node), 'callee')
+  if (calleeName === 'tv') return withOrigin(extractFromTvCall(node), 'callee')
+  if (calleeName === 'classed') return withOrigin(extractFromClassedCall(node), 'callee')
 
   const results: ClassLocation[] = []
   for (const arg of node.arguments) {
     extractFromExpression(arg, results)
   }
-  return results
+  return withOrigin(results, 'callee')
 }
 
 /**
@@ -258,7 +342,7 @@ export function extractFromTaggedTemplate(
   const tagName = getCalleeName(node.tag)
   if (!tagName || !config.tags.includes(tagName)) return []
 
-  return extractFromTemplateLiteral(node.quasi)
+  return withOrigin(extractFromTemplateLiteral(node.quasi), 'template-tag')
 }
 
 /**
@@ -472,7 +556,10 @@ export function extractFromVariableDeclarator(
   if (!config.variablePatterns.some((p) => p.test((node.id as ESTree.BindingIdentifier).name)))
     return []
   if (!node.init) return []
-  return extractFromExpression(node.init)
+  // A `const className = "..."` can flow into a native attribute (final list) or
+  // into a merge call (fragment) — we can't tell statically, so it is never
+  // `jsx-native`.
+  return withOrigin(extractFromExpression(node.init), 'variable')
 }
 
 /**

--- a/packages/oxlint-tailwindcss/tests/rules/no-contradicting-variants.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-contradicting-variants.test.ts
@@ -30,6 +30,25 @@ ruleTester.run('no-contradicting-variants', noContradictingVariants, {
     // Child/descendant selectors target different elements
     { code: '<div className="flex *:data-[slot=select-value]:flex" />', filename: 'test.tsx' },
     { code: '<div className="flex *:[span]:last:flex" />', filename: 'test.tsx' },
+    // Composition guard (issue #117): "base + variant:same-utility is redundant"
+    // only holds for the element's FINAL class list. In a `cn`/`twMerge`
+    // fragment or a custom component's `className`, the variant is often
+    // load-bearing — it exists to beat a same-group class the component merges
+    // in from its own `cva` (another module). These must NOT report.
+    // The exact reproduction from the issue:
+    {
+      code: '<Button className="bg-transparent hover:bg-transparent" />',
+      filename: 'test.tsx',
+    },
+    // Each merge-call argument is analyzed in isolation, so the override
+    // fragment `"bg-transparent hover:bg-transparent"` must not be flagged even
+    // when the base it defeats sits in a sibling argument.
+    {
+      code: 'twMerge("rounded hover:bg-accent", "bg-transparent hover:bg-transparent")',
+      filename: 'test.tsx',
+    },
+    { code: 'cn("flex", "flex dark:flex")', filename: 'test.tsx' },
+    { code: '<Field.Root className="flex dark:flex" />', filename: 'test.tsx' },
   ],
   invalid: [
     // Base flex + dark:flex → dark:flex is redundant

--- a/packages/oxlint-tailwindcss/tests/rules/no-dark-without-light.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-dark-without-light.test.ts
@@ -24,6 +24,15 @@ ruleTester.run('no-dark-without-light', noDarkWithoutLight, {
     { code: '<div className="hidden dark:block" />', filename: 'test.tsx' },
     { code: '<div className="flex dark:hidden" />', filename: 'test.tsx' },
     { code: '<div className="relative dark:absolute" />', filename: 'test.tsx' },
+    // Composition guard (issue #117): a dark-only string is only "missing a
+    // base" when it is the element's FINAL class list. In a `cn`/`twMerge`
+    // fragment or a custom component's `className`, the light base routinely
+    // lives in another argument or in the component's own `cva`, so these must
+    // NOT report — acting on the finding removes a load-bearing dark override.
+    { code: 'cn("dark:bg-gray-900")', filename: 'test.tsx' },
+    { code: 'twMerge(fieldVariants(), "dark:bg-transparent")', filename: 'test.tsx' },
+    { code: '<Field className="dark:bg-transparent" />', filename: 'test.tsx' },
+    { code: '<Card.Body className="dark:bg-gray-900" />', filename: 'test.tsx' },
   ],
   invalid: [
     {
@@ -33,11 +42,6 @@ ruleTester.run('no-dark-without-light', noDarkWithoutLight, {
     },
     {
       code: '<div className="bg-white dark:bg-gray-900 dark:text-white" />',
-      filename: 'test.tsx',
-      errors: [{ messageId: 'missingBase' }],
-    },
-    {
-      code: 'cn("dark:bg-gray-900")',
       filename: 'test.tsx',
       errors: [{ messageId: 'missingBase' }],
     },

--- a/packages/oxlint-tailwindcss/tests/utils/extractors.test.ts
+++ b/packages/oxlint-tailwindcss/tests/utils/extractors.test.ts
@@ -1,0 +1,121 @@
+import type { ESTree } from '@oxlint/plugins'
+import { describe, expect, it } from 'vitest'
+import {
+  extractFromCallExpression,
+  extractFromJSXAttribute,
+  extractFromTaggedTemplate,
+  extractFromVariableDeclarator,
+} from '../../src/utils/extractors'
+
+/**
+ * Contract test for the `origin` tag added in issue #117. The gated relational
+ * rules (`no-contradicting-variants`, `no-dark-without-light`) are exercised
+ * end-to-end through a real parser in their own suites; this pins the exact
+ * origin value each extraction site emits — including `variable`,
+ * `template-tag`, and `jsx-object`, which the gated rules never surface.
+ *
+ * Nodes are hand-built with only the fields the extractor reads, cast to the
+ * plugin AST types. Ranges are arbitrary but valid `[start, end]` pairs.
+ */
+
+const RANGE: [number, number] = [0, 20]
+
+function stringLiteral(value: string): ESTree.Node {
+  return { type: 'Literal', value, range: RANGE } as unknown as ESTree.Node
+}
+
+function jsxAttribute(hostName: string, value: ESTree.Node): ESTree.JSXAttribute {
+  const attr = {
+    type: 'JSXAttribute',
+    name: { type: 'JSXIdentifier', name: 'className' },
+    value,
+  } as unknown as ESTree.JSXAttribute
+  // The extractor reads the host via `node.parent` (the JSXOpeningElement).
+  ;(attr as unknown as { parent: unknown }).parent = {
+    type: 'JSXOpeningElement',
+    name: { type: 'JSXIdentifier', name: hostName },
+  }
+  return attr
+}
+
+describe('extractor origin (issue #117)', () => {
+  it('tags a literal on a native (lowercase) host as jsx-native', () => {
+    const locs = extractFromJSXAttribute(
+      jsxAttribute('div', {
+        type: 'Literal',
+        value: 'flex dark:flex',
+        range: RANGE,
+      } as unknown as ESTree.Node),
+    )
+    expect(locs).toHaveLength(1)
+    expect(locs[0].origin).toBe('jsx-native')
+  })
+
+  it('tags a literal on a custom (capitalized) component host as jsx-component', () => {
+    const locs = extractFromJSXAttribute(
+      jsxAttribute('Button', {
+        type: 'Literal',
+        value: 'flex dark:flex',
+        range: RANGE,
+      } as unknown as ESTree.Node),
+    )
+    expect(locs).toHaveLength(1)
+    expect(locs[0].origin).toBe('jsx-component')
+  })
+
+  it('tags classNames={{ ... }} object values as jsx-object', () => {
+    const objectContainer = {
+      type: 'JSXExpressionContainer',
+      expression: {
+        type: 'ObjectExpression',
+        properties: [
+          {
+            type: 'Property',
+            key: { type: 'Identifier', name: 'root' },
+            value: stringLiteral('flex'),
+          },
+        ],
+      },
+    } as unknown as ESTree.Node
+    const locs = extractFromJSXAttribute(jsxAttribute('div', objectContainer))
+    expect(locs).toHaveLength(1)
+    expect(locs[0].origin).toBe('jsx-object')
+  })
+
+  it('tags merge-call arguments as callee', () => {
+    const call = {
+      type: 'CallExpression',
+      callee: { type: 'Identifier', name: 'cn' },
+      arguments: [stringLiteral('flex'), stringLiteral('dark:flex')],
+    } as unknown as ESTree.CallExpression
+    const locs = extractFromCallExpression(call)
+    expect(locs).toHaveLength(2)
+    expect(locs.every((l) => l.origin === 'callee')).toBe(true)
+  })
+
+  it('tags tagged-template classes as template-tag', () => {
+    const tagged = {
+      type: 'TaggedTemplateExpression',
+      tag: { type: 'Identifier', name: 'tw' },
+      quasi: {
+        type: 'TemplateLiteral',
+        quasis: [{ type: 'TemplateElement', value: { raw: 'flex dark:flex' }, range: RANGE }],
+        expressions: [],
+      },
+    } as unknown as ESTree.TaggedTemplateExpression
+    const locs = extractFromTaggedTemplate(tagged)
+    expect(locs).toHaveLength(1)
+    expect(locs[0].origin).toBe('template-tag')
+  })
+
+  it('tags a matching variable initializer as variable', () => {
+    const declarator = {
+      type: 'VariableDeclarator',
+      id: { type: 'Identifier', name: 'className' },
+      init: stringLiteral('flex dark:flex'),
+    } as unknown as ESTree.VariableDeclarator
+    const locs = extractFromVariableDeclarator(declarator)
+    expect(locs).toHaveLength(1)
+    expect(locs[0].origin).toBe('variable')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #117 — a **composition false positive** in `no-contradicting-variants`, plus its confirmed
twin `no-dark-without-light`.

Both rules make a **relational** decision by reading the _other_ classes in the same extracted
string — "the base already applies unconditionally", "there is no light-mode base". That only holds
when the string is the element's **final, self-contained class list**. In the `cn`/`twMerge` + `cva`
pattern shadcn-style codebases use, a `className` is frequently an **override fragment** whose
sibling — the base it defeats, or the light base it pairs with — lives in another argument or
another module (a component's own `cva`, merged by `twMerge` at runtime). There the "redundant"
class is load-bearing, so acting on the finding changes rendering.

Verified repro (from the issue):
`twMerge("rounded hover:bg-accent", "bg-transparent hover:bg-transparent")` keeps the accent hover
only while `hover:bg-transparent` is present — removing the "redundant" class restores
`hover:bg-accent`, because `bg-transparent` (no modifier) and `hover:bg-accent` sit in different
`tailwind-merge` conflict groups.

## Fix

- **Origin-aware extraction.** Extracted class strings now carry a `ClassOrigin` (`jsx-native` /
  `jsx-component` / `callee` / `template-tag` / `variable` / `jsx-object`), stamped once at each of
  the 4 extractor entry points. The JSX host is read via `node.parent` and classified native
  (lowercase tag) vs component.
- **Both relational rules gate on `isFinalClassList(loc)`** — a single canonical predicate
  (`origin === 'jsx-native'`) — and skip merge-call arguments, custom-component `className`s,
  variables, and tagged templates. Reports on native-element literals are unchanged.

The trade-off is deliberate: a few false negatives (a genuinely redundant/dark-only pair hidden in a
fragment) in exchange for eliminating the false positives, which read as obviously correct and
invite a regression.

## Cross-rule audit (all 23 rules)

- **`no-conflicting-classes`** is relational by shape but its claim ("of two co-located classes, one
  loses") is **invariant to merges** — within one string, `tailwind-merge` last-wins or the CSS
  cascade drops the loser regardless. **Not gated**; a code comment records why so nobody adds it.
- **`enforce-sort-order`** (MEDIUM): the autofix can reorder two same-conflict-group classes in one
  string and flip which one `tailwind-merge` keeps. Bounded, and byte-identical to
  `prettier-plugin-tailwindcss`, so **doc-only** — plus a correction to the `no-conflicting-classes`
  note that claimed sorting can never change a conflict outcome.
- Everything else is per-class (or count/combine and merge-safe) and unaffected.

## Docs

Composition-limitation section (with the repro) on both rules, EN + ES; scope notes in the
recommended config and rule index; the `enforce-sort-order` caveat. The two rules stay at `warn`
under Correctness — the code fix makes them sound, so they keep their value on native-element
literals without the false positive.

## Testing

- New `valid` composition cases on both rules (including the exact issue repro); the
  `cn("dark:bg-gray-900")` case that previously asserted the false positive moved to `valid`.
- New `tests/utils/extractors.test.ts` pins all six `origin` values.
- Full suite green: **1835 tests / 72 files**. `build`, `typecheck`, `lint`, `format:check` all
  pass. Minor bump `1.9.0 → 1.10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWi4wSzHsmqqpLAJwc2har
