### PR TITLE
docs: surface prefer-scale-token for IntelliSense canonical suggestions (#119)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ That's it — the push fast-forwards `release` to `main` and `release.yml` takes
 
 ## Architecture
 
-oxlint plugin with 23 Tailwind CSS v4 linting rules. Uses `@oxlint/plugins`' `createOnce` API (runs
+oxlint plugin with 24 Tailwind CSS v4 linting rules. Uses `@oxlint/plugins`' `createOnce` API (runs
 once per lint session; returned visitors run on every matching AST node).
 
 **v1.0.0 philosophy — deterministic, explicit, fail-loud.** The plugin used to auto-detect the CSS

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ deterministic, with typo suggestions and autofixes.
 
 ---
 
-23 lint rules that catch invalid classes, conflicts, and deprecated utilities, and keep your class
+24 lint rules that catch invalid classes, conflicts, and deprecated utilities, and keep your class
 strings canonical and sorted — reading your real Tailwind v4 design system (`@theme` tokens, shadcn
 variables, typography plugin) for exact, machine-independent results.
 
@@ -82,7 +82,7 @@ recommended full rule set, monorepo patterns, and all `settings.tailwindcss` opt
 
 ## Rules
 
-23 rules across four categories. Every rule has a
+24 rules across four categories. Every rule has a
 [dedicated docs page](https://oxlint-tailwindcss.pages.dev/rules/) (EN/ES) with examples and
 options.
 
@@ -97,7 +97,7 @@ options.
 **Complexity** — `max-class-count` · `enforce-consistent-line-wrapping`
 
 **Restrictions** — `no-restricted-classes` · `no-arbitrary-value` · `no-hardcoded-colors` ·
-`no-unnecessary-arbitrary-value` · `prefer-theme-tokens`
+`no-unnecessary-arbitrary-value` · `prefer-theme-tokens` · `prefer-scale-token`
 
 Classes are detected in `className`/`class` attributes, 14 utility helpers (`cn`, `clsx`, `cva`,
 `tv`, `twMerge`, …), `tw` tagged templates, and variables matching `/^classNames?$/`, `/^classes$/`,

--- a/packages/docs/es/index.md
+++ b/packages/docs/es/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: oxlint-tailwindcss
   text: Linting de Tailwind CSS para oxlint.
-  tagline: 23 reglas pensadas para Tailwind v4. Determinista, rápido, fail-loud.
+  tagline: 24 reglas pensadas para Tailwind v4. Determinista, rápido, fail-loud.
   actions:
     - theme: brand
       text: Empezar

--- a/packages/docs/es/rules/_extras/enforce-canonical.md
+++ b/packages/docs/es/rules/_extras/enforce-canonical.md
@@ -5,9 +5,9 @@ que no lo son. "Canónico" es lo que devuelve `canonicalizeCandidates()` de `@ta
 misma fuente de verdad que usan prettier-plugin-tailwindcss, oxfmt y las herramientas oficiales de
 Tailwind. Ejemplos: `-m-0` → `m-0` (no necesitas el negativo para un cero), `bg-gradient-to-r` →
 `bg-linear-to-r`, `break-words` → `wrap-break-word`, `start-2` → `inset-s-2`, `flex-grow-1` →
-`grow`, `p-[2px]` → `p-0.5` (valor arbitrario normalizado a un token con nombre vía tu escala
-`--spacing`), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. El auto-fix corrige el
-primer hit, las sugerencias cubren el resto en el mismo string.
+`grow`, `flex-grow-[2]` → `grow-2` (un valor arbitrario cuya forma nombrada emite el mismo CSS),
+`text-[var(--color-text)]/90` → `text-(--color-text)/90`. El auto-fix corrige el primer hit, las
+sugerencias cubren el resto en el mismo string.
 
 Las clases con nombre resuelven contra un `canonicalMap` precomputado en memoria (sub-microsegundo).
 Los valores arbitrarios (`p-[2px]`, `bg-(--c)`) pasan por el worker `canonicalize-service` porque
@@ -38,8 +38,8 @@ para todo el proyecto en vez de por-regla cuando puedas.
 // Shorthand de inset lógico → canónico inset-s-* / inset-e-*
 <div className="start-2 end-4" />
 
-// Valores arbitrarios que matchean un token nombrado vía tu escala
-<div className="p-[2px] max-w-[400px]" />
+// Un valor arbitrario cuya forma nombrada emite el mismo CSS
+<div className="flex-grow-[2]" />
 
 // Variants e important se preservan
 <div className="hover:!break-words" />
@@ -54,18 +54,19 @@ para todo el proyecto en vez de por-regla cuando puedas.
 
 <div className="inset-s-2 inset-e-4" />
 
-<div className="p-0.5 max-w-100" />
+<div className="grow-2" />
 
 <div className="hover:!wrap-break-word" />
 ```
 
 ## Interacciones con otras reglas
 
-- **`no-unnecessary-arbitrary-value`**: complementaria, no hay doble-fire. Esta regla reescribe
-  valores arbitrarios a utilities con nombre solamente cuando la resolución canónica produce un CSS
-  distinto (e.g. `p-[2px]` → `p-0.5` vía escala de spacing). `no-unnecessary-arbitrary-value` cubre
-  los casos donde el arbitrario mapea directo a una utility con nombre produciendo el mismo CSS
-  (e.g. `h-[auto]` → `h-auto`).
+- **`no-unnecessary-arbitrary-value`**: complementaria, no hay doble-fire. Las dos actúan solo
+  cuando el valor arbitrario y su reemplazo nombrado emiten CSS **idéntico**; se reparten por forma.
+  `no-unnecessary-arbitrary-value` es dueña de los casos donde el arbitrario mapea directo a una
+  única utility con nombre (e.g. `h-[auto]` → `h-auto`). Un valor que solo es _numéricamente_ igual
+  a un paso de la escala (`p-[2px]` → `p-0.5`, cuyo texto CSS difiere) no es asunto de ninguna de
+  las dos — eso es `prefer-scale-token`, solo-reporte.
 - **`prefer-theme-tokens`**: el tercer partner del trío arbitrario→nombrado. Atrapa referencias a
   variables CSS como `border-(--border)` → `border-border` donde ni `enforce-canonical` (el CSS
   difiere) ni `no-unnecessary-arbitrary-value` (no hay equivalente bracket compartido) se

--- a/packages/docs/es/rules/_extras/no-unnecessary-arbitrary-value.md
+++ b/packages/docs/es/rules/_extras/no-unnecessary-arbitrary-value.md
@@ -54,11 +54,14 @@ para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Interacciones con otras reglas
 
-- **`enforce-canonical`**: complementaria, no hay doble-fire. Esta regla se dispara solo cuando la
-  forma arbitraria mapea directo a una utility con nombre que produce el mismo CSS (`h-[auto]` →
-  `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`). `enforce-canonical` se dispara cuando la
-  forma canónica es otra shape distinta que igual produce el CSS correcto vía tus tokens (`p-[2px]`
-  → `p-0.5` vía escala de spacing). Las dos parten el espacio arbitrario→nombrado de forma limpia.
+- **`enforce-canonical`**: complementaria, no hay doble-fire. Las dos actúan solo cuando la forma
+  arbitraria y su reemplazo nombrado emiten CSS **idéntico**; se reparten por forma. Esta regla es
+  dueña del caso directo arbitrario→nombrado (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` →
+  `bg-red-500`); `enforce-canonical` es dueña de los renombres canónicos y la normalización de
+  sintaxis de variables CSS. Las dos parten el espacio arbitrario→nombrado de forma limpia.
+- **`prefer-scale-token`**: dueña de lo que ninguna de las anteriores toca — un valor que solo es
+  _numéricamente_ igual a un paso de la escala o a un token de tema (`p-[2px]` → `p-0.5`), cuyo
+  texto CSS difiere (`calc(var(--spacing) * 0.5)` vs `2px`). Solo-reporte, apagada por defecto.
 - **`prefer-theme-tokens`**: también complementaria. Se dispara para referencias a variables CSS en
   el shorthand de paréntesis `prefix-(--name)` / `prefix-[var(--name)]` cuando no existe un
   equivalente bracket — ese es el caso solo-heurístico que esta regla rechaza explícitamente (ver el

--- a/packages/docs/es/rules/_extras/prefer-scale-token.md
+++ b/packages/docs/es/rules/_extras/prefer-scale-token.md
@@ -3,6 +3,23 @@
 Reporta un valor hardcodeado que es **numéricamente igual** a algo que tu design system ya nombra, y
 sugiere el nombre — `p-[10px]` → `p-2.5`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` → `rounded-lg`.
 
+### Paridad con Tailwind CSS IntelliSense
+
+Esta es la regla que reproduce el diagnóstico `suggestCanonicalClasses` de Tailwind CSS IntelliSense
+para longitudes arbitrarias — el aviso "`pl-[15px]` can be written as `pl-3.75`".
+`enforce-canonical` y `no-unnecessary-arbitrary-value` deliberadamente **no** lo reportan: las dos
+exigen CSS byte-idéntico, y `pl-3.75` compila a `calc(var(--spacing) * 3.75)`, no a `15px`
+([#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78)).
+
+Las sugerencias las aplica `oxlint --fix-suggestions` (nunca el `oxlint --fix` normal), igual que la
+experiencia en el editor. Para reproducir el ejemplo de IntelliSense exactamente — pasos dinámicos
+como `pl-3.75` que caen entre los stops enumerados de `0.5` — configura un `step` más fino (ver
+[`step`](#step) más abajo):
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
 Existe porque las otras tres reglas de arbitrario→nombrado se apoyan cada una en algo que este caso
 no cumple:
 

--- a/packages/docs/es/rules/enforce-canonical.md
+++ b/packages/docs/es/rules/enforce-canonical.md
@@ -9,9 +9,9 @@ que no lo son. "Canónico" es lo que devuelve `canonicalizeCandidates()` de `@ta
 misma fuente de verdad que usan prettier-plugin-tailwindcss, oxfmt y las herramientas oficiales de
 Tailwind. Ejemplos: `-m-0` → `m-0` (no necesitas el negativo para un cero), `bg-gradient-to-r` →
 `bg-linear-to-r`, `break-words` → `wrap-break-word`, `start-2` → `inset-s-2`, `flex-grow-1` →
-`grow`, `p-[2px]` → `p-0.5` (valor arbitrario normalizado a un token con nombre vía tu escala
-`--spacing`), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. El auto-fix corrige el
-primer hit, las sugerencias cubren el resto en el mismo string.
+`grow`, `flex-grow-[2]` → `grow-2` (un valor arbitrario cuya forma nombrada emite el mismo CSS),
+`text-[var(--color-text)]/90` → `text-(--color-text)/90`. El auto-fix corrige el primer hit, las
+sugerencias cubren el resto en el mismo string.
 
 Las clases con nombre resuelven contra un `canonicalMap` precomputado en memoria (sub-microsegundo).
 Los valores arbitrarios (`p-[2px]`, `bg-(--c)`) pasan por el worker `canonicalize-service` porque
@@ -42,8 +42,8 @@ para todo el proyecto en vez de por-regla cuando puedas.
 // Shorthand de inset lógico → canónico inset-s-* / inset-e-*
 <div className="start-2 end-4" />
 
-// Valores arbitrarios que matchean un token nombrado vía tu escala
-<div className="p-[2px] max-w-[400px]" />
+// Un valor arbitrario cuya forma nombrada emite el mismo CSS
+<div className="flex-grow-[2]" />
 
 // Variants e important se preservan
 <div className="hover:!break-words" />
@@ -58,18 +58,19 @@ para todo el proyecto en vez de por-regla cuando puedas.
 
 <div className="inset-s-2 inset-e-4" />
 
-<div className="p-0.5 max-w-100" />
+<div className="grow-2" />
 
 <div className="hover:!wrap-break-word" />
 ```
 
 ## Interacciones con otras reglas
 
-- **`no-unnecessary-arbitrary-value`**: complementaria, no hay doble-fire. Esta regla reescribe
-  valores arbitrarios a utilities con nombre solamente cuando la resolución canónica produce un CSS
-  distinto (e.g. `p-[2px]` → `p-0.5` vía escala de spacing). `no-unnecessary-arbitrary-value` cubre
-  los casos donde el arbitrario mapea directo a una utility con nombre produciendo el mismo CSS
-  (e.g. `h-[auto]` → `h-auto`).
+- **`no-unnecessary-arbitrary-value`**: complementaria, no hay doble-fire. Las dos actúan solo
+  cuando el valor arbitrario y su reemplazo nombrado emiten CSS **idéntico**; se reparten por forma.
+  `no-unnecessary-arbitrary-value` es dueña de los casos donde el arbitrario mapea directo a una
+  única utility con nombre (e.g. `h-[auto]` → `h-auto`). Un valor que solo es _numéricamente_ igual
+  a un paso de la escala (`p-[2px]` → `p-0.5`, cuyo texto CSS difiere) no es asunto de ninguna de
+  las dos — eso es `prefer-scale-token`, solo-reporte.
 - **`prefer-theme-tokens`**: el tercer partner del trío arbitrario→nombrado. Atrapa referencias a
   variables CSS como `border-(--border)` → `border-border` donde ni `enforce-canonical` (el CSS
   difiere) ni `no-unnecessary-arbitrary-value` (no hay equivalente bracket compartido) se

--- a/packages/docs/es/rules/index.md
+++ b/packages/docs/es/rules/index.md
@@ -1,6 +1,6 @@
 # Reglas
 
-Las 23 reglas de `oxlint-tailwindcss`, agrupadas por lo que hacen cumplir. Haz clic en cualquier
+Las 24 reglas de `oxlint-tailwindcss`, agrupadas por lo que hacen cumplir. Haz clic en cualquier
 regla para ver ejemplos y referencia de opciones.
 
 ## Corrección

--- a/packages/docs/es/rules/no-unnecessary-arbitrary-value.md
+++ b/packages/docs/es/rules/no-unnecessary-arbitrary-value.md
@@ -58,11 +58,14 @@ para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Interacciones con otras reglas
 
-- **`enforce-canonical`**: complementaria, no hay doble-fire. Esta regla se dispara solo cuando la
-  forma arbitraria mapea directo a una utility con nombre que produce el mismo CSS (`h-[auto]` →
-  `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`). `enforce-canonical` se dispara cuando la
-  forma canónica es otra shape distinta que igual produce el CSS correcto vía tus tokens (`p-[2px]`
-  → `p-0.5` vía escala de spacing). Las dos parten el espacio arbitrario→nombrado de forma limpia.
+- **`enforce-canonical`**: complementaria, no hay doble-fire. Las dos actúan solo cuando la forma
+  arbitraria y su reemplazo nombrado emiten CSS **idéntico**; se reparten por forma. Esta regla es
+  dueña del caso directo arbitrario→nombrado (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` →
+  `bg-red-500`); `enforce-canonical` es dueña de los renombres canónicos y la normalización de
+  sintaxis de variables CSS. Las dos parten el espacio arbitrario→nombrado de forma limpia.
+- **`prefer-scale-token`**: dueña de lo que ninguna de las anteriores toca — un valor que solo es
+  _numéricamente_ igual a un paso de la escala o a un token de tema (`p-[2px]` → `p-0.5`), cuyo
+  texto CSS difiere (`calc(var(--spacing) * 0.5)` vs `2px`). Solo-reporte, apagada por defecto.
 - **`prefer-theme-tokens`**: también complementaria. Se dispara para referencias a variables CSS en
   el shorthand de paréntesis `prefix-(--name)` / `prefix-[var(--name)]` cuando no existe un
   equivalente bracket — ese es el caso solo-heurístico que esta regla rechaza explícitamente (ver el

--- a/packages/docs/es/rules/prefer-scale-token.md
+++ b/packages/docs/es/rules/prefer-scale-token.md
@@ -7,6 +7,23 @@
 Reporta un valor hardcodeado que es **numéricamente igual** a algo que tu design system ya nombra, y
 sugiere el nombre — `p-[10px]` → `p-2.5`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` → `rounded-lg`.
 
+### Paridad con Tailwind CSS IntelliSense
+
+Esta es la regla que reproduce el diagnóstico `suggestCanonicalClasses` de Tailwind CSS IntelliSense
+para longitudes arbitrarias — el aviso "`pl-[15px]` can be written as `pl-3.75`".
+`enforce-canonical` y `no-unnecessary-arbitrary-value` deliberadamente **no** lo reportan: las dos
+exigen CSS byte-idéntico, y `pl-3.75` compila a `calc(var(--spacing) * 3.75)`, no a `15px`
+([#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78)).
+
+Las sugerencias las aplica `oxlint --fix-suggestions` (nunca el `oxlint --fix` normal), igual que la
+experiencia en el editor. Para reproducir el ejemplo de IntelliSense exactamente — pasos dinámicos
+como `pl-3.75` que caen entre los stops enumerados de `0.5` — configura un `step` más fino (ver
+[`step`](#step) más abajo):
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
 Existe porque las otras tres reglas de arbitrario→nombrado se apoyan cada una en algo que este caso
 no cumple:
 

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: oxlint-tailwindcss
   text: Tailwind CSS linting for oxlint.
-  tagline: 23 rules, designed for Tailwind v4. Deterministic, fast, fail-loud.
+  tagline: 24 rules, designed for Tailwind v4. Deterministic, fast, fail-loud.
   actions:
     - theme: brand
       text: Get started

--- a/packages/docs/rules/_extras/enforce-canonical.md
+++ b/packages/docs/rules/_extras/enforce-canonical.md
@@ -5,9 +5,9 @@ that aren't already canonical. "Canonical" is whatever `canonicalizeCandidates()
 `@tailwindcss/node` returns — the same source of truth used by prettier-plugin-tailwindcss, oxfmt,
 and the official Tailwind tooling. Examples: `-m-0` → `m-0` (no negative is needed for a zero),
 `bg-gradient-to-r` → `bg-linear-to-r`, `break-words` → `wrap-break-word`, `start-2` → `inset-s-2`,
-`flex-grow-1` → `grow`, `p-[2px]` → `p-0.5` (arbitrary value normalized to a named token via your
-`--spacing` scale), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. Auto- fix lands the
-first hit, suggestions cover the rest in the same string.
+`flex-grow-1` → `grow`, `flex-grow-[2]` → `grow-2` (an arbitrary value whose named form emits
+identical CSS), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. Auto- fix lands the first
+hit, suggestions cover the rest in the same string.
 
 Named classes resolve through a precomputed in-memory `canonicalMap` (sub-microsecond). Arbitrary
 values (`p-[2px]`, `bg-(--c)`) go through the `canonicalize-service` worker because they need a live
@@ -37,8 +37,8 @@ for the whole project instead of per-rule whenever possible.
 // Logical inset shorthand → canonical inset-s-* / inset-e-*
 <div className="start-2 end-4" />
 
-// Arbitrary values that match a named token via your spacing scale
-<div className="p-[2px] max-w-[400px]" />
+// An arbitrary value whose named form emits identical CSS
+<div className="flex-grow-[2]" />
 
 // Variants and important are preserved
 <div className="hover:!break-words" />
@@ -53,18 +53,19 @@ for the whole project instead of per-rule whenever possible.
 
 <div className="inset-s-2 inset-e-4" />
 
-<div className="p-0.5 max-w-100" />
+<div className="grow-2" />
 
 <div className="hover:!wrap-break-word" />
 ```
 
 ## Interactions with other rules
 
-- **`no-unnecessary-arbitrary-value`**: complementary, no double-fire. This rule rewrites arbitrary
-  values to named utilities only when the canonical resolution produces a different CSS shape (e.g.
-  `p-[2px]` → `p-0.5` via spacing scale). `no-unnecessary-arbitrary-value` covers the cases where
-  the arbitrary already maps directly to a named utility producing the same CSS (e.g. `h-[auto]` →
-  `h-auto`).
+- **`no-unnecessary-arbitrary-value`**: complementary, no double-fire. Both rewrite an arbitrary
+  value to a named utility only when the two emit **identical** CSS; they split on shape.
+  `no-unnecessary-arbitrary-value` owns the cases where the arbitrary maps directly to a single
+  named utility (e.g. `h-[auto]` → `h-auto`). A value that is only _numerically_ equal to a scale
+  step (`p-[2px]` → `p-0.5`, whose CSS text differs) is neither rule's business — that is
+  `prefer-scale-token`, report-only.
 - **`prefer-theme-tokens`**: the third partner of the arbitrary→named trio. It catches CSS-var
   references like `border-(--border)` → `border-border` where neither `enforce-canonical` (the CSS
   differs) nor `no-unnecessary-arbitrary-value` (no shared bracket equivalent) would fire.

--- a/packages/docs/rules/_extras/no-unnecessary-arbitrary-value.md
+++ b/packages/docs/rules/_extras/no-unnecessary-arbitrary-value.md
@@ -52,11 +52,14 @@ for the whole project instead of per-rule whenever possible.
 
 ## Interactions with other rules
 
-- **`enforce-canonical`**: complementary, no double-fire. This rule fires only when the arbitrary
-  form maps directly to a named utility producing the same CSS (`h-[auto]` → `h-auto`,
-  `bg-[var(--color-red-500)]` → `bg-red-500`). `enforce-canonical` fires when the canonical form is
-  a different shape that still happens to produce the right CSS via your tokens (`p-[2px]` →
-  `p- 0.5` via the spacing scale). The two carve up the arbitrary→named space cleanly.
+- **`enforce-canonical`**: complementary, no double-fire. Both act only when the arbitrary form and
+  its named replacement emit **identical** CSS. This rule owns the direct arbitrary→named case
+  (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`); `enforce-canonical` owns
+  canonical renames and CSS-var syntax normalization. The two carve up the arbitrary→named space
+  cleanly.
+- **`prefer-scale-token`**: owns what neither of the above touches — a value that is only
+  _numerically_ equal to a scale step or theme token (`p-[2px]` → `p-0.5`), whose CSS text differs
+  (`calc(var(--spacing) * 0.5)` vs `2px`). Report-only, off by default.
 - **`prefer-theme-tokens`**: also complementary. It fires for CSS-var references in the
   `prefix-(--name)` / `prefix-[var(--name)]` paren shorthand when no bracket-equivalent exists —
   that's the heuristic- only case this rule explicitly rejects (see the `getNamedEquivalent` guard).

--- a/packages/docs/rules/_extras/prefer-scale-token.md
+++ b/packages/docs/rules/_extras/prefer-scale-token.md
@@ -4,6 +4,23 @@ Reports a hardcoded value that is **numerically equal** to something your design
 names, and suggests the name — `p-[10px]` → `p-2.5`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` →
 `rounded-lg`.
 
+### Parity with Tailwind CSS IntelliSense
+
+This is the rule that reproduces Tailwind CSS IntelliSense's `suggestCanonicalClasses` diagnostic
+for arbitrary lengths — the "`pl-[15px]` can be written as `pl-3.75`" hint. `enforce-canonical` and
+`no-unnecessary-arbitrary-value` deliberately do **not** report it: both require byte-identical CSS,
+and `pl-3.75` compiles to `calc(var(--spacing) * 3.75)`, not `15px`
+([#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78)).
+
+The suggestions are applied by `oxlint --fix-suggestions` (never by plain `oxlint --fix`), which
+matches the editor experience. To reproduce the IntelliSense example exactly — dynamic steps like
+`pl-3.75` that fall between the enumerated `0.5` stops — set a finer `step` (see [`step`](#step)
+below):
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
 It exists because the other three arbitrary→named rules each key on something this case does not
 satisfy:
 

--- a/packages/docs/rules/enforce-canonical.md
+++ b/packages/docs/rules/enforce-canonical.md
@@ -9,9 +9,9 @@ that aren't already canonical. "Canonical" is whatever `canonicalizeCandidates()
 `@tailwindcss/node` returns — the same source of truth used by prettier-plugin-tailwindcss, oxfmt,
 and the official Tailwind tooling. Examples: `-m-0` → `m-0` (no negative is needed for a zero),
 `bg-gradient-to-r` → `bg-linear-to-r`, `break-words` → `wrap-break-word`, `start-2` → `inset-s-2`,
-`flex-grow-1` → `grow`, `p-[2px]` → `p-0.5` (arbitrary value normalized to a named token via your
-`--spacing` scale), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. Auto- fix lands the
-first hit, suggestions cover the rest in the same string.
+`flex-grow-1` → `grow`, `flex-grow-[2]` → `grow-2` (an arbitrary value whose named form emits
+identical CSS), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. Auto- fix lands the first
+hit, suggestions cover the rest in the same string.
 
 Named classes resolve through a precomputed in-memory `canonicalMap` (sub-microsecond). Arbitrary
 values (`p-[2px]`, `bg-(--c)`) go through the `canonicalize-service` worker because they need a live
@@ -41,8 +41,8 @@ for the whole project instead of per-rule whenever possible.
 // Logical inset shorthand → canonical inset-s-* / inset-e-*
 <div className="start-2 end-4" />
 
-// Arbitrary values that match a named token via your spacing scale
-<div className="p-[2px] max-w-[400px]" />
+// An arbitrary value whose named form emits identical CSS
+<div className="flex-grow-[2]" />
 
 // Variants and important are preserved
 <div className="hover:!break-words" />
@@ -57,18 +57,19 @@ for the whole project instead of per-rule whenever possible.
 
 <div className="inset-s-2 inset-e-4" />
 
-<div className="p-0.5 max-w-100" />
+<div className="grow-2" />
 
 <div className="hover:!wrap-break-word" />
 ```
 
 ## Interactions with other rules
 
-- **`no-unnecessary-arbitrary-value`**: complementary, no double-fire. This rule rewrites arbitrary
-  values to named utilities only when the canonical resolution produces a different CSS shape (e.g.
-  `p-[2px]` → `p-0.5` via spacing scale). `no-unnecessary-arbitrary-value` covers the cases where
-  the arbitrary already maps directly to a named utility producing the same CSS (e.g. `h-[auto]` →
-  `h-auto`).
+- **`no-unnecessary-arbitrary-value`**: complementary, no double-fire. Both rewrite an arbitrary
+  value to a named utility only when the two emit **identical** CSS; they split on shape.
+  `no-unnecessary-arbitrary-value` owns the cases where the arbitrary maps directly to a single
+  named utility (e.g. `h-[auto]` → `h-auto`). A value that is only _numerically_ equal to a scale
+  step (`p-[2px]` → `p-0.5`, whose CSS text differs) is neither rule's business — that is
+  `prefer-scale-token`, report-only.
 - **`prefer-theme-tokens`**: the third partner of the arbitrary→named trio. It catches CSS-var
   references like `border-(--border)` → `border-border` where neither `enforce-canonical` (the CSS
   differs) nor `no-unnecessary-arbitrary-value` (no shared bracket equivalent) would fire.

--- a/packages/docs/rules/index.md
+++ b/packages/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules
 
-The 23 rules in `oxlint-tailwindcss`, grouped by what they enforce. Click into any rule for examples
+The 24 rules in `oxlint-tailwindcss`, grouped by what they enforce. Click into any rule for examples
 and option reference.
 
 ## Correctness

--- a/packages/docs/rules/no-unnecessary-arbitrary-value.md
+++ b/packages/docs/rules/no-unnecessary-arbitrary-value.md
@@ -56,11 +56,14 @@ for the whole project instead of per-rule whenever possible.
 
 ## Interactions with other rules
 
-- **`enforce-canonical`**: complementary, no double-fire. This rule fires only when the arbitrary
-  form maps directly to a named utility producing the same CSS (`h-[auto]` → `h-auto`,
-  `bg-[var(--color-red-500)]` → `bg-red-500`). `enforce-canonical` fires when the canonical form is
-  a different shape that still happens to produce the right CSS via your tokens (`p-[2px]` →
-  `p- 0.5` via the spacing scale). The two carve up the arbitrary→named space cleanly.
+- **`enforce-canonical`**: complementary, no double-fire. Both act only when the arbitrary form and
+  its named replacement emit **identical** CSS. This rule owns the direct arbitrary→named case
+  (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`); `enforce-canonical` owns
+  canonical renames and CSS-var syntax normalization. The two carve up the arbitrary→named space
+  cleanly.
+- **`prefer-scale-token`**: owns what neither of the above touches — a value that is only
+  _numerically_ equal to a scale step or theme token (`p-[2px]` → `p-0.5`), whose CSS text differs
+  (`calc(var(--spacing) * 0.5)` vs `2px`). Report-only, off by default.
 - **`prefer-theme-tokens`**: also complementary. It fires for CSS-var references in the
   `prefix-(--name)` / `prefix-[var(--name)]` paren shorthand when no bracket-equivalent exists —
   that's the heuristic- only case this rule explicitly rejects (see the `getNamedEquivalent` guard).

--- a/packages/docs/rules/prefer-scale-token.md
+++ b/packages/docs/rules/prefer-scale-token.md
@@ -8,6 +8,23 @@ Reports a hardcoded value that is **numerically equal** to something your design
 names, and suggests the name — `p-[10px]` → `p-2.5`, `w-[140px]` → `w-35`, `rounded-[0.5rem]` →
 `rounded-lg`.
 
+### Parity with Tailwind CSS IntelliSense
+
+This is the rule that reproduces Tailwind CSS IntelliSense's `suggestCanonicalClasses` diagnostic
+for arbitrary lengths — the "`pl-[15px]` can be written as `pl-3.75`" hint. `enforce-canonical` and
+`no-unnecessary-arbitrary-value` deliberately do **not** report it: both require byte-identical CSS,
+and `pl-3.75` compiles to `calc(var(--spacing) * 3.75)`, not `15px`
+([#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78)).
+
+The suggestions are applied by `oxlint --fix-suggestions` (never by plain `oxlint --fix`), which
+matches the editor experience. To reproduce the IntelliSense example exactly — dynamic steps like
+`pl-3.75` that fall between the enumerated `0.5` stops — set a finer `step` (see [`step`](#step)
+below):
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
 It exists because the other three arbitrary→named rules each key on something this case does not
 satisfy:
 

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -1,6 +1,6 @@
 # oxlint-tailwindcss
 
-23 Tailwind CSS linting rules for [oxlint](https://oxc.rs/docs/guide/usage/linter). Built for
+24 Tailwind CSS linting rules for [oxlint](https://oxc.rs/docs/guide/usage/linter). Built for
 Tailwind CSS v4 with deterministic config, typo suggestions, and autofixes.
 
 > **v1.0.0** — Upgrading from v0.x? See the
@@ -30,7 +30,7 @@ Read the story behind this plugin:
 - **Typo suggestions** — `itms-center` → "Did you mean `items-center`?"
 - **Conflict detection** — Shows exactly which CSS properties conflict and which class wins.
 - **Lightweight** — Only 2 runtime dependencies: `@tailwindcss/node` and `tailwindcss`.
-- **23 rules** — Correctness, style, complexity, and restriction rules with autofixes where
+- **24 rules** — Correctness, style, complexity, and restriction rules with autofixes where
   possible.
 - **Variable detection** — Lints variables matching `/^classNames?$/`, `/^classes$/`, `/^styles?$/`
   (e.g. `className`, `classNames`, `classes`, `styles`) automatically.
@@ -247,7 +247,7 @@ entries are appended to the built-in defaults:
 }
 ```
 
-This applies to all 23 rules at once. For example, adding `"classNames"` to `attributes` makes every
+This applies to all 24 rules at once. For example, adding `"classNames"` to `attributes` makes every
 rule lint `<Input classNames={{ root: "..." }} />`.
 
 To **remove** specific items from the built-in defaults, use `exclude`:
@@ -528,18 +528,22 @@ class the component merges in), so they are skipped to avoid false positives.
 
 Enforces canonical Tailwind CSS class names. Uses `canonicalizeCandidates()` from the Tailwind CSS
 engine dynamically — the same API that powers Tailwind CSS IntelliSense's `suggestCanonicalClasses`.
+It only rewrites when the canonical form emits **byte-identical CSS** (a value-preserving rename or
+syntax normalization), so `--fix` never changes how your design renders.
 
 ```tsx
 // ❌ Bad → ✅ Fixed
-"-m-0"                              → "m-0"
-"-mt-0"                             → "mt-0"
-"p-[2px]"                           → "p-0.5"
-"max-w-[400px]"                     → "max-w-100"
-"text-[var(--color-text)]/90"       → "text-(--color-text)/90"
-"[--w-padding:theme(spacing.1)]"    → "[--w-padding:--spacing(1)]"
+"-m-0"                         → "m-0"
+"-mt-0"                        → "mt-0"
+"flex-grow-[2]"                → "grow-2"
+"text-[var(--color-text)]/90"  → "text-(--color-text)/90"
 ```
 
-The px→named conversion (e.g. `p-[2px]` → `p-0.5`) depends on `rootFontSize` (default: 16).
+It does **not** rewrite an arbitrary length into a spacing-scale step (`pl-[15px]` → `pl-3.75`),
+even though IntelliSense suggests it: `pl-3.75` compiles to `calc(var(--spacing) * 3.75)`, which is
+not byte-identical to `15px`, so the two can diverge under a `:root` override or a different root
+font size. Those value-changing suggestions live in [`prefer-scale-token`](#prefer-scale-token),
+report-only.
 
 **Requires design system.** **Autofix:** Replaces with canonical form.
 
@@ -935,6 +939,35 @@ CSS in those setups. (When the theme exposes the variable directly with no wrapp
 
 ---
 
+#### `prefer-scale-token`
+
+Reports a hardcoded value that is **numerically equal** to a spacing-scale step or a named theme
+token, and suggests the token. This is the rule that matches Tailwind CSS IntelliSense's
+`suggestCanonicalClasses` suggestion for arbitrary lengths (e.g. `pl-[15px]` → `pl-3.75`) — the
+conversion `enforce-canonical` deliberately leaves alone because the CSS isn't byte-identical (see
+[#78](https://github.com/sergioazoc/oxlint-tailwindcss/issues/78)).
+
+**Report-only, on purpose.** There is no autofix: the token resolves through `var(--spacing)`, so a
+`:root` override or a different root font size can make the two diverge. It only ever suggests, so
+`oxlint --fix` skips it while `oxlint --fix-suggestions` applies it in bulk.
+
+```tsx
+// ⚠️ Suggested (not auto-fixed)
+"p-[10px]"          → "p-2.5"
+"rounded-[0.5rem]"  → "rounded-lg"
+```
+
+By default it reports values on the granularity Tailwind's own scale enumerates (multiples of
+`0.5`). To match IntelliSense exactly — including dynamic steps like `pl-3.75` — set a finer `step`:
+
+```jsonc
+{ "tailwindcss/prefer-scale-token": ["warn", { "step": 0.25 }] }
+```
+
+**Off by default.** **Requires design system.** **No autofix — suggestions only.**
+
+---
+
 ## Edge cases
 
 The class parser correctly handles:
@@ -952,9 +985,10 @@ The class parser correctly handles:
 - **`enforce-canonical`**: Named classes are canonicalized via the precomputed map (covers
   everything in `getClassList()` plus a curated list of legacy v3 spellings like `break-words`,
   `flex-grow`, `start-N`, `bg-gradient-to-*`, `bg-left-top` → `bg-top-left`). Arbitrary/CSS-var
-  forms (`p-[2px]`, `bg-(--c)`) are canonicalized dynamically via the worker. Some valid v4 classes
-  that don't appear in `getClassList()` and have no canonical rewrite (e.g. `border-1` is valid as a
-  dynamic numeric value but isn't enumerated) are left untouched.
+  forms (`bg-(--c)`, `text-[var(--x)]`) are canonicalized dynamically via the worker when the result
+  is byte-identical; a value-changing form like `p-[2px]` → `p-0.5` is left to `prefer-scale-token`.
+  Some valid v4 classes that don't appear in `getClassList()` and have no canonical rewrite (e.g.
+  `border-1` is valid as a dynamic numeric value but isn't enumerated) are left untouched.
 - **`no-conflicting-classes`**: compares the emitted declarations (property, value, the custom
   properties each value reads, and which box it applies to), so compositions are derived rather than
   enumerated. Two exceptions cannot be derived and stay declared in the source: `prose` variants and


### PR DESCRIPTION
## What

Refs #119 (documentation, not a code change).

`prefer-scale-token` (shipped in v1.6.0) already delivers the Tailwind CSS IntelliSense
`suggestCanonicalClasses` behavior the issue asks for: `pl-[15px]` → `pl-3.75`, report-only, applied
by `oxlint --fix-suggestions`, preserving variants/modifiers/`!` position and reading
`settings.tailwindcss.rootFontSize`. The reporter (on v1.10.0) already had the rule. They never
found it because the docs pointed the wrong way.

## Why the reporter got stuck

They tried `enforce-canonical` + `no-unnecessary-arbitrary-value`. Both only rewrite when the
emitted CSS is byte-identical (#78), and `pl-3.75` compiles to `calc(var(--spacing) * 3.75)`, not
`15px`, so neither fires. But the docs claimed otherwise:

- The package README and the `enforce-canonical` rule page listed `p-[2px]` → `p-0.5` and
  `max-w-[400px]` → `max-w-100` as conversions it performs. #78 removed exactly those. The
  `enforce-canonical` page even contradicted itself (the top said it does px→scale; the
  `prefer-scale-token` interaction note said it doesn't).
- `prefer-scale-token` was missing from the root README rule list and had no section in the package
  README at all.

## Changes (docs only)

- **Package README** — corrected the `enforce-canonical` examples, added the byte-identical caveat
  and a pointer to `prefer-scale-token`; added a full `prefer-scale-token` section with the
  IntelliSense-parity note and the `{ "step": 0.25 }` recipe; fixed the stale `p-[2px]` mention in
  Known limitations.
- **Root README** — added `prefer-scale-token` to the rule list.
- **VitePress `_extras`** (EN + ES, neutral tuteo) — resolved the `enforce-canonical` contradiction,
  added a "Parity with Tailwind CSS IntelliSense" section to `prefer-scale-token`, and fixed the
  same stale claim in `no-unnecessary-arbitrary-value`. Rule pages regenerated via
  `pnpm -C packages/docs generate`.
- **Rule count** — 23 → 24 across README, docs and CLAUDE.md (the registry has 24;
  `prefer-scale-token` was never counted).

No runtime code changes; `prefer-scale-token`'s behavior is unchanged. `format:check` passes and the
`prefer-scale-token` test suite is green. Docs deploy with the next release (per the release
workflow).

Using `Refs` rather than `Closes` so the issue stays open until the reporter confirms the recipe
covers their case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B47HN9LuMbjKtwVyjmGL29
