### PR TITLE
feat(enforce-consistent-line-wrapping): add printWidth fixer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,12 +159,15 @@ Core sync/async bridge: `@tailwindcss/node`'s `__unstable__loadDesignSystem` is 
 
 DS-dependent rules: `no-unknown-classes`, `no-conflicting-classes`, `enforce-canonical`,
 `enforce-sort-order`, `no-unnecessary-arbitrary-value`, `prefer-theme-tokens`.
-`consistent-variant-order` and `no-contradicting-variants` are the DS-optional rules: their static
-fallbacks (variant order, and the pseudo-element/barrier name lists) are themselves deterministic,
-so a missing entryPoint is tolerated silently in both — neither may ever emit
-`designSystemUnavailable`. `no-deprecated-classes` is DS-independent outright (guard removed in
-#69): it consults only the hardcoded `DEPRECATED_MAP`, so it never loads the design system and never
-emits `designSystemUnavailable`.
+`consistent-variant-order`, `no-contradicting-variants`, and `enforce-consistent-line-wrapping` are
+the DS-optional rules: their static fallbacks (variant order, the pseudo-element/barrier name lists,
+and prefix-unaware variant-run grouping respectively) are themselves deterministic, so a missing
+entryPoint is tolerated silently — none may ever emit `designSystemUnavailable`.
+`enforce-consistent-line-wrapping` consults the DS ONLY for the project prefix (so
+`wrapLines: 'all'` grouping treats `tw:` as transparent, matching the prefix invariant); everything
+else it does is DS-free. `no-deprecated-classes` is DS-independent outright (guard removed in #69):
+it consults only the hardcoded `DEPRECATED_MAP`, so it never loads the design system and never emits
+`designSystemUnavailable`.
 
 ## Extraction System
 

--- a/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
@@ -1,20 +1,23 @@
 ## Qué hace esta regla
 
 Marca strings de clases largos para que no se desparramen más allá de un largo de línea razonable y,
-opcionalmente, los parte en varias líneas cuando contienen más clases de las que tu team acuerda que
-una sola línea debería cargar. Dos triggers independientes: un print width basado en caracteres y un
-budget de clases por línea, ambos con autofix en template literals (los string literals solo
-reportan — no pueden cruzar líneas con seguridad).
+cuando lo activas, los envuelve en varias líneas. Dos modos de formateo independientes: un re-wrap
+basado en el width (opt-in vía `wrapLines`) y un budget de clases por línea (`classesPerLine`),
+ambos con autofix en template literals (los string literals solo reportan — no pueden cruzar líneas
+con seguridad).
 
 DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string
 crudo de clases y no le importa qué significan.
 
-El autofix envuelve los template literals en la **convención bloque**: el contenido empieza en su
+Ambos fixers envuelven los template literals en la **convención bloque**: el contenido empieza en su
 propia línea, cada línea envuelta se indenta un nivel por debajo de la indentación del statement, y
 el backtick de cierre queda en su propia línea. La indentación base se lee de la línea de código (no
 de la columna del backtick), así que el bloque anida bien incluso dentro de JSX muy indentado. El
-fix es **no destructivo** — un template que ya está envuelto solo re-envuelve sus líneas que exceden
-el budget; las líneas conformes quedan intactas. Las otras reglas (`no-unnecessary-whitespace`,
+fix de `classesPerLine` y el fix de width en modo `"overWidth"` son **no destructivos** — un
+template que ya está envuelto solo re-envuelve sus líneas que exceden el budget; las líneas
+conformes quedan intactas. El fix de width en modo `"all"` es un **re-layout completo**: reacomoda
+el template entero en la forma canónica agrupada por variantes, reemplazando cualquier layout hecho
+a mano (por eso es un modo aparte y explícito). Las otras reglas (`no-unnecessary-whitespace`,
 `enforce-sort-order`, …) están al tanto de esta forma multilínea y no la colapsan de vuelta.
 
 ## Opciones
@@ -28,17 +31,76 @@ su largo completo; para un template multilínea es la línea individual más lar
 string largo en varias líneas sí puede satisfacer la regla. Una línea cuya única clase excede por sí
 sola el width no se reporta — no hay forma de wrappearla más corta.
 
-Cuando `classesPerLine` **no** está seteado, los template literals reciben un **autofix basado en el
-width**: las clases se agrupan en runs que comparten la cadena de variantes (`hover:`, `md:hover:`,
-o ninguna), cada run arranca su propia línea, y dentro de un run las clases se empaquetan en una
-línea hasta que agregar la siguiente excedería `printWidth` (indentación incluida). Los templates
-multilínea que caben en el width pero no siguen ese layout también se normalizan, bajo el mensaje
-`inconsistentWrapping`. En string literals la regla reporta `tooLong` sin fix — partir un string
-literal en un template multilínea es una decisión de criterio (extraer un componente vs. solo
-wrappearlo), así que la regla saca el warning y te deja decidir.
+Por sí solo, `printWidth` es **solo warning**: reporta `tooLong` y nunca reescribe tu código. El
+autofix es opt-in vía `wrapLines`.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
+```
+
+### `wrapLines`
+
+`"overWidth" | "all"`, opcional. Sin default — igual que `classesPerLine`, dejarlo sin setear
+significa que el fixer está apagado y `printWidth` solo reporta.
+
+Activa el **autofix basado en el width** para template literals. Los dos modos difieren tanto en
+alcance como en layout:
+
+- `"overWidth"`: solo se re-envuelven las **líneas** que realmente exceden `printWidth` — cada una
+  se empaqueta de forma greedy en las menos líneas que caben en el budget (sin agrupar por
+  variantes), reusando la indentación de la propia línea. Todo lo demás queda intacto: los templates
+  cuyas líneas caben todas, y las líneas conformes de un template que sí se toca, conservan su
+  layout hecho a mano. Un template de una sola línea no tiene layout que preservar, así que se
+  convierte a la convención bloque.
+- `"all"`: **todo** template multilínea (o con una línea que excede) se normaliza a un layout
+  canónico, espejando el fixer de `eslint-plugin-better-tailwindcss`: las clases se agrupan en runs
+  que comparten la cadena de variantes (`hover:`, `md:hover:`, o ninguna), y dentro de un run las
+  clases se empaquetan en una línea hasta que agregar la siguiente excedería `printWidth`
+  (indentación incluida). Cómo se separan los runs lo controla `group` (abajo). Los templates dentro
+  del budget que no siguen ese layout reportan `inconsistentWrapping`.
+
+En string literals la regla reporta `tooLong` sin fix sin importar `wrapLines` — partir un string
+literal en un template multilínea es una decisión de criterio (extraer un componente vs. solo
+wrappearlo), así que la regla saca el warning y te deja decidir. Un fragmento de template **pegado**
+a un `${}` sin whitespace (`` `${a}flex …` `` — una sola clase en runtime) tampoco se autofixea
+nunca: cualquier whitespace introducido en ese borde partiría esa clase en dos.
+
+`wrapLines` solo aplica cuando `classesPerLine` **no** está seteado — si no, `classesPerLine` es
+dueño del layout.
+
+```jsonc
+{
+  "tailwindcss/enforce-consistent-line-wrapping": [
+    "error",
+    { "printWidth": 100, "wrapLines": "overWidth" },
+  ],
+}
+```
+
+### `group`
+
+`"newLine" | "emptyLine" | "never"`, default `"newLine"`.
+
+Cómo separa los grupos de variantes el layout de `wrapLines: "all"`. Coincide con la opción `group`
+de `eslint-plugin-better-tailwindcss` (mismo nombre, valores y default), así que una config migrada
+se traslada sin cambios.
+
+- `"newLine"` (default): cada run de variantes arranca su propia línea.
+- `"emptyLine"`: además, una **línea en blanco** separa los runs (las líneas en blanco no llevan
+  whitespace colgando, y `no-unnecessary-whitespace` las preserva).
+- `"never"`: sin agrupado — las clases se empaquetan de forma greedy a través de los límites de los
+  runs, en las menos líneas que caben en `printWidth`.
+
+`group` solo da forma al layout de `"all"`: `"overWidth"` a propósito nunca reagrupa (solo parte las
+líneas que exceden), y el fixer de `classesPerLine` corta por conteo, así que ambos lo ignoran.
+
+```jsonc
+{
+  "tailwindcss/enforce-consistent-line-wrapping": [
+    "error",
+    { "printWidth": 100, "wrapLines": "all", "group": "emptyLine" },
+  ],
+}
 ```
 
 ### `classesPerLine`
@@ -51,7 +113,8 @@ Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un tem
 no autofixea — los string literals no pueden cruzar líneas con seguridad sin intervención manual.
 
 Setear `classesPerLine` cambia el fixer de template literals a este modo por chunks y apaga el fixer
-basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta.
+basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta, y `wrapLines` se
+ignora.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -62,7 +125,7 @@ basado en el width (agrupado por variantes) — `printWidth` entonces solo repor
 ### ✗ Incorrecto
 
 ```tsx
-// Excede el printWidth default de 80 caracteres
+// Excede el printWidth default de 80 caracteres — reporta; sin `wrapLines` no hay autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white text-black rounded shadow-lg border w-full" />
 //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tooLong
 
@@ -76,7 +139,21 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 // Mismo conteo, string literal — reporta pero no autofixea
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
 
-// printWidth: 40 sin classesPerLine — fix basado en el width, agrupado por variante
+// printWidth: 40 con wrapLines: "overWidth" — SOLO se re-envuelve la
+// línea que excede; las líneas conformes alrededor quedan tal como estaban
+const cardClass = `
+  flex hover:underline
+  items-center justify-between gap-4 rounded-lg p-6
+  focus:outline-none
+`
+// → const cardClass = `
+//     flex hover:underline
+//     items-center justify-between gap-4
+//     rounded-lg p-6
+//     focus:outline-none
+//   `
+
+// printWidth: 40 con wrapLines: "all" — re-layout completo, agrupado por variante
 const buttonClass = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`
 // → const buttonClass = `
 //     flex items-center gap-2
@@ -96,6 +173,13 @@ const className = `
   flex items-center p-4
   bg-white text-black
 `
+
+// Template multilínea formateado a mano, cada línea dentro del printWidth —
+// con wrapLines sin setear o en "overWidth"; solo "all" lo reagrupa
+const cardClass = `
+  flex hover:underline
+  items-center
+`
 ```
 
 ## Interacciones con otras reglas
@@ -104,7 +188,9 @@ const className = `
   Las dos están diseñadas para coexistir; sin esa preservación, los fixers oscilarían (issue #14).
 - **`enforce-sort-order`**: rearma los strings de clases desde una lista de tokens vía
   `rebuildClassString`, que mantiene los separadores multilínea. El fixer del sort y el del wrap
-  corren sobre el mismo string sin pelearse.
+  corren sobre el mismo string sin pelearse. El fixer del width nunca reordena clases — solo elige
+  dónde van los saltos de línea — así que el ordenamiento sigue siendo trabajo exclusivo de
+  `enforce-sort-order`.
 - **Todas las reglas manejadas por el extractor**: `splitClassesWithSeparators` es multiline-aware,
   así que toda otra regla (`enforce-canonical`, `enforce-shorthand`, …) reporta sobre strings
   multilínea igual que sobre los de una sola línea.

--- a/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
@@ -6,8 +6,12 @@ basado en el width (opt-in vía `wrapLines`) y un budget de clases por línea (`
 ambos con autofix en template literals (los string literals solo reportan — no pueden cruzar líneas
 con seguridad).
 
-DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string
-crudo de clases y no le importa qué significan.
+DS-opcional — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string crudo
+de clases y no le importa qué significan, con una excepción: cuando **sí** hay un design system
+disponible, el agrupado de `wrapLines: "all"` le consulta el prefix de proyecto de Tailwind v4
+(`@import "tailwindcss" prefix(tw)`) para que el prefix sea transparente al agrupar — `tw:flex`
+agrupa como utility base y `tw:hover:x` como `hover:`. Sin entry point la regla cae silenciosamente
+a tratar el prefix como parte de la cadena de variantes (nunca reporta un design system faltante).
 
 Ambos fixers envuelven los template literals en la **convención bloque**: el contenido empieza en su
 propia línea, cada línea envuelta se indenta un nivel por debajo de la indentación del statement, y

--- a/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
@@ -2,8 +2,9 @@
 
 Marca strings de clases largos para que no se desparramen más allá de un largo de línea razonable y,
 opcionalmente, los parte en varias líneas cuando contienen más clases de las que tu team acuerda que
-una sola línea debería cargar. Dos triggers independientes: un print width basado en caracteres
-(solo warn) y un budget de clases por línea (autofix en template literals).
+una sola línea debería cargar. Dos triggers independientes: un print width basado en caracteres y un
+budget de clases por línea, ambos con autofix en template literals (los string literals solo
+reportan — no pueden cruzar líneas con seguridad).
 
 DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string
 crudo de clases y no le importa qué significan.
@@ -24,10 +25,17 @@ el budget; las líneas conformes quedan intactas. Las otras reglas (`no-unnecess
 
 Largo máximo de cualquier **línea individual** del string de clases. Para un string de una línea es
 su largo completo; para un template multilínea es la línea individual más larga, así que partir un
-string largo en varias líneas sí puede satisfacer la regla. Cuando se excede, la regla reporta
-`tooLong` pero **no** autofixea — partir un string largo en un literal multilínea es una decisión de
-criterio (extraer un componente vs. solo wrappearlo), así que la regla saca el warning y te deja
-decidir.
+string largo en varias líneas sí puede satisfacer la regla. Una línea cuya única clase excede por sí
+sola el width no se reporta — no hay forma de wrappearla más corta.
+
+Cuando `classesPerLine` **no** está seteado, los template literals reciben un **autofix basado en el
+width**: las clases se agrupan en runs que comparten la cadena de variantes (`hover:`, `md:hover:`,
+o ninguna), cada run arranca su propia línea, y dentro de un run las clases se empaquetan en una
+línea hasta que agregar la siguiente excedería `printWidth` (indentación incluida). Los templates
+multilínea que caben en el width pero no siguen ese layout también se normalizan, bajo el mensaje
+`inconsistentWrapping`. En string literals la regla reporta `tooLong` sin fix — partir un string
+literal en un template multilínea es una decisión de criterio (extraer un componente vs. solo
+wrappearlo), así que la regla saca el warning y te deja decidir.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
@@ -41,6 +49,9 @@ Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un tem
 (`` `…` ``), la regla autofixea envolviendo las clases en la convención bloque, en chunks de
 `classesPerLine` por línea. Dentro de string literals (`"…"`) la regla reporta `tooManyPerLine` pero
 no autofixea — los string literals no pueden cruzar líneas con seguridad sin intervención manual.
+
+Setear `classesPerLine` cambia el fixer de template literals a este modo por chunks y apaga el fixer
+basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -64,6 +75,14 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 
 // Mismo conteo, string literal — reporta pero no autofixea
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
+
+// printWidth: 40 sin classesPerLine — fix basado en el width, agrupado por variante
+const buttonClass = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`
+// → const buttonClass = `
+//     flex items-center gap-2
+//     hover:bg-red-500 hover:underline
+//     focus:outline-none
+//   `
 ```
 
 ### ✓ Correcto

--- a/packages/docs/es/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/enforce-consistent-line-wrapping.md
@@ -5,20 +5,23 @@
 ## Qué hace esta regla
 
 Marca strings de clases largos para que no se desparramen más allá de un largo de línea razonable y,
-opcionalmente, los parte en varias líneas cuando contienen más clases de las que tu team acuerda que
-una sola línea debería cargar. Dos triggers independientes: un print width basado en caracteres y un
-budget de clases por línea, ambos con autofix en template literals (los string literals solo
-reportan — no pueden cruzar líneas con seguridad).
+cuando lo activas, los envuelve en varias líneas. Dos modos de formateo independientes: un re-wrap
+basado en el width (opt-in vía `wrapLines`) y un budget de clases por línea (`classesPerLine`),
+ambos con autofix en template literals (los string literals solo reportan — no pueden cruzar líneas
+con seguridad).
 
 DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string
 crudo de clases y no le importa qué significan.
 
-El autofix envuelve los template literals en la **convención bloque**: el contenido empieza en su
+Ambos fixers envuelven los template literals en la **convención bloque**: el contenido empieza en su
 propia línea, cada línea envuelta se indenta un nivel por debajo de la indentación del statement, y
 el backtick de cierre queda en su propia línea. La indentación base se lee de la línea de código (no
 de la columna del backtick), así que el bloque anida bien incluso dentro de JSX muy indentado. El
-fix es **no destructivo** — un template que ya está envuelto solo re-envuelve sus líneas que exceden
-el budget; las líneas conformes quedan intactas. Las otras reglas (`no-unnecessary-whitespace`,
+fix de `classesPerLine` y el fix de width en modo `"overWidth"` son **no destructivos** — un
+template que ya está envuelto solo re-envuelve sus líneas que exceden el budget; las líneas
+conformes quedan intactas. El fix de width en modo `"all"` es un **re-layout completo**: reacomoda
+el template entero en la forma canónica agrupada por variantes, reemplazando cualquier layout hecho
+a mano (por eso es un modo aparte y explícito). Las otras reglas (`no-unnecessary-whitespace`,
 `enforce-sort-order`, …) están al tanto de esta forma multilínea y no la colapsan de vuelta.
 
 ## Opciones
@@ -32,17 +35,76 @@ su largo completo; para un template multilínea es la línea individual más lar
 string largo en varias líneas sí puede satisfacer la regla. Una línea cuya única clase excede por sí
 sola el width no se reporta — no hay forma de wrappearla más corta.
 
-Cuando `classesPerLine` **no** está seteado, los template literals reciben un **autofix basado en el
-width**: las clases se agrupan en runs que comparten la cadena de variantes (`hover:`, `md:hover:`,
-o ninguna), cada run arranca su propia línea, y dentro de un run las clases se empaquetan en una
-línea hasta que agregar la siguiente excedería `printWidth` (indentación incluida). Los templates
-multilínea que caben en el width pero no siguen ese layout también se normalizan, bajo el mensaje
-`inconsistentWrapping`. En string literals la regla reporta `tooLong` sin fix — partir un string
-literal en un template multilínea es una decisión de criterio (extraer un componente vs. solo
-wrappearlo), así que la regla saca el warning y te deja decidir.
+Por sí solo, `printWidth` es **solo warning**: reporta `tooLong` y nunca reescribe tu código. El
+autofix es opt-in vía `wrapLines`.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
+```
+
+### `wrapLines`
+
+`"overWidth" | "all"`, opcional. Sin default — igual que `classesPerLine`, dejarlo sin setear
+significa que el fixer está apagado y `printWidth` solo reporta.
+
+Activa el **autofix basado en el width** para template literals. Los dos modos difieren tanto en
+alcance como en layout:
+
+- `"overWidth"`: solo se re-envuelven las **líneas** que realmente exceden `printWidth` — cada una
+  se empaqueta de forma greedy en las menos líneas que caben en el budget (sin agrupar por
+  variantes), reusando la indentación de la propia línea. Todo lo demás queda intacto: los templates
+  cuyas líneas caben todas, y las líneas conformes de un template que sí se toca, conservan su
+  layout hecho a mano. Un template de una sola línea no tiene layout que preservar, así que se
+  convierte a la convención bloque.
+- `"all"`: **todo** template multilínea (o con una línea que excede) se normaliza a un layout
+  canónico, espejando el fixer de `eslint-plugin-better-tailwindcss`: las clases se agrupan en runs
+  que comparten la cadena de variantes (`hover:`, `md:hover:`, o ninguna), y dentro de un run las
+  clases se empaquetan en una línea hasta que agregar la siguiente excedería `printWidth`
+  (indentación incluida). Cómo se separan los runs lo controla `group` (abajo). Los templates dentro
+  del budget que no siguen ese layout reportan `inconsistentWrapping`.
+
+En string literals la regla reporta `tooLong` sin fix sin importar `wrapLines` — partir un string
+literal en un template multilínea es una decisión de criterio (extraer un componente vs. solo
+wrappearlo), así que la regla saca el warning y te deja decidir. Un fragmento de template **pegado**
+a un `${}` sin whitespace (`` `${a}flex …` `` — una sola clase en runtime) tampoco se autofixea
+nunca: cualquier whitespace introducido en ese borde partiría esa clase en dos.
+
+`wrapLines` solo aplica cuando `classesPerLine` **no** está seteado — si no, `classesPerLine` es
+dueño del layout.
+
+```jsonc
+{
+  "tailwindcss/enforce-consistent-line-wrapping": [
+    "error",
+    { "printWidth": 100, "wrapLines": "overWidth" },
+  ],
+}
+```
+
+### `group`
+
+`"newLine" | "emptyLine" | "never"`, default `"newLine"`.
+
+Cómo separa los grupos de variantes el layout de `wrapLines: "all"`. Coincide con la opción `group`
+de `eslint-plugin-better-tailwindcss` (mismo nombre, valores y default), así que una config migrada
+se traslada sin cambios.
+
+- `"newLine"` (default): cada run de variantes arranca su propia línea.
+- `"emptyLine"`: además, una **línea en blanco** separa los runs (las líneas en blanco no llevan
+  whitespace colgando, y `no-unnecessary-whitespace` las preserva).
+- `"never"`: sin agrupado — las clases se empaquetan de forma greedy a través de los límites de los
+  runs, en las menos líneas que caben en `printWidth`.
+
+`group` solo da forma al layout de `"all"`: `"overWidth"` a propósito nunca reagrupa (solo parte las
+líneas que exceden), y el fixer de `classesPerLine` corta por conteo, así que ambos lo ignoran.
+
+```jsonc
+{
+  "tailwindcss/enforce-consistent-line-wrapping": [
+    "error",
+    { "printWidth": 100, "wrapLines": "all", "group": "emptyLine" },
+  ],
+}
 ```
 
 ### `classesPerLine`
@@ -55,7 +117,8 @@ Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un tem
 no autofixea — los string literals no pueden cruzar líneas con seguridad sin intervención manual.
 
 Setear `classesPerLine` cambia el fixer de template literals a este modo por chunks y apaga el fixer
-basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta.
+basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta, y `wrapLines` se
+ignora.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -66,7 +129,7 @@ basado en el width (agrupado por variantes) — `printWidth` entonces solo repor
 ### ✗ Incorrecto
 
 ```tsx
-// Excede el printWidth default de 80 caracteres
+// Excede el printWidth default de 80 caracteres — reporta; sin `wrapLines` no hay autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white text-black rounded shadow-lg border w-full" />
 //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tooLong
 
@@ -80,7 +143,21 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 // Mismo conteo, string literal — reporta pero no autofixea
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
 
-// printWidth: 40 sin classesPerLine — fix basado en el width, agrupado por variante
+// printWidth: 40 con wrapLines: "overWidth" — SOLO se re-envuelve la
+// línea que excede; las líneas conformes alrededor quedan tal como estaban
+const cardClass = `
+  flex hover:underline
+  items-center justify-between gap-4 rounded-lg p-6
+  focus:outline-none
+`
+// → const cardClass = `
+//     flex hover:underline
+//     items-center justify-between gap-4
+//     rounded-lg p-6
+//     focus:outline-none
+//   `
+
+// printWidth: 40 con wrapLines: "all" — re-layout completo, agrupado por variante
 const buttonClass = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`
 // → const buttonClass = `
 //     flex items-center gap-2
@@ -100,6 +177,13 @@ const className = `
   flex items-center p-4
   bg-white text-black
 `
+
+// Template multilínea formateado a mano, cada línea dentro del printWidth —
+// con wrapLines sin setear o en "overWidth"; solo "all" lo reagrupa
+const cardClass = `
+  flex hover:underline
+  items-center
+`
 ```
 
 ## Interacciones con otras reglas
@@ -108,7 +192,9 @@ const className = `
   Las dos están diseñadas para coexistir; sin esa preservación, los fixers oscilarían (issue #14).
 - **`enforce-sort-order`**: rearma los strings de clases desde una lista de tokens vía
   `rebuildClassString`, que mantiene los separadores multilínea. El fixer del sort y el del wrap
-  corren sobre el mismo string sin pelearse.
+  corren sobre el mismo string sin pelearse. El fixer del width nunca reordena clases — solo elige
+  dónde van los saltos de línea — así que el ordenamiento sigue siendo trabajo exclusivo de
+  `enforce-sort-order`.
 - **Todas las reglas manejadas por el extractor**: `splitClassesWithSeparators` es multiline-aware,
   así que toda otra regla (`enforce-canonical`, `enforce-shorthand`, …) reporta sobre strings
   multilínea igual que sobre los de una sola línea.

--- a/packages/docs/es/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/enforce-consistent-line-wrapping.md
@@ -6,8 +6,9 @@
 
 Marca strings de clases largos para que no se desparramen más allá de un largo de línea razonable y,
 opcionalmente, los parte en varias líneas cuando contienen más clases de las que tu team acuerda que
-una sola línea debería cargar. Dos triggers independientes: un print width basado en caracteres
-(solo warn) y un budget de clases por línea (autofix en template literals).
+una sola línea debería cargar. Dos triggers independientes: un print width basado en caracteres y un
+budget de clases por línea, ambos con autofix en template literals (los string literals solo
+reportan — no pueden cruzar líneas con seguridad).
 
 DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string
 crudo de clases y no le importa qué significan.
@@ -28,10 +29,17 @@ el budget; las líneas conformes quedan intactas. Las otras reglas (`no-unnecess
 
 Largo máximo de cualquier **línea individual** del string de clases. Para un string de una línea es
 su largo completo; para un template multilínea es la línea individual más larga, así que partir un
-string largo en varias líneas sí puede satisfacer la regla. Cuando se excede, la regla reporta
-`tooLong` pero **no** autofixea — partir un string largo en un literal multilínea es una decisión de
-criterio (extraer un componente vs. solo wrappearlo), así que la regla saca el warning y te deja
-decidir.
+string largo en varias líneas sí puede satisfacer la regla. Una línea cuya única clase excede por sí
+sola el width no se reporta — no hay forma de wrappearla más corta.
+
+Cuando `classesPerLine` **no** está seteado, los template literals reciben un **autofix basado en el
+width**: las clases se agrupan en runs que comparten la cadena de variantes (`hover:`, `md:hover:`,
+o ninguna), cada run arranca su propia línea, y dentro de un run las clases se empaquetan en una
+línea hasta que agregar la siguiente excedería `printWidth` (indentación incluida). Los templates
+multilínea que caben en el width pero no siguen ese layout también se normalizan, bajo el mensaje
+`inconsistentWrapping`. En string literals la regla reporta `tooLong` sin fix — partir un string
+literal en un template multilínea es una decisión de criterio (extraer un componente vs. solo
+wrappearlo), así que la regla saca el warning y te deja decidir.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
@@ -45,6 +53,9 @@ Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un tem
 (`` `…` ``), la regla autofixea envolviendo las clases en la convención bloque, en chunks de
 `classesPerLine` por línea. Dentro de string literals (`"…"`) la regla reporta `tooManyPerLine` pero
 no autofixea — los string literals no pueden cruzar líneas con seguridad sin intervención manual.
+
+Setear `classesPerLine` cambia el fixer de template literals a este modo por chunks y apaga el fixer
+basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -68,6 +79,14 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 
 // Mismo conteo, string literal — reporta pero no autofixea
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
+
+// printWidth: 40 sin classesPerLine — fix basado en el width, agrupado por variante
+const buttonClass = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`
+// → const buttonClass = `
+//     flex items-center gap-2
+//     hover:bg-red-500 hover:underline
+//     focus:outline-none
+//   `
 ```
 
 ### ✓ Correcto

--- a/packages/docs/es/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/enforce-consistent-line-wrapping.md
@@ -10,8 +10,12 @@ basado en el width (opt-in vía `wrapLines`) y un budget de clases por línea (`
 ambos con autofix en template literals (los string literals solo reportan — no pueden cruzar líneas
 con seguridad).
 
-DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string
-crudo de clases y no le importa qué significan.
+DS-opcional — funciona sin `settings.tailwindcss.entryPoint`. La regla opera sobre el string crudo
+de clases y no le importa qué significan, con una excepción: cuando **sí** hay un design system
+disponible, el agrupado de `wrapLines: "all"` le consulta el prefix de proyecto de Tailwind v4
+(`@import "tailwindcss" prefix(tw)`) para que el prefix sea transparente al agrupar — `tw:flex`
+agrupa como utility base y `tw:hover:x` como `hover:`. Sin entry point la regla cae silenciosamente
+a tratar el prefix como parte de la cadena de variantes (nunca reporta un design system faltante).
 
 Ambos fixers envuelven los template literals en la **convención bloque**: el contenido empieza en su
 propia línea, cada línea envuelta se indenta un nivel por debajo de la indentación del statement, y

--- a/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
@@ -5,8 +5,12 @@ wraps them into multiple lines. Two independent formatting modes: a width-based 
 `wrapLines`) and a class-count budget per line (`classesPerLine`), both autofixing template literals
 (string literals only report — they can't safely span lines).
 
-DS-independent — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
-string and doesn't care what the classes mean.
+DS-optional — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
+string and doesn't care what the classes mean, with one exception: when a design system **is**
+available, the `wrapLines: "all"` grouping consults it for the Tailwind v4 project prefix
+(`@import "tailwindcss" prefix(tw)`) so the prefix is transparent to grouping — `tw:flex` groups as
+a base utility and `tw:hover:x` as `hover:`. Without an entry point the rule silently falls back to
+treating the prefix as part of the variant chain (it never reports a missing design system).
 
 Both fixers wrap template literals into the **block convention**: the content starts on its own
 line, each wrapped line is indented one level below the statement's own indentation, and the closing

--- a/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
@@ -2,8 +2,8 @@
 
 Flags long class strings so they don't sprawl past a sensible line length and, optionally, splits
 them into multiple lines when they contain more classes than your team agrees a single line should
-carry. Two independent triggers: a character-based print width (warn only) and a class-count budget
-per line (autofix on template literals).
+carry. Two independent triggers: a character-based print width and a class-count budget per line,
+both autofixing template literals (string literals only report — they can't safely span lines).
 
 DS-independent — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
 string and doesn't care what the classes mean.
@@ -24,9 +24,16 @@ conforming lines are left untouched. Other rules (`no-unnecessary-whitespace`, `
 
 Maximum length of any **single line** of the class string. For a one-line string that is its whole
 length; for a multiline template it is the longest individual line, so splitting a long string
-across lines can actually satisfy the rule. When exceeded, the rule reports `tooLong` but does
-**not** autofix — splitting a long string into a multiline literal is a judgment call (extract a
-component vs. just wrap it), so the rule surfaces the warning and lets you decide.
+across lines can actually satisfy the rule. A line whose single class alone exceeds the width is not
+reported — it can't be wrapped any shorter.
+
+When `classesPerLine` is **not** set, template literals get a **width-based autofix**: classes are
+grouped into runs sharing a variant chain (`hover:`, `md:hover:`, or none), each run starts its own
+line, and within a run classes are packed onto a line until adding the next would exceed
+`printWidth` (indentation included). Multiline templates that fit the width but don't match that
+layout are normalized too, under the `inconsistentWrapping` message. In string literals the rule
+reports `tooLong` without a fix — splitting a string literal into a multiline template is a judgment
+call (extract a component vs. just wrap it), so the rule surfaces the warning and lets you decide.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
@@ -40,6 +47,9 @@ Maximum number of classes on a single line. When exceeded inside a template lite
 rule autofixes by wrapping the classes into the block convention, chunks of `classesPerLine` per
 line. Inside string literals (`"…"`) the rule reports `tooManyPerLine` but doesn't autofix — string
 literals can't safely span lines without manual intervention.
+
+Setting `classesPerLine` switches the template-literal fixer to this chunk-based mode and turns the
+width-based (variant-grouped) fixer off — `printWidth` then only reports.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -63,6 +73,14 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 
 // Same count, string literal — reports but no autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
+
+// printWidth: 40 without classesPerLine — width-based fix, grouped by variant
+const buttonClass = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`
+// → const buttonClass = `
+//     flex items-center gap-2
+//     hover:bg-red-500 hover:underline
+//     focus:outline-none
+//   `
 ```
 
 ### ✓ Correct

--- a/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
@@ -1,20 +1,23 @@
 ## What this rule does
 
-Flags long class strings so they don't sprawl past a sensible line length and, optionally, splits
-them into multiple lines when they contain more classes than your team agrees a single line should
-carry. Two independent triggers: a character-based print width and a class-count budget per line,
-both autofixing template literals (string literals only report — they can't safely span lines).
+Flags long class strings so they don't sprawl past a sensible line length and, when you opt in,
+wraps them into multiple lines. Two independent formatting modes: a width-based re-wrap (opt-in via
+`wrapLines`) and a class-count budget per line (`classesPerLine`), both autofixing template literals
+(string literals only report — they can't safely span lines).
 
 DS-independent — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
 string and doesn't care what the classes mean.
 
-The autofix wraps template literals into the **block convention**: the content starts on its own
+Both fixers wrap template literals into the **block convention**: the content starts on its own
 line, each wrapped line is indented one level below the statement's own indentation, and the closing
 backtick sits on its own line. The base indentation is read from the source line (not the backtick
-column), so the block nests correctly even inside deeply-indented JSX. The fix is
-**non-destructive** — a template that is already wrapped only has its over-budget lines re-wrapped;
-conforming lines are left untouched. Other rules (`no-unnecessary-whitespace`, `enforce-sort-order`,
-…) are aware of this multiline shape and won't collapse it back.
+column), so the block nests correctly even inside deeply-indented JSX. The `classesPerLine` fix and
+the `"overWidth"` width fix are **non-destructive** — a template that is already wrapped only has
+its over-budget lines re-wrapped; conforming lines are left untouched. The `"all"` width fix is a
+**full re-layout**: it lays the whole template out in the canonical variant-grouped form, replacing
+any hand layout (which is why it's a separate, explicit mode). Other rules
+(`no-unnecessary-whitespace`, `enforce-sort-order`, …) are aware of this multiline shape and won't
+collapse it back.
 
 ## Options
 
@@ -27,16 +30,75 @@ length; for a multiline template it is the longest individual line, so splitting
 across lines can actually satisfy the rule. A line whose single class alone exceeds the width is not
 reported — it can't be wrapped any shorter.
 
-When `classesPerLine` is **not** set, template literals get a **width-based autofix**: classes are
-grouped into runs sharing a variant chain (`hover:`, `md:hover:`, or none), each run starts its own
-line, and within a run classes are packed onto a line until adding the next would exceed
-`printWidth` (indentation included). Multiline templates that fit the width but don't match that
-layout are normalized too, under the `inconsistentWrapping` message. In string literals the rule
-reports `tooLong` without a fix — splitting a string literal into a multiline template is a judgment
-call (extract a component vs. just wrap it), so the rule surfaces the warning and lets you decide.
+On its own, `printWidth` is **warn-only**: it reports `tooLong` and never rewrites your code. The
+autofix is opt-in via `wrapLines`.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
+```
+
+### `wrapLines`
+
+`"overWidth" | "all"`, optional. No default — like `classesPerLine`, leaving it unset means the
+fixer is off and `printWidth` only reports.
+
+Turns on the **width-based autofix** for template literals. The two modes differ in both reach and
+layout:
+
+- `"overWidth"`: only the **lines** that actually exceed `printWidth` are re-wrapped — each is
+  greedily packed into the fewest lines that fit the budget (no variant grouping), reusing the
+  line's own indentation. Everything else is left verbatim: templates whose lines all fit, and the
+  conforming lines of a template that does get touched, keep their hand-formatted layout. A
+  single-line template has no layout to preserve, so it converts to the block convention.
+- `"all"`: **every** multiline (or over-width) template is normalized to a canonical layout,
+  mirroring `eslint-plugin-better-tailwindcss`'s fixer: classes are grouped into runs sharing a
+  variant chain (`hover:`, `md:hover:`, or none), and within a run classes are packed onto a line
+  until adding the next would exceed `printWidth` (indentation included). How the runs are separated
+  is controlled by `group` (below). Within-budget templates that don't match that layout report
+  `inconsistentWrapping`.
+
+In string literals the rule reports `tooLong` without a fix regardless of `wrapLines` — splitting a
+string literal into a multiline template is a judgment call (extract a component vs. just wrap it),
+so the rule surfaces the warning and lets you decide. A template fragment **glued** to a `${}` with
+no whitespace (`` `${a}flex …` `` — one runtime class) is also never autofixed: any whitespace
+introduced at the boundary would split that class in two.
+
+`wrapLines` only applies when `classesPerLine` is **not** set — `classesPerLine` owns the layout
+otherwise.
+
+```jsonc
+{
+  "tailwindcss/enforce-consistent-line-wrapping": [
+    "error",
+    { "printWidth": 100, "wrapLines": "overWidth" },
+  ],
+}
+```
+
+### `group`
+
+`"newLine" | "emptyLine" | "never"`, default `"newLine"`.
+
+How the `wrapLines: "all"` layout separates variant groups. Matches
+`eslint-plugin-better-tailwindcss`'s `group` option (same name, values, and default), so a migrated
+config carries over unchanged.
+
+- `"newLine"` (default): each variant run starts its own line.
+- `"emptyLine"`: additionally, a **blank line** separates the runs (the blank lines carry no
+  trailing whitespace, and `no-unnecessary-whitespace` preserves them).
+- `"never"`: no grouping — classes are packed greedily across run boundaries into the fewest lines
+  that fit `printWidth`.
+
+`group` only shapes the `"all"` layout: `"overWidth"` deliberately never re-groups (it only splits
+over-budget lines), and the `classesPerLine` fixer chunks by count, so both ignore it.
+
+```jsonc
+{
+  "tailwindcss/enforce-consistent-line-wrapping": [
+    "error",
+    { "printWidth": 100, "wrapLines": "all", "group": "emptyLine" },
+  ],
+}
 ```
 
 ### `classesPerLine`
@@ -49,7 +111,8 @@ line. Inside string literals (`"…"`) the rule reports `tooManyPerLine` but doe
 literals can't safely span lines without manual intervention.
 
 Setting `classesPerLine` switches the template-literal fixer to this chunk-based mode and turns the
-width-based (variant-grouped) fixer off — `printWidth` then only reports.
+width-based (variant-grouped) fixer off — `printWidth` then only reports, and `wrapLines` is
+ignored.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -60,7 +123,7 @@ width-based (variant-grouped) fixer off — `printWidth` then only reports.
 ### ✗ Incorrect
 
 ```tsx
-// Exceeds default printWidth of 80 characters
+// Exceeds default printWidth of 80 characters — reports; without `wrapLines` there is no autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white text-black rounded shadow-lg border w-full" />
 //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tooLong
 
@@ -74,7 +137,21 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 // Same count, string literal — reports but no autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
 
-// printWidth: 40 without classesPerLine — width-based fix, grouped by variant
+// printWidth: 40 with wrapLines: "overWidth" — ONLY the over-budget
+// line is re-wrapped; the conforming lines around it stay exactly as written
+const cardClass = `
+  flex hover:underline
+  items-center justify-between gap-4 rounded-lg p-6
+  focus:outline-none
+`
+// → const cardClass = `
+//     flex hover:underline
+//     items-center justify-between gap-4
+//     rounded-lg p-6
+//     focus:outline-none
+//   `
+
+// printWidth: 40 with wrapLines: "all" — full re-layout, grouped by variant
 const buttonClass = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`
 // → const buttonClass = `
 //     flex items-center gap-2
@@ -94,6 +171,13 @@ const className = `
   flex items-center p-4
   bg-white text-black
 `
+
+// Hand-formatted multiline template, every line within printWidth — untouched
+// when wrapLines is unset or "overWidth"; only "all" re-groups it
+const cardClass = `
+  flex hover:underline
+  items-center
+`
 ```
 
 ## Interactions with other rules
@@ -102,7 +186,8 @@ const className = `
   The two were designed to coexist; without that preservation, fixers would oscillate (issue #14).
 - **`enforce-sort-order`**: rebuilds class strings from a token list via `rebuildClassString`, which
   keeps the multiline separators. The sort fixer and the wrap fixer run on the same string without
-  fighting.
+  fighting. The width fixer never reorders classes — it only chooses where the line breaks go — so
+  sorting stays entirely `enforce-sort-order`'s job.
 - **All extractor-driven rules**: `splitClassesWithSeparators` is multiline-aware, so every other
   rule (`enforce-canonical`, `enforce-shorthand`, …) reports against multiline class strings the
   same way it does against single-line ones.

--- a/packages/docs/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/enforce-consistent-line-wrapping.md
@@ -6,8 +6,8 @@
 
 Flags long class strings so they don't sprawl past a sensible line length and, optionally, splits
 them into multiple lines when they contain more classes than your team agrees a single line should
-carry. Two independent triggers: a character-based print width (warn only) and a class-count budget
-per line (autofix on template literals).
+carry. Two independent triggers: a character-based print width and a class-count budget per line,
+both autofixing template literals (string literals only report — they can't safely span lines).
 
 DS-independent — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
 string and doesn't care what the classes mean.
@@ -28,9 +28,16 @@ conforming lines are left untouched. Other rules (`no-unnecessary-whitespace`, `
 
 Maximum length of any **single line** of the class string. For a one-line string that is its whole
 length; for a multiline template it is the longest individual line, so splitting a long string
-across lines can actually satisfy the rule. When exceeded, the rule reports `tooLong` but does
-**not** autofix — splitting a long string into a multiline literal is a judgment call (extract a
-component vs. just wrap it), so the rule surfaces the warning and lets you decide.
+across lines can actually satisfy the rule. A line whose single class alone exceeds the width is not
+reported — it can't be wrapped any shorter.
+
+When `classesPerLine` is **not** set, template literals get a **width-based autofix**: classes are
+grouped into runs sharing a variant chain (`hover:`, `md:hover:`, or none), each run starts its own
+line, and within a run classes are packed onto a line until adding the next would exceed
+`printWidth` (indentation included). Multiline templates that fit the width but don't match that
+layout are normalized too, under the `inconsistentWrapping` message. In string literals the rule
+reports `tooLong` without a fix — splitting a string literal into a multiline template is a judgment
+call (extract a component vs. just wrap it), so the rule surfaces the warning and lets you decide.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
@@ -44,6 +51,9 @@ Maximum number of classes on a single line. When exceeded inside a template lite
 rule autofixes by wrapping the classes into the block convention, chunks of `classesPerLine` per
 line. Inside string literals (`"…"`) the rule reports `tooManyPerLine` but doesn't autofix — string
 literals can't safely span lines without manual intervention.
+
+Setting `classesPerLine` switches the template-literal fixer to this chunk-based mode and turns the
+width-based (variant-grouped) fixer off — `printWidth` then only reports.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -67,6 +77,14 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 
 // Same count, string literal — reports but no autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
+
+// printWidth: 40 without classesPerLine — width-based fix, grouped by variant
+const buttonClass = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`
+// → const buttonClass = `
+//     flex items-center gap-2
+//     hover:bg-red-500 hover:underline
+//     focus:outline-none
+//   `
 ```
 
 ### ✓ Correct

--- a/packages/docs/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/enforce-consistent-line-wrapping.md
@@ -4,21 +4,24 @@
 
 ## What this rule does
 
-Flags long class strings so they don't sprawl past a sensible line length and, optionally, splits
-them into multiple lines when they contain more classes than your team agrees a single line should
-carry. Two independent triggers: a character-based print width and a class-count budget per line,
-both autofixing template literals (string literals only report — they can't safely span lines).
+Flags long class strings so they don't sprawl past a sensible line length and, when you opt in,
+wraps them into multiple lines. Two independent formatting modes: a width-based re-wrap (opt-in via
+`wrapLines`) and a class-count budget per line (`classesPerLine`), both autofixing template literals
+(string literals only report — they can't safely span lines).
 
 DS-independent — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
 string and doesn't care what the classes mean.
 
-The autofix wraps template literals into the **block convention**: the content starts on its own
+Both fixers wrap template literals into the **block convention**: the content starts on its own
 line, each wrapped line is indented one level below the statement's own indentation, and the closing
 backtick sits on its own line. The base indentation is read from the source line (not the backtick
-column), so the block nests correctly even inside deeply-indented JSX. The fix is
-**non-destructive** — a template that is already wrapped only has its over-budget lines re-wrapped;
-conforming lines are left untouched. Other rules (`no-unnecessary-whitespace`, `enforce-sort-order`,
-…) are aware of this multiline shape and won't collapse it back.
+column), so the block nests correctly even inside deeply-indented JSX. The `classesPerLine` fix and
+the `"overWidth"` width fix are **non-destructive** — a template that is already wrapped only has
+its over-budget lines re-wrapped; conforming lines are left untouched. The `"all"` width fix is a
+**full re-layout**: it lays the whole template out in the canonical variant-grouped form, replacing
+any hand layout (which is why it's a separate, explicit mode). Other rules
+(`no-unnecessary-whitespace`, `enforce-sort-order`, …) are aware of this multiline shape and won't
+collapse it back.
 
 ## Options
 
@@ -31,16 +34,75 @@ length; for a multiline template it is the longest individual line, so splitting
 across lines can actually satisfy the rule. A line whose single class alone exceeds the width is not
 reported — it can't be wrapped any shorter.
 
-When `classesPerLine` is **not** set, template literals get a **width-based autofix**: classes are
-grouped into runs sharing a variant chain (`hover:`, `md:hover:`, or none), each run starts its own
-line, and within a run classes are packed onto a line until adding the next would exceed
-`printWidth` (indentation included). Multiline templates that fit the width but don't match that
-layout are normalized too, under the `inconsistentWrapping` message. In string literals the rule
-reports `tooLong` without a fix — splitting a string literal into a multiline template is a judgment
-call (extract a component vs. just wrap it), so the rule surfaces the warning and lets you decide.
+On its own, `printWidth` is **warn-only**: it reports `tooLong` and never rewrites your code. The
+autofix is opt-in via `wrapLines`.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "printWidth": 100 }] }
+```
+
+### `wrapLines`
+
+`"overWidth" | "all"`, optional. No default — like `classesPerLine`, leaving it unset means the
+fixer is off and `printWidth` only reports.
+
+Turns on the **width-based autofix** for template literals. The two modes differ in both reach and
+layout:
+
+- `"overWidth"`: only the **lines** that actually exceed `printWidth` are re-wrapped — each is
+  greedily packed into the fewest lines that fit the budget (no variant grouping), reusing the
+  line's own indentation. Everything else is left verbatim: templates whose lines all fit, and the
+  conforming lines of a template that does get touched, keep their hand-formatted layout. A
+  single-line template has no layout to preserve, so it converts to the block convention.
+- `"all"`: **every** multiline (or over-width) template is normalized to a canonical layout,
+  mirroring `eslint-plugin-better-tailwindcss`'s fixer: classes are grouped into runs sharing a
+  variant chain (`hover:`, `md:hover:`, or none), and within a run classes are packed onto a line
+  until adding the next would exceed `printWidth` (indentation included). How the runs are separated
+  is controlled by `group` (below). Within-budget templates that don't match that layout report
+  `inconsistentWrapping`.
+
+In string literals the rule reports `tooLong` without a fix regardless of `wrapLines` — splitting a
+string literal into a multiline template is a judgment call (extract a component vs. just wrap it),
+so the rule surfaces the warning and lets you decide. A template fragment **glued** to a `${}` with
+no whitespace (`` `${a}flex …` `` — one runtime class) is also never autofixed: any whitespace
+introduced at the boundary would split that class in two.
+
+`wrapLines` only applies when `classesPerLine` is **not** set — `classesPerLine` owns the layout
+otherwise.
+
+```jsonc
+{
+  "tailwindcss/enforce-consistent-line-wrapping": [
+    "error",
+    { "printWidth": 100, "wrapLines": "overWidth" },
+  ],
+}
+```
+
+### `group`
+
+`"newLine" | "emptyLine" | "never"`, default `"newLine"`.
+
+How the `wrapLines: "all"` layout separates variant groups. Matches
+`eslint-plugin-better-tailwindcss`'s `group` option (same name, values, and default), so a migrated
+config carries over unchanged.
+
+- `"newLine"` (default): each variant run starts its own line.
+- `"emptyLine"`: additionally, a **blank line** separates the runs (the blank lines carry no
+  trailing whitespace, and `no-unnecessary-whitespace` preserves them).
+- `"never"`: no grouping — classes are packed greedily across run boundaries into the fewest lines
+  that fit `printWidth`.
+
+`group` only shapes the `"all"` layout: `"overWidth"` deliberately never re-groups (it only splits
+over-budget lines), and the `classesPerLine` fixer chunks by count, so both ignore it.
+
+```jsonc
+{
+  "tailwindcss/enforce-consistent-line-wrapping": [
+    "error",
+    { "printWidth": 100, "wrapLines": "all", "group": "emptyLine" },
+  ],
+}
 ```
 
 ### `classesPerLine`
@@ -53,7 +115,8 @@ line. Inside string literals (`"…"`) the rule reports `tooManyPerLine` but doe
 literals can't safely span lines without manual intervention.
 
 Setting `classesPerLine` switches the template-literal fixer to this chunk-based mode and turns the
-width-based (variant-grouped) fixer off — `printWidth` then only reports.
+width-based (variant-grouped) fixer off — `printWidth` then only reports, and `wrapLines` is
+ignored.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
@@ -64,7 +127,7 @@ width-based (variant-grouped) fixer off — `printWidth` then only reports.
 ### ✗ Incorrect
 
 ```tsx
-// Exceeds default printWidth of 80 characters
+// Exceeds default printWidth of 80 characters — reports; without `wrapLines` there is no autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white text-black rounded shadow-lg border w-full" />
 //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ tooLong
 
@@ -78,7 +141,21 @@ const className = `flex items-center justify-between p-4 m-2 bg-white`
 // Same count, string literal — reports but no autofix
 <div className="flex items-center justify-between p-4 m-2 bg-white" />
 
-// printWidth: 40 without classesPerLine — width-based fix, grouped by variant
+// printWidth: 40 with wrapLines: "overWidth" — ONLY the over-budget
+// line is re-wrapped; the conforming lines around it stay exactly as written
+const cardClass = `
+  flex hover:underline
+  items-center justify-between gap-4 rounded-lg p-6
+  focus:outline-none
+`
+// → const cardClass = `
+//     flex hover:underline
+//     items-center justify-between gap-4
+//     rounded-lg p-6
+//     focus:outline-none
+//   `
+
+// printWidth: 40 with wrapLines: "all" — full re-layout, grouped by variant
 const buttonClass = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`
 // → const buttonClass = `
 //     flex items-center gap-2
@@ -98,6 +175,13 @@ const className = `
   flex items-center p-4
   bg-white text-black
 `
+
+// Hand-formatted multiline template, every line within printWidth — untouched
+// when wrapLines is unset or "overWidth"; only "all" re-groups it
+const cardClass = `
+  flex hover:underline
+  items-center
+`
 ```
 
 ## Interactions with other rules
@@ -106,7 +190,8 @@ const className = `
   The two were designed to coexist; without that preservation, fixers would oscillate (issue #14).
 - **`enforce-sort-order`**: rebuilds class strings from a token list via `rebuildClassString`, which
   keeps the multiline separators. The sort fixer and the wrap fixer run on the same string without
-  fighting.
+  fighting. The width fixer never reorders classes — it only chooses where the line breaks go — so
+  sorting stays entirely `enforce-sort-order`'s job.
 - **All extractor-driven rules**: `splitClassesWithSeparators` is multiline-aware, so every other
   rule (`enforce-canonical`, `enforce-shorthand`, …) reports against multiline class strings the
   same way it does against single-line ones.

--- a/packages/docs/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/enforce-consistent-line-wrapping.md
@@ -9,8 +9,12 @@ wraps them into multiple lines. Two independent formatting modes: a width-based 
 `wrapLines`) and a class-count budget per line (`classesPerLine`), both autofixing template literals
 (string literals only report — they can't safely span lines).
 
-DS-independent — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
-string and doesn't care what the classes mean.
+DS-optional — works without `settings.tailwindcss.entryPoint`. The rule operates on the raw class
+string and doesn't care what the classes mean, with one exception: when a design system **is**
+available, the `wrapLines: "all"` grouping consults it for the Tailwind v4 project prefix
+(`@import "tailwindcss" prefix(tw)`) so the prefix is transparent to grouping — `tw:flex` groups as
+a base utility and `tw:hover:x` as `hover:`. Without an entry point the rule silently falls back to
+treating the prefix as part of the variant chain (it never reports a missing design system).
 
 Both fixers wrap template literals into the **block convention**: the content starts on its own
 line, each wrapped line is indented one level below the statement's own indentation, and the closing

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 1.11.0
+
+`enforce-consistent-line-wrapping`'s `printWidth` reported over-width class strings but offered no
+fix, so satisfying it in a large codebase meant re-wrapping by hand. This release adds a width-based
+autofix for template literals — **off by default and opt-in via the new `wrapLines` option**
+([#126](https://github.com/sergioazoc/oxlint-tailwindcss/pull/126)).
+
+### New features
+
+- **`enforce-consistent-line-wrapping`: new `wrapLines` option** (`"overWidth" | "all"`, optional).
+  Like `classesPerLine`, it has no default: left unset, `printWidth` stays exactly as it was —
+  warn-only, no autofix — so existing configs see no behavior change; nothing is re-wrapped until
+  you explicitly choose one of the two modes (and `classesPerLine` is not set).
+  - `"overWidth"` re-wraps **only the lines that actually exceed `printWidth`**, greedily packing
+    each into the fewest lines that fit the budget while reusing that line's own indentation — the
+    same non-destructive contract as the `classesPerLine` fixer. Templates whose lines all fit, and
+    the conforming lines of a template that does get touched, keep their hand-formatted layout
+    untouched.
+  - `"all"` normalizes every multiline (or over-width) template to a canonical layout, mirroring
+    better-tailwindcss's fixer: classes sharing a variant chain (`hover:`, `md:hover:`, or none)
+    form runs, and a run wraps when adding the next class would exceed `printWidth` (indentation
+    included). A within-budget template that doesn't match that layout reports
+    `inconsistentWrapping`.
+
+  In both modes class **order is never changed** — the fixer only chooses where the line breaks go.
+  Template fragments glued to a `${}` with no whitespace (`` `${a}flex …` `` — one runtime class)
+  are never autofixed: introducing whitespace at the boundary would split the class in two.
+
+- **`enforce-consistent-line-wrapping`: new `group` option** (`"newLine" | "emptyLine" | "never"`,
+  default `"newLine"`), controlling how the `wrapLines: "all"` layout separates variant groups. It
+  matches better-tailwindcss's `group` option — same name, values, and default — so a migrated
+  config carries over unchanged: `"newLine"` starts each variant run on its own line (the default,
+  and the previous behavior), `"emptyLine"` additionally separates runs with a blank line (blank
+  lines carry no trailing whitespace and survive `no-unnecessary-whitespace` and the other fixers),
+  and `"never"` skips grouping entirely, packing classes greedily into the fewest lines that fit.
+  `"overWidth"` and the `classesPerLine` fixer never re-group, so they ignore `group`.
+
+### Changed
+
+- **`enforce-consistent-line-wrapping` no longer reports `tooLong` for a line whose single class
+  alone exceeds `printWidth`** (e.g. a long arbitrary value like `w-[calc(100vw-theme(spacing.24))]`
+  under a small width). Such a line cannot be wrapped any shorter, so the report was unactionable
+  noise. If you relied on it to catch very long single classes,
+  `max-class-count`/`no-arbitrary-value` remain the right tools.
+
 ## 1.10.2
 
 Typing an **incomplete** arbitrary value in a `className` (e.g. `px-[calc(var(--a)+var(--b)+)]`, a

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -44,6 +44,14 @@ autofix for template literals — **off by default and opt-in via the new `wrapL
   under a small width). Such a line cannot be wrapped any shorter, so the report was unactionable
   noise. If you relied on it to catch very long single classes,
   `max-class-count`/`no-arbitrary-value` remain the right tools.
+- **`enforce-consistent-line-wrapping` is now design-system optional**. When
+  `settings.tailwindcss.entryPoint` is configured, the `wrapLines: "all"` with either
+  `group: "newLine"` or `group: "emptyLine"` consults the design system for the project prefix
+  (`@import "tailwindcss" prefix(tw)`) and strips that prefix before determining variant groups. If
+  `entryPoint` is not configured, these rules silently fall back to treating the prefix as part of
+  the variant chain. It never reports `designSystemUnavailable`, and the design system is only
+  consulted for these two specific fixers so no performance penalty is applied to the rule if those
+  fixers are not used.
 
 ## 1.10.2
 

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
@@ -4,12 +4,55 @@ import { splitClasses } from '../utils/class-splitter'
 import { createLazyOptions, safeSourceCode } from '../utils/context'
 import { getVariantPrefix } from '../utils/class-parser'
 
+/*
+ * A template literal is linted per QUASI — each run of static text between
+ * the backticks and any `${}` interpolations. In `` `flex ${a} p-2` `` there
+ * are two quasis: the LEADING one (`flex `, between the opening backtick and
+ * the first `${}`) and the TRAILING one (` p-2`, between the last `${}` and
+ * the closing backtick); a template without interpolations is one quasi. On
+ * a quasi's ClassLocation, `preserveLeadingSpace` means a `${}` sits
+ * directly before it, `preserveTrailingSpace` that one sits directly after.
+ *
+ * The fixers wrap a quasi according to what borders it:
+ *  - opening backtick before it (whole template, or a leading quasi):
+ *    BLOCK form — classes move onto their own indented lines below the
+ *    backtick;
+ *  - `${}` before it: HANGING form — the first packed line stays beside the
+ *    interpolation, continuation lines are indented below it;
+ *  - GLUED to a `${}` (no whitespace at the boundary, as in `${a}flex`):
+ *    never autofixed, warn-only — the quasi text concatenates with the
+ *    interpolation into ONE runtime class, so inserting whitespace at the
+ *    boundary would split that class in two.
+ */
+
+/**
+ * Which lines the width-based autofix re-wraps. No default — unset means
+ * `printWidth` is warn-only (no autofix), like `classesPerLine`.
+ *  - 'overWidth' — only lines exceeding `printWidth`, greedily re-packed;
+ *                  conforming lines are left exactly as hand-formatted.
+ *  - 'all'       — every multiline or over-width template is re-laid-out
+ *                  into the canonical layout shaped by `group`.
+ */
+type WrapLinesMode = 'overWidth' | 'all'
+
+/**
+ * How the `wrapLines: 'all'` canonical layout separates variant groups
+ * ('overWidth' never re-groups, so this option does not affect it):
+ *  - 'newLine'   — each variant run starts its own line. The default.
+ *  - 'emptyLine' — additionally, a blank line separates the runs.
+ *  - 'never'     — no grouping: classes pack greedily across run boundaries.
+ */
+type GroupMode = 'newLine' | 'emptyLine' | 'never'
+
 interface Options {
   printWidth?: number
   classesPerLine?: number
+  wrapLines?: WrapLinesMode
+  group?: GroupMode
 }
 
 const DEFAULT_PRINT_WIDTH = 80
+const DEFAULT_GROUP: GroupMode = 'newLine'
 
 /** One indentation level added below the statement's base indent for wrapped lines. */
 const INDENT_UNIT = '  '
@@ -24,9 +67,10 @@ function chunkList(classes: string[], n: number): string[] {
 }
 
 /**
- * Greedily pack `classes` into space-joined lines, adding classes to the
- * current line until `indent` + the line would exceed `width`. A single class
- * that alone exceeds the budget still gets its own line.
+ * Greedily pack `classes` into space-joined lines: a line takes classes until
+ * `indent` + the next one would exceed `width`; a single class over the
+ * budget still gets its own line. Widths count characters, so a tab in
+ * `indent` is 1 column (detection uses the same yardstick, so tabs converge).
  */
 function packToWidth(classes: string[], indent: string, width: number): string[] {
   const lines: string[] = []
@@ -66,9 +110,25 @@ function groupByVariantRun(classes: string[]): string[][] {
   return groups
 }
 
-/** Pack each variant group onto its own line(s): groups never share a line. */
-function packGroupedToWidth(classes: string[], indent: string, width: number): string[] {
-  return groupByVariantRun(classes).flatMap((group) => packToWidth(group, indent, width))
+/**
+ * Pack `classes` per the `group` mode: 'never' packs greedily across
+ * variant-run boundaries, 'newLine' starts each run on its own line(s), and
+ * 'emptyLine' additionally inserts an extra line between runs — emitted as a
+ * blank line with no indent.
+ */
+function packGroupedToWidth(
+  classes: string[],
+  indent: string,
+  width: number,
+  group: GroupMode,
+): string[] {
+  if (group === 'never') return packToWidth(classes, indent, width)
+  const lines: string[] = []
+  for (const run of groupByVariantRun(classes)) {
+    if (group === 'emptyLine' && lines.length > 0) lines.push('')
+    lines.push(...packToWidth(run, indent, width))
+  }
+  return lines
 }
 
 export const enforceConsistentLineWrapping = defineRule({
@@ -84,18 +144,22 @@ export const enforceConsistentLineWrapping = defineRule({
         properties: {
           printWidth: { type: 'number' },
           classesPerLine: { type: 'number' },
+          wrapLines: { type: 'string', enum: ['overWidth', 'all'] },
+          group: { type: 'string', enum: ['newLine', 'emptyLine', 'never'] },
         },
         additionalProperties: false,
       },
     ],
-    defaultOptions: [{ printWidth: DEFAULT_PRINT_WIDTH }],
+    // `wrapLines` and `classesPerLine` deliberately have no default:
+    // leaving either unset turns its fixer off.
+    defaultOptions: [{ printWidth: DEFAULT_PRINT_WIDTH, group: DEFAULT_GROUP }],
     messages: {
       tooLong:
         'Class string exceeds the print width of {{printWidth}} (longest line is {{length}} characters). Consider splitting into multiple lines or extracting into a component.',
       tooManyPerLine:
         'Too many classes on a single line ({{count}}). Maximum allowed per line is {{max}}.',
       inconsistentWrapping:
-        'Class string is not wrapped consistently. Classes should be grouped by variant and wrapped within the print width of {{printWidth}}.',
+        'Class string is not wrapped consistently. Classes should be re-wrapped to the configured layout within the print width of {{printWidth}}.',
     },
   },
   createOnce(context) {
@@ -106,6 +170,14 @@ export const enforceConsistentLineWrapping = defineRule({
     const getClassesPerLine = createLazyOptions<Options, number | undefined>(
       context,
       (o) => o?.classesPerLine,
+    )
+    const getWrapLines = createLazyOptions<Options, WrapLinesMode | undefined>(
+      context,
+      (o) => o?.wrapLines,
+    )
+    const getGroup = createLazyOptions<Options, GroupMode>(
+      context,
+      (o) => o?.group ?? DEFAULT_GROUP,
     )
 
     /**
@@ -163,46 +235,94 @@ export const enforceConsistentLineWrapping = defineRule({
     }
 
     /**
-     * Width-based variant of `rewrapTemplate`: classes are grouped into runs
-     * sharing a variant chain (each run starts its own line), and within a
-     * run classes are packed onto a line until adding the next one would
-     * exceed `printWidth` (indent included). Multiline templates are fully
-     * re-laid-out into that canonical grouped form, not just their
-     * offending lines. Same indentation conventions as `rewrapTemplate`.
-     * Reserves one character per preserved leading/trailing space, since
-     * `preserveSpaces` re-adds them after packing — without the reserve a
-     * line packed to exactly `printWidth` lands at `printWidth + 1` and the
-     * fix never converges.
+     * `wrapLines: 'all'` fixer (also the single-line conversion for
+     * 'overWidth', which passes `group: 'never'`): the WHOLE quasi is
+     * re-laid-out into lines packed to `printWidth` per the `group` mode,
+     * in the block or hanging form its position dictates (see the quasi
+     * note at the top of the file).
      */
-    function rewrapTemplateToWidth(loc: ClassLocation, printWidth: number): string {
+    function rewrapTemplateToWidth(
+      loc: ClassLocation,
+      printWidth: number,
+      group: GroupMode,
+    ): string {
       const baseIndent = deriveBaseIndent(loc)
       const interiorIndent = baseIndent + INDENT_UNIT
-      const leadingReserve = loc.preserveLeadingSpace ? 1 : 0
-      const trailingReserve = loc.preserveTrailingSpace ? 1 : 0
       const classes = splitClasses(loc.value)
       if (classes.length === 0) return loc.value
-      if (!loc.preserveLeadingSpace && !loc.preserveTrailingSpace) {
-        const packed = packGroupedToWidth(classes, interiorIndent, printWidth)
-        return '\n' + packed.map((c) => interiorIndent + c).join('\n') + '\n' + baseIndent
+      if (!loc.preserveLeadingSpace) {
+        // Block form. Keyed off `preserveLeadingSpace` ALONE: a leading quasi
+        // must not take the hanging form below — its first line would land on
+        // the code before the backtick, over-width in the source yet
+        // invisible to the per-quasi line measurement. A `${}` after the
+        // quasi goes on its own interior-indented line.
+        const packed = packGroupedToWidth(classes, interiorIndent, printWidth, group)
+        const close = loc.preserveTrailingSpace ? interiorIndent : baseIndent
+        // `''` entries (blank group separators) take no indent.
+        return (
+          '\n' + packed.map((c) => (c === '' ? c : interiorIndent + c)).join('\n') + '\n' + close
+        )
       }
-      // Fragment adjacent to a `${}`: hanging join, no leading/trailing newline.
-      return packGroupedToWidth(
-        classes,
-        interiorIndent,
-        printWidth - leadingReserve - trailingReserve,
-      ).join('\n' + interiorIndent)
+      // Hanging form. One character is reserved per bordering `${}` for the
+      // boundary space `preserveSpaces` re-adds after packing — without the
+      // reserve a line packed to exactly `printWidth` lands at
+      // `printWidth + 1` and the fix never converges.
+      const trailingReserve = loc.preserveTrailingSpace ? 1 : 0
+      return packGroupedToWidth(classes, interiorIndent, printWidth - 1 - trailingReserve, group)
+        .map((c, i) => (i === 0 || c === '' ? c : interiorIndent + c))
+        .join('\n')
+    }
+
+    /**
+     * `wrapLines: 'overWidth'` fixer: non-destructive like `rewrapTemplate`
+     * — only lines exceeding `printWidth` are greedily re-packed, each
+     * keeping its own indent; conforming lines are left verbatim. A
+     * single-line value has no layout to preserve and converts to the block
+     * form. Returns the FINAL value, `${}` boundary spaces included — never
+     * run it through `preserveSpaces`, which would prepend a stray space to
+     * a quasi that legitimately starts with `\n`.
+     */
+    function rewrapOverBudgetLinesToWidth(loc: ClassLocation, printWidth: number): string {
+      const lines = loc.value.split('\n')
+      if (lines.length === 1) {
+        return preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth, 'never'))
+      }
+      const interiorIndent = deriveBaseIndent(loc) + INDENT_UNIT
+      // Reserve for the boundary space before a `${}` after the quasi,
+      // re-appended below if repacking dropped it.
+      const width = printWidth - (loc.preserveTrailingSpace ? 1 : 0)
+      const fixed = lines
+        .map((line) => {
+          const classes = splitClasses(line)
+          if (line.length <= printWidth || classes.length <= 1) return line
+          const m = /^[ \t]*/.exec(line)
+          const lead = m ? m[0] : ''
+          const contIndent = lead.length > 0 ? lead : interiorIndent
+          // First chunk keeps the line's original position (its `lead`,
+          // possibly none); continuation lines reuse that indent.
+          return packToWidth(classes, contIndent, width)
+            .map((c, i) => (i === 0 ? lead + c : contIndent + c))
+            .join('\n')
+        })
+        .join('\n')
+      // Leading boundary whitespace always survives as the first line's
+      // `lead`; only a repacked last line loses its trailing boundary space.
+      if (loc.preserveTrailingSpace && !/\s$/.test(fixed)) return fixed + ' '
+      return fixed
     }
 
     function check(locations: ClassLocation[]) {
       const printWidth = getPrintWidth()
       const classesPerLine = getClassesPerLine()
+      const wrapLines = getWrapLines()
+      const group = getGroup()
 
       for (const loc of locations) {
         // #110: measure the LONGEST INDIVIDUAL LINE, not the raw total. The raw
         // value of a multiline template includes every `\n` and indent, so
         // comparing its total length made wrapping impossible to satisfy.
-        // A line holding a single class can never be wrapped shorter, so an
-        // over-budget single class is not counted against the print width.
+        // An over-budget line holding a single class is skipped — it can't
+        // be wrapped any shorter.
         let maxLine = 0
         for (const line of loc.value.split('\n')) {
           if (line.length <= maxLine) continue
@@ -214,19 +334,26 @@ export const enforceConsistentLineWrapping = defineRule({
           printWidth: String(printWidth),
         }
         const isMultiline = loc.value.includes('\n')
+        // Glued quasis are warn-only (see the quasi note at the top).
+        const glued =
+          (loc.preserveLeadingSpace === true && !/^\s/.test(loc.value)) ||
+          (loc.preserveTrailingSpace === true && !/\s$/.test(loc.value))
         if (
+          wrapLines !== undefined &&
           classesPerLine === undefined &&
           loc.node.type === 'TemplateElement' &&
-          (maxLine > printWidth || isMultiline)
+          !glued &&
+          (maxLine > printWidth || (wrapLines === 'all' && isMultiline))
         ) {
-          // printWidth set without classesPerLine: enforce (and autofix to)
-          // variant-grouped lines packed to the print width. A multiline
-          // template that already fits is still normalized to that canonical
-          // form; one that matches it is valid. Compare AFTER preserveSpaces:
-          // a fragment's raw value carries the preserved space, and comparing
-          // without it re-reports an already-canonical fragment with a no-op
-          // fix.
-          const fixedValue = preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth))
+          // Compare the FINAL value (boundary spaces included), or an
+          // already-canonical quasi re-reports with a no-op fix. Equal values
+          // need no warn-only fallback: at a fixed point of either fixer
+          // every multi-class line fits the budget, and over-budget
+          // single-class lines were already excluded from `maxLine`.
+          const fixedValue =
+            wrapLines === 'all'
+              ? preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth, group))
+              : rewrapOverBudgetLinesToWidth(loc, printWidth)
           if (fixedValue !== loc.value) {
             context.report({
               node: loc.node,
@@ -236,8 +363,6 @@ export const enforceConsistentLineWrapping = defineRule({
                 return fixer.replaceTextRange(loc.range, fixedValue)
               },
             })
-          } else if (maxLine > printWidth) {
-            context.report({ node: loc.node, messageId: 'tooLong', data })
           }
         } else if (maxLine > printWidth) {
           context.report({ node: loc.node, messageId: 'tooLong', data })

--- a/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
@@ -2,6 +2,7 @@ import { defineRule } from '@oxlint/plugins'
 import { createExtractorVisitors, preserveSpaces, type ClassLocation } from '../utils/extractors'
 import { splitClasses } from '../utils/class-splitter'
 import { createLazyOptions, safeSourceCode } from '../utils/context'
+import { getVariantPrefix } from '../utils/class-parser'
 
 interface Options {
   printWidth?: number
@@ -20,6 +21,54 @@ function chunkList(classes: string[], n: number): string[] {
     chunks.push(classes.slice(i, i + n).join(' '))
   }
   return chunks
+}
+
+/**
+ * Greedily pack `classes` into space-joined lines, adding classes to the
+ * current line until `indent` + the line would exceed `width`. A single class
+ * that alone exceeds the budget still gets its own line.
+ */
+function packToWidth(classes: string[], indent: string, width: number): string[] {
+  const lines: string[] = []
+  let current = ''
+  for (const cls of classes) {
+    const candidate = current === '' ? cls : current + ' ' + cls
+    if (current !== '' && indent.length + candidate.length > width) {
+      lines.push(current)
+      current = cls
+    } else {
+      current = candidate
+    }
+  }
+  if (current !== '') lines.push(current)
+  return lines
+}
+
+/**
+ * Split `classes` into runs of consecutive classes sharing the same variant
+ * chain ("hover:", "md:hover:", "" for base utilities), so wrapping breaks
+ * between variant groups rather than mid-group.
+ */
+function groupByVariantRun(classes: string[]): string[][] {
+  const groups: string[][] = []
+  let current: string[] = []
+  let currentVariant: string | null = null
+  for (const cls of classes) {
+    const variant = getVariantPrefix(cls)
+    if (currentVariant !== null && variant !== currentVariant) {
+      groups.push(current)
+      current = []
+    }
+    currentVariant = variant
+    current.push(cls)
+  }
+  if (current.length > 0) groups.push(current)
+  return groups
+}
+
+/** Pack each variant group onto its own line(s): groups never share a line. */
+function packGroupedToWidth(classes: string[], indent: string, width: number): string[] {
+  return groupByVariantRun(classes).flatMap((group) => packToWidth(group, indent, width))
 }
 
 export const enforceConsistentLineWrapping = defineRule({
@@ -45,6 +94,8 @@ export const enforceConsistentLineWrapping = defineRule({
         'Class string exceeds the print width of {{printWidth}} (longest line is {{length}} characters). Consider splitting into multiple lines or extracting into a component.',
       tooManyPerLine:
         'Too many classes on a single line ({{count}}). Maximum allowed per line is {{max}}.',
+      inconsistentWrapping:
+        'Class string is not wrapped consistently. Classes should be grouped by variant and wrapped within the print width of {{printWidth}}.',
     },
   },
   createOnce(context) {
@@ -111,6 +162,37 @@ export const enforceConsistentLineWrapping = defineRule({
         .join('\n')
     }
 
+    /**
+     * Width-based variant of `rewrapTemplate`: classes are grouped into runs
+     * sharing a variant chain (each run starts its own line), and within a
+     * run classes are packed onto a line until adding the next one would
+     * exceed `printWidth` (indent included). Multiline templates are fully
+     * re-laid-out into that canonical grouped form, not just their
+     * offending lines. Same indentation conventions as `rewrapTemplate`.
+     * Reserves one character per preserved leading/trailing space, since
+     * `preserveSpaces` re-adds them after packing — without the reserve a
+     * line packed to exactly `printWidth` lands at `printWidth + 1` and the
+     * fix never converges.
+     */
+    function rewrapTemplateToWidth(loc: ClassLocation, printWidth: number): string {
+      const baseIndent = deriveBaseIndent(loc)
+      const interiorIndent = baseIndent + INDENT_UNIT
+      const leadingReserve = loc.preserveLeadingSpace ? 1 : 0
+      const trailingReserve = loc.preserveTrailingSpace ? 1 : 0
+      const classes = splitClasses(loc.value)
+      if (classes.length === 0) return loc.value
+      if (!loc.preserveLeadingSpace && !loc.preserveTrailingSpace) {
+        const packed = packGroupedToWidth(classes, interiorIndent, printWidth)
+        return '\n' + packed.map((c) => interiorIndent + c).join('\n') + '\n' + baseIndent
+      }
+      // Fragment adjacent to a `${}`: hanging join, no leading/trailing newline.
+      return packGroupedToWidth(
+        classes,
+        interiorIndent,
+        printWidth - leadingReserve - trailingReserve,
+      ).join('\n' + interiorIndent)
+    }
+
     function check(locations: ClassLocation[]) {
       const printWidth = getPrintWidth()
       const classesPerLine = getClassesPerLine()
@@ -119,19 +201,46 @@ export const enforceConsistentLineWrapping = defineRule({
         // #110: measure the LONGEST INDIVIDUAL LINE, not the raw total. The raw
         // value of a multiline template includes every `\n` and indent, so
         // comparing its total length made wrapping impossible to satisfy.
+        // A line holding a single class can never be wrapped shorter, so an
+        // over-budget single class is not counted against the print width.
         let maxLine = 0
         for (const line of loc.value.split('\n')) {
-          if (line.length > maxLine) maxLine = line.length
+          if (line.length <= maxLine) continue
+          if (line.length > printWidth && splitClasses(line).length <= 1) continue
+          maxLine = line.length
         }
-        if (maxLine > printWidth) {
-          context.report({
-            node: loc.node,
-            messageId: 'tooLong',
-            data: {
-              length: String(maxLine),
-              printWidth: String(printWidth),
-            },
-          })
+        const data = {
+          length: String(maxLine),
+          printWidth: String(printWidth),
+        }
+        const isMultiline = loc.value.includes('\n')
+        if (
+          classesPerLine === undefined &&
+          loc.node.type === 'TemplateElement' &&
+          (maxLine > printWidth || isMultiline)
+        ) {
+          // printWidth set without classesPerLine: enforce (and autofix to)
+          // variant-grouped lines packed to the print width. A multiline
+          // template that already fits is still normalized to that canonical
+          // form; one that matches it is valid. Compare AFTER preserveSpaces:
+          // a fragment's raw value carries the preserved space, and comparing
+          // without it re-reports an already-canonical fragment with a no-op
+          // fix.
+          const fixedValue = preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth))
+          if (fixedValue !== loc.value) {
+            context.report({
+              node: loc.node,
+              messageId: maxLine > printWidth ? 'tooLong' : 'inconsistentWrapping',
+              data,
+              fix(fixer) {
+                return fixer.replaceTextRange(loc.range, fixedValue)
+              },
+            })
+          } else if (maxLine > printWidth) {
+            context.report({ node: loc.node, messageId: 'tooLong', data })
+          }
+        } else if (maxLine > printWidth) {
+          context.report({ node: loc.node, messageId: 'tooLong', data })
         }
 
         if (classesPerLine !== undefined) {

--- a/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
@@ -3,6 +3,8 @@ import { createExtractorVisitors, preserveSpaces, type ClassLocation } from '../
 import { splitClasses } from '../utils/class-splitter'
 import { createLazyOptions, safeSourceCode } from '../utils/context'
 import { getVariantPrefix } from '../utils/class-parser'
+import { createLazyLoader } from '../design-system/loader'
+import { softGetDS } from '../utils/fatal'
 
 /*
  * A template literal is linted per QUASI — each run of static text between
@@ -45,6 +47,7 @@ type WrapLinesMode = 'overWidth' | 'all'
 type GroupMode = 'newLine' | 'emptyLine' | 'never'
 
 interface Options {
+  entryPoint?: string
   printWidth?: number
   classesPerLine?: number
   wrapLines?: WrapLinesMode
@@ -89,16 +92,29 @@ function packToWidth(classes: string[], indent: string, width: number): string[]
 }
 
 /**
+ * Variant chain used as the grouping key. A Tailwind v4 project prefix
+ * (`tw:`) is structurally a variant but pinned first, so it is stripped
+ * before the key is computed — `tw:flex` keys as a base utility (grouping
+ * with unprefixed component classes) and `tw:hover:x` keys as `hover:`,
+ * matching how consistent-variant-order / enforce-sort-order treat the
+ * prefix. Grouping only: emitted classes are never rewritten.
+ */
+function groupingKey(cls: string, prefix: string): string {
+  const bare = prefix !== '' && cls.startsWith(prefix + ':') ? cls.slice(prefix.length + 1) : cls
+  return getVariantPrefix(bare)
+}
+
+/**
  * Split `classes` into runs of consecutive classes sharing the same variant
  * chain ("hover:", "md:hover:", "" for base utilities), so wrapping breaks
  * between variant groups rather than mid-group.
  */
-function groupByVariantRun(classes: string[]): string[][] {
+function groupByVariantRun(classes: string[], prefix: string): string[][] {
   const groups: string[][] = []
   let current: string[] = []
   let currentVariant: string | null = null
   for (const cls of classes) {
-    const variant = getVariantPrefix(cls)
+    const variant = groupingKey(cls, prefix)
     if (currentVariant !== null && variant !== currentVariant) {
       groups.push(current)
       current = []
@@ -121,10 +137,11 @@ function packGroupedToWidth(
   indent: string,
   width: number,
   group: GroupMode,
+  prefix: string,
 ): string[] {
   if (group === 'never') return packToWidth(classes, indent, width)
   const lines: string[] = []
-  for (const run of groupByVariantRun(classes)) {
+  for (const run of groupByVariantRun(classes, prefix)) {
     if (group === 'emptyLine' && lines.length > 0) lines.push('')
     lines.push(...packToWidth(run, indent, width))
   }
@@ -142,6 +159,7 @@ export const enforceConsistentLineWrapping = defineRule({
       {
         type: 'object',
         properties: {
+          entryPoint: { type: 'string' },
           printWidth: { type: 'number' },
           classesPerLine: { type: 'number' },
           wrapLines: { type: 'string', enum: ['overWidth', 'all'] },
@@ -179,6 +197,7 @@ export const enforceConsistentLineWrapping = defineRule({
       context,
       (o) => o?.group ?? DEFAULT_GROUP,
     )
+    const getDS = createLazyLoader(context)
 
     /**
      * The statement's real base indentation — the leading whitespace of the
@@ -245,6 +264,7 @@ export const enforceConsistentLineWrapping = defineRule({
       loc: ClassLocation,
       printWidth: number,
       group: GroupMode,
+      prefix: string,
     ): string {
       const baseIndent = deriveBaseIndent(loc)
       const interiorIndent = baseIndent + INDENT_UNIT
@@ -256,7 +276,7 @@ export const enforceConsistentLineWrapping = defineRule({
         // the code before the backtick, over-width in the source yet
         // invisible to the per-quasi line measurement. A `${}` after the
         // quasi goes on its own interior-indented line.
-        const packed = packGroupedToWidth(classes, interiorIndent, printWidth, group)
+        const packed = packGroupedToWidth(classes, interiorIndent, printWidth, group, prefix)
         const close = loc.preserveTrailingSpace ? interiorIndent : baseIndent
         // `''` entries (blank group separators) take no indent.
         return (
@@ -268,7 +288,13 @@ export const enforceConsistentLineWrapping = defineRule({
       // reserve a line packed to exactly `printWidth` lands at
       // `printWidth + 1` and the fix never converges.
       const trailingReserve = loc.preserveTrailingSpace ? 1 : 0
-      return packGroupedToWidth(classes, interiorIndent, printWidth - 1 - trailingReserve, group)
+      return packGroupedToWidth(
+        classes,
+        interiorIndent,
+        printWidth - 1 - trailingReserve,
+        group,
+        prefix,
+      )
         .map((c, i) => (i === 0 || c === '' ? c : interiorIndent + c))
         .join('\n')
     }
@@ -285,7 +311,8 @@ export const enforceConsistentLineWrapping = defineRule({
     function rewrapOverBudgetLinesToWidth(loc: ClassLocation, printWidth: number): string {
       const lines = loc.value.split('\n')
       if (lines.length === 1) {
-        return preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth, 'never'))
+        // group 'never' does no grouping, so the prefix is irrelevant.
+        return preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth, 'never', ''))
       }
       const interiorIndent = deriveBaseIndent(loc) + INDENT_UNIT
       // Reserve for the boundary space before a `${}` after the quasi,
@@ -316,6 +343,15 @@ export const enforceConsistentLineWrapping = defineRule({
       const classesPerLine = getClassesPerLine()
       const wrapLines = getWrapLines()
       const group = getGroup()
+      // DS-OPTIONAL (see `softGetDS`): the design system is consulted ONLY
+      // for the Tailwind v4 project prefix, and only when the 'all' layout
+      // will actually group. With no entryPoint configured (or a failed
+      // load) the prefix silently falls back to '' and reads as part of the
+      // variant chain — this rule never emits `designSystemUnavailable`.
+      const prefix =
+        wrapLines === 'all' && group !== 'never' && classesPerLine === undefined
+          ? (softGetDS(getDS)?.cache.prefix ?? '')
+          : ''
 
       for (const loc of locations) {
         // #110: measure the LONGEST INDIVIDUAL LINE, not the raw total. The raw
@@ -352,7 +388,7 @@ export const enforceConsistentLineWrapping = defineRule({
           // single-class lines were already excluded from `maxLine`.
           const fixedValue =
             wrapLines === 'all'
-              ? preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth, group))
+              ? preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth, group, prefix))
               : rewrapOverBudgetLinesToWidth(loc, printWidth)
           if (fixedValue !== loc.value) {
             context.report({

--- a/packages/oxlint-tailwindcss/tests/integration/multiline-preservation.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/multiline-preservation.test.ts
@@ -202,6 +202,35 @@ describe('multiline preservation under default theme', () => {
     ],
   })
 
+  // Blank-line group separators (`\n\n` + indent, produced by
+  // enforce-consistent-line-wrapping's `group: 'emptyLine'` layout) must
+  // round-trip the fixers exactly like single-newline separators: verbatim
+  // through 1-to-1 reordering, and recovered via `pickSeparator` through
+  // count-changing fixes.
+  run('enforce-sort-order keeps emptyLine group separators', enforceSortOrder, {
+    valid: [],
+    invalid: [
+      {
+        code: 'const className = `text-white bg-red-500\n\n  focus:ring-2\n`',
+        filename: 'a.tsx',
+        errors: [{ messageId: 'unsorted' }],
+        output: 'const className = `bg-red-500 text-white\n\n  focus:ring-2\n`',
+      },
+    ],
+  })
+
+  run('no-duplicate-classes keeps emptyLine group separators', noDuplicateClasses, {
+    valid: [],
+    invalid: [
+      {
+        code: 'const className = `\n  flex flex items-center\n\n  hover:bg-white\n`',
+        filename: 'a.tsx',
+        errors: [{ messageId: 'duplicate' }],
+        output: 'const className = `\n  flex items-center\n\n  hover:bg-white\n`',
+      },
+    ],
+  })
+
   // Suggestion-only (typo fix); still needs to preserve multiline in the suggestion.
   run('no-unknown-classes suggestion keeps multiline', noUnknownClasses, {
     valid: [],

--- a/packages/oxlint-tailwindcss/tests/integration/whitespace-line-wrap-cycle.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/whitespace-line-wrap-cycle.test.ts
@@ -87,22 +87,22 @@ describe('issue #14 — whitespace × line-wrapping no longer cycle', () => {
     },
   )
 
-  // Step 5: the width-based fixer (printWidth without classesPerLine) wraps
-  // into the same block convention, grouped by variant run.
+  // Step 5: the width-based fixer (opt-in via `wrapLines`, no classesPerLine)
+  // wraps into the same block convention, grouped by variant run.
   new RuleTester().run('step 5: width-based line-wrapping autofix', enforceConsistentLineWrapping, {
     valid: [
       // Its own output is the canonical form — the fix converges.
       {
         code: 'const className = `\n  bg-red-500 text-white\n  hover:bg-red-600\n  focus:ring-2 focus:ring-red-500\n  disabled:bg-gray-300\n`',
         filename: 'a.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
       },
     ],
     invalid: [
       {
         code: 'const className = `bg-red-500 text-white hover:bg-red-600 focus:ring-2 focus:ring-red-500 disabled:bg-gray-300`',
         filename: 'a.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
         errors: [{ messageId: 'tooLong' }],
         output:
           'const className = `\n  bg-red-500 text-white\n  hover:bg-red-600\n  focus:ring-2 focus:ring-red-500\n  disabled:bg-gray-300\n`',
@@ -118,6 +118,45 @@ describe('issue #14 — whitespace × line-wrapping no longer cycle', () => {
       valid: [
         {
           code: 'const className = `\n  bg-red-500 text-white\n  hover:bg-red-600\n  focus:ring-2 focus:ring-red-500\n  disabled:bg-gray-300\n`',
+          filename: 'a.tsx',
+        },
+      ],
+      invalid: [],
+    },
+  )
+
+  // Step 7: group: 'emptyLine' separates the variant runs with blank lines.
+  new RuleTester().run('step 7: width fixer with group: emptyLine', enforceConsistentLineWrapping, {
+    valid: [
+      // Its own output is the canonical form — the fix converges.
+      {
+        code: 'const className = `\n  bg-red-500 text-white\n\n  hover:bg-red-600\n\n  focus:ring-2 focus:ring-red-500\n\n  disabled:bg-gray-300\n`',
+        filename: 'a.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all', group: 'emptyLine' }],
+      },
+    ],
+    invalid: [
+      {
+        code: 'const className = `bg-red-500 text-white hover:bg-red-600 focus:ring-2 focus:ring-red-500 disabled:bg-gray-300`',
+        filename: 'a.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all', group: 'emptyLine' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  bg-red-500 text-white\n\n  hover:bg-red-600\n\n  focus:ring-2 focus:ring-red-500\n\n  disabled:bg-gray-300\n`',
+      },
+    ],
+  })
+
+  // Step 8: whitespace stays silent on the blank-line-separated output — a
+  // blank line has no horizontal whitespace to collapse, so the emptyLine
+  // shape must not re-enter the #14 cycle.
+  new RuleTester().run(
+    'step 8: whitespace stays silent on emptyLine-grouped output',
+    noUnnecessaryWhitespace,
+    {
+      valid: [
+        {
+          code: 'const className = `\n  bg-red-500 text-white\n\n  hover:bg-red-600\n\n  focus:ring-2 focus:ring-red-500\n\n  disabled:bg-gray-300\n`',
           filename: 'a.tsx',
         },
       ],

--- a/packages/oxlint-tailwindcss/tests/integration/whitespace-line-wrap-cycle.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/whitespace-line-wrap-cycle.test.ts
@@ -86,4 +86,42 @@ describe('issue #14 — whitespace × line-wrapping no longer cycle', () => {
       invalid: [],
     },
   )
+
+  // Step 5: the width-based fixer (printWidth without classesPerLine) wraps
+  // into the same block convention, grouped by variant run.
+  new RuleTester().run('step 5: width-based line-wrapping autofix', enforceConsistentLineWrapping, {
+    valid: [
+      // Its own output is the canonical form — the fix converges.
+      {
+        code: 'const className = `\n  bg-red-500 text-white\n  hover:bg-red-600\n  focus:ring-2 focus:ring-red-500\n  disabled:bg-gray-300\n`',
+        filename: 'a.tsx',
+        options: [{ printWidth: 40 }],
+      },
+    ],
+    invalid: [
+      {
+        code: 'const className = `bg-red-500 text-white hover:bg-red-600 focus:ring-2 focus:ring-red-500 disabled:bg-gray-300`',
+        filename: 'a.tsx',
+        options: [{ printWidth: 40 }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  bg-red-500 text-white\n  hover:bg-red-600\n  focus:ring-2 focus:ring-red-500\n  disabled:bg-gray-300\n`',
+      },
+    ],
+  })
+
+  // Step 6: whitespace stays silent on the width-fixer output too.
+  new RuleTester().run(
+    'step 6: whitespace stays silent on width-wrapped output',
+    noUnnecessaryWhitespace,
+    {
+      valid: [
+        {
+          code: 'const className = `\n  bg-red-500 text-white\n  hover:bg-red-600\n  focus:ring-2 focus:ring-red-500\n  disabled:bg-gray-300\n`',
+          filename: 'a.tsx',
+        },
+      ],
+      invalid: [],
+    },
+  )
 })

--- a/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
@@ -483,7 +483,8 @@ ruleTester.run(
         output:
           'const className = `\n  !flex items-center! gap-2\n  hover:!bg-red-500 hover:!underline\n  focus:!outline-none\n`',
       },
-      // Tailwind v4 project prefix: `tw:` counts toward the variant chain, so
+      // Tailwind v4 project prefix WITHOUT a design system (no entryPoint):
+      // the prefix can't be known, so `tw:` counts toward the variant chain —
       // base utilities (`tw:`) and variants (`tw:hover:`) form separate runs.
       {
         code: 'const className = `tw:flex tw:items-center tw:gap-2 tw:hover:bg-red-500 tw:hover:underline`',
@@ -492,6 +493,17 @@ ruleTester.run(
         errors: [{ messageId: 'tooLong' }],
         output:
           'const className = `\n  tw:flex tw:items-center tw:gap-2\n  tw:hover:bg-red-500 tw:hover:underline\n`',
+      },
+      // Same fallback: an unprefixed class between prefixed ones splits the
+      // runs. With a DS (entryPoint configured) the prefix is transparent and
+      // this stays one run — locked in prefix.test.ts.
+      {
+        code: 'const className = `tw:flex my-card tw:items-center tw:hover:underline`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  tw:flex\n  my-card\n  tw:items-center\n  tw:hover:underline\n`',
       },
       // Tab-indented source: the tab is reused as the base indent (the width
       // budget counts it as one column — see packToWidth).

--- a/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
@@ -86,24 +86,30 @@ ruleTester.run(
   enforceConsistentLineWrapping,
   {
     valid: [
-      // Already split: no single line exceeds 80 even though the raw total does.
+      // Already split (in the canonical packed layout): no single line exceeds
+      // 80 even though the raw total does.
       {
-        code: 'const className = `\n  flex items-center justify-between p-4\n  m-2 bg-white text-black rounded shadow-lg\n`',
+        code: 'const className = `\n  flex items-center justify-between p-4 m-2 bg-white text-black rounded\n  shadow-lg\n`',
         filename: 'test.tsx',
       },
     ],
     invalid: [
-      // Still one long line — reports.
+      // Still one long line — reports, and (no classesPerLine set) autofixes
+      // into the width-packed block.
       {
         code: `const className = \`${veryLongClass}\``,
         filename: 'test.tsx',
         errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  flex items-center justify-between p-4 m-2 bg-white text-black rounded\n  shadow-lg border w-full\n`',
       },
-      // Wrapped, but one line is itself still too long — reports.
+      // Wrapped, but one line is itself still too long — reports and repacks.
       {
         code: `const className = \`\n  ${veryLongClass}\n  p-4\n\``,
         filename: 'test.tsx',
         errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  flex items-center justify-between p-4 m-2 bg-white text-black rounded\n  shadow-lg border w-full p-4\n`',
       },
     ],
   },
@@ -150,6 +156,100 @@ ruleTester.run(
         errors: [{ messageId: 'tooManyPerLine' }],
         output:
           'function C() {\n  return <div className={`\n    flex items-center\n    justify-between p-4\n  `} />\n}',
+      },
+    ],
+  },
+)
+
+// Width-based fixer (printWidth without classesPerLine): classes grouped
+// into runs by variant chain (each run starts its own line), packed to the
+// print width.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (width fixer + variant groups)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [
+      // Single line within budget: untouched.
+      {
+        code: 'const className = `flex hover:underline`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40 }],
+      },
+      // Already in the canonical grouped layout: no report.
+      {
+        code: 'const className = `\n  flex items-center\n  hover:bg-red-500 hover:underline\n  focus:outline-none\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40 }],
+      },
+      // A single class can never be wrapped shorter, so an over-budget single
+      // class is not counted against the print width.
+      {
+        code: '<div className="supercalifragilisticexpialidocious-classname" />',
+        filename: 'test.tsx',
+        options: [{ printWidth: 20 }],
+      },
+      {
+        code: 'const className = `w-[calc(100vw-theme(spacing.24))]`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 20 }],
+      },
+      // Fragment adjacent to `${}` already in the canonical hanging layout:
+      // the preserved leading space must not read as "inconsistent".
+      {
+        code: 'const className = `${base} flex items-center gap-2\n  hover:bg-red-500 hover:underline`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40 }],
+      },
+    ],
+    invalid: [
+      // Group recognition: base, hover: and focus: runs each get their own
+      // line even when two of them would fit together within the width.
+      {
+        code: 'const className = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40 }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  flex items-center gap-2\n  hover:bg-red-500 hover:underline\n  focus:outline-none\n`',
+      },
+      // Chained variants: `md:hover:` is one run, distinct from `md:`; a run
+      // that exceeds the width packs across its own lines, never sharing one.
+      {
+        code: 'const className = `p-2 md:p-4 md:m-2 md:hover:bg-blue-500 md:hover:text-white`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40 }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  p-2\n  md:p-4 md:m-2\n  md:hover:bg-blue-500\n  md:hover:text-white\n`',
+      },
+      // Within the width but not grouped by variant: normalized to the
+      // canonical layout under the inconsistentWrapping message.
+      {
+        code: 'const className = `\n  flex hover:underline\n  items-center\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40 }],
+        errors: [{ messageId: 'inconsistentWrapping' }],
+        output: 'const className = `\n  flex\n  hover:underline\n  items-center\n`',
+      },
+      // Fragment adjacent to `${}`: hanging join (no leading/trailing
+      // newline), one character reserved for the preserved leading space.
+      {
+        code: 'const className = `${base} flex items-center gap-2 hover:bg-red-500 hover:underline`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40 }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `${base} flex items-center gap-2\n  hover:bg-red-500 hover:underline`',
+      },
+      // Nested JSX: base indent derived from the source line, and the indent
+      // counts against the width budget when packing.
+      {
+        code: 'function C() {\n  return <div className={`flex items-center justify-between gap-2 p-4`} />\n}',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40 }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'function C() {\n  return <div className={`\n    flex items-center justify-between\n    gap-2 p-4\n  `} />\n}',
       },
     ],
   },

--- a/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
@@ -81,8 +81,10 @@ ruleTester.run('enforce-consistent-line-wrapping (classesPerLine)', enforceConsi
 })
 
 // #110 — printWidth is measured against the LONGEST LINE, not the raw total.
+// Without `wrapLines`, printWidth is warn-only: no autofix, and multiline templates
+// are never re-laid-out.
 ruleTester.run(
-  'enforce-consistent-line-wrapping (#110 longest line)',
+  'enforce-consistent-line-wrapping (#110 longest line, default warn-only)',
   enforceConsistentLineWrapping,
   {
     valid: [
@@ -92,24 +94,106 @@ ruleTester.run(
         code: 'const className = `\n  flex items-center justify-between p-4 m-2 bg-white text-black rounded\n  shadow-lg\n`',
         filename: 'test.tsx',
       },
+      // Hand-formatted multiline template, every line well under 80: untouched
+      // and unreported under the default config — the width-based re-layout is
+      // opt-in via `wrapLines`.
+      {
+        code: 'const className = `\n  flex\n  items-center\n  p-4\n`',
+        filename: 'test.tsx',
+      },
+      // Same, non-canonical grouping within the width: still untouched.
+      {
+        code: 'const className = `\n  flex hover:underline\n  items-center\n`',
+        filename: 'test.tsx',
+      },
     ],
     invalid: [
-      // Still one long line — reports, and (no classesPerLine set) autofixes
-      // into the width-packed block.
+      // Still one long line — reports, but does NOT autofix (wrapLines
+      // is unset).
       {
         code: `const className = \`${veryLongClass}\``,
         filename: 'test.tsx',
         errors: [{ messageId: 'tooLong' }],
-        output:
-          'const className = `\n  flex items-center justify-between p-4 m-2 bg-white text-black rounded\n  shadow-lg border w-full\n`',
       },
-      // Wrapped, but one line is itself still too long — reports and repacks.
+      // Wrapped, but one line is itself still too long — reports, no fix.
       {
         code: `const className = \`\n  ${veryLongClass}\n  p-4\n\``,
         filename: 'test.tsx',
         errors: [{ messageId: 'tooLong' }],
+      },
+    ],
+  },
+)
+
+// wrapLines: 'overWidth' — only the lines that actually exceed the
+// budget are greedily re-packed (no variant grouping); everything else,
+// including conforming lines of a touched template, stays verbatim.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (wrapLines: over-width)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [
+      // Multiline, within budget, NOT in the canonical grouped layout: left
+      // exactly as hand-formatted (this is the difference from 'all').
+      {
+        code: 'const className = `\n  flex hover:underline\n  items-center\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+      },
+    ],
+    invalid: [
+      // Single long line — no hand layout to preserve, so it converts to the
+      // block convention (greedily packed).
+      {
+        code: `const className = \`${veryLongClass}\``,
+        filename: 'test.tsx',
+        options: [{ wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
         output:
-          'const className = `\n  flex items-center justify-between p-4 m-2 bg-white text-black rounded\n  shadow-lg border w-full p-4\n`',
+          'const className = `\n  flex items-center justify-between p-4 m-2 bg-white text-black rounded\n  shadow-lg border w-full\n`',
+      },
+      // Wrapped, but one line is itself still too long — ONLY that line is
+      // repacked; the conforming `p-4` line survives verbatim instead of
+      // being absorbed into a whole-template re-layout.
+      {
+        code: `const className = \`\n  ${veryLongClass}\n  p-4\n\``,
+        filename: 'test.tsx',
+        options: [{ wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  flex items-center justify-between p-4 m-2 bg-white text-black rounded\n  shadow-lg border w-full\n  p-4\n`',
+      },
+      // Conforming lines around the offending one stay verbatim, even when
+      // they mix variant runs (`flex hover:underline`) — 'overWidth' never
+      // re-groups, it only splits the over-budget line.
+      {
+        code: 'const className = `\n  flex hover:underline\n  items-center justify-between gap-4 rounded-lg p-6\n  focus:outline-none\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  flex hover:underline\n  items-center justify-between gap-4\n  rounded-lg p-6\n  focus:outline-none\n`',
+      },
+      // Greedy packing, not variant grouping: the same input the 'all'
+      // block lays out as four run-per-line lines packs into two here.
+      {
+        code: 'const className = `p-2 md:p-4 md:m-2 md:hover:bg-blue-500 md:hover:text-white`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  p-2 md:p-4 md:m-2 md:hover:bg-blue-500\n  md:hover:text-white\n`',
+      },
+      // Multiline quasi after a `${}` whose value starts with `\n`: the
+      // 'overWidth' fix keeps lines in place and must NOT gain a stray
+      // boundary space before the newline.
+      {
+        code: 'const className = `${base}\n  flex items-center justify-between gap-4 rounded-lg p-6\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `${base}\n  flex items-center justify-between\n  gap-4 rounded-lg p-6\n`',
       },
     ],
   },
@@ -161,9 +245,9 @@ ruleTester.run(
   },
 )
 
-// Width-based fixer (printWidth without classesPerLine): classes grouped
+// Width-based fixer (wrapLines: 'all', no classesPerLine): classes grouped
 // into runs by variant chain (each run starts its own line), packed to the
-// print width.
+// print width; every multiline template is normalized to that layout.
 ruleTester.run(
   'enforce-consistent-line-wrapping (width fixer + variant groups)',
   enforceConsistentLineWrapping,
@@ -173,13 +257,13 @@ ruleTester.run(
       {
         code: 'const className = `flex hover:underline`',
         filename: 'test.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
       },
       // Already in the canonical grouped layout: no report.
       {
         code: 'const className = `\n  flex items-center\n  hover:bg-red-500 hover:underline\n  focus:outline-none\n`',
         filename: 'test.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
       },
       // A single class can never be wrapped shorter, so an over-budget single
       // class is not counted against the print width.
@@ -191,14 +275,14 @@ ruleTester.run(
       {
         code: 'const className = `w-[calc(100vw-theme(spacing.24))]`',
         filename: 'test.tsx',
-        options: [{ printWidth: 20 }],
+        options: [{ printWidth: 20, wrapLines: 'all' }],
       },
       // Fragment adjacent to `${}` already in the canonical hanging layout:
       // the preserved leading space must not read as "inconsistent".
       {
         code: 'const className = `${base} flex items-center gap-2\n  hover:bg-red-500 hover:underline`',
         filename: 'test.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
       },
     ],
     invalid: [
@@ -207,7 +291,7 @@ ruleTester.run(
       {
         code: 'const className = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`',
         filename: 'test.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
         errors: [{ messageId: 'tooLong' }],
         output:
           'const className = `\n  flex items-center gap-2\n  hover:bg-red-500 hover:underline\n  focus:outline-none\n`',
@@ -217,7 +301,7 @@ ruleTester.run(
       {
         code: 'const className = `p-2 md:p-4 md:m-2 md:hover:bg-blue-500 md:hover:text-white`',
         filename: 'test.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
         errors: [{ messageId: 'tooLong' }],
         output:
           'const className = `\n  p-2\n  md:p-4 md:m-2\n  md:hover:bg-blue-500\n  md:hover:text-white\n`',
@@ -227,7 +311,7 @@ ruleTester.run(
       {
         code: 'const className = `\n  flex hover:underline\n  items-center\n`',
         filename: 'test.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
         errors: [{ messageId: 'inconsistentWrapping' }],
         output: 'const className = `\n  flex\n  hover:underline\n  items-center\n`',
       },
@@ -236,7 +320,7 @@ ruleTester.run(
       {
         code: 'const className = `${base} flex items-center gap-2 hover:bg-red-500 hover:underline`',
         filename: 'test.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
         errors: [{ messageId: 'tooLong' }],
         output:
           'const className = `${base} flex items-center gap-2\n  hover:bg-red-500 hover:underline`',
@@ -246,10 +330,281 @@ ruleTester.run(
       {
         code: 'function C() {\n  return <div className={`flex items-center justify-between gap-2 p-4`} />\n}',
         filename: 'test.tsx',
-        options: [{ printWidth: 40 }],
+        options: [{ printWidth: 40, wrapLines: 'all' }],
         errors: [{ messageId: 'tooLong' }],
         output:
           'function C() {\n  return <div className={`\n    flex items-center justify-between\n    gap-2 p-4\n  `} />\n}',
+      },
+    ],
+  },
+)
+
+// group option (wrapLines: 'all' layout): 'newLine' is the default
+// (covered by the block above); 'emptyLine' separates variant runs with a
+// blank line; 'never' packs greedily across run boundaries.
+ruleTester.run('enforce-consistent-line-wrapping (group option)', enforceConsistentLineWrapping, {
+  valid: [
+    // Canonical emptyLine layout: blank lines between variant runs, and the
+    // blank lines carry no trailing whitespace.
+    {
+      code: 'const className = `\n  flex items-center gap-2\n\n  hover:bg-red-500 hover:underline\n\n  focus:outline-none\n`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all', group: 'emptyLine' }],
+    },
+    // Canonical group: 'never' layout: greedily packed, no run breaks.
+    {
+      code: 'const className = `\n  p-2 md:p-4 md:m-2 md:hover:bg-blue-500\n  md:hover:text-white\n`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all', group: 'never' }],
+    },
+  ],
+  invalid: [
+    // emptyLine: over-width single line lays out with blank group separators.
+    {
+      code: 'const className = `flex items-center gap-2 hover:bg-red-500 hover:underline focus:outline-none`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all', group: 'emptyLine' }],
+      errors: [{ messageId: 'tooLong' }],
+      output:
+        'const className = `\n  flex items-center gap-2\n\n  hover:bg-red-500 hover:underline\n\n  focus:outline-none\n`',
+    },
+    // emptyLine: a newLine-shaped block within budget is normalized to the
+    // blank-line-separated form.
+    {
+      code: 'const className = `\n  flex items-center gap-2\n  hover:bg-red-500 hover:underline\n  focus:outline-none\n`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all', group: 'emptyLine' }],
+      errors: [{ messageId: 'inconsistentWrapping' }],
+      output:
+        'const className = `\n  flex items-center gap-2\n\n  hover:bg-red-500 hover:underline\n\n  focus:outline-none\n`',
+    },
+    // emptyLine: hanging fragment after a `${}` — the blank separator works
+    // in the hanging join too.
+    {
+      code: 'const className = `${base} flex items-center gap-2 hover:bg-red-500 hover:underline`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all', group: 'emptyLine' }],
+      errors: [{ messageId: 'tooLong' }],
+      output:
+        'const className = `${base} flex items-center gap-2\n\n  hover:bg-red-500 hover:underline`',
+    },
+    // never: the same input the newLine layout splits into four run-per-line
+    // lines packs greedily into two.
+    {
+      code: 'const className = `p-2 md:p-4 md:m-2 md:hover:bg-blue-500 md:hover:text-white`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all', group: 'never' }],
+      errors: [{ messageId: 'tooLong' }],
+      output:
+        'const className = `\n  p-2 md:p-4 md:m-2 md:hover:bg-blue-500\n  md:hover:text-white\n`',
+    },
+    // never: a run-per-line block within budget is normalized to the greedy
+    // packing.
+    {
+      code: 'const className = `\n  p-2\n  md:p-4 md:m-2\n  md:hover:bg-blue-500\n  md:hover:text-white\n`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all', group: 'never' }],
+      errors: [{ messageId: 'inconsistentWrapping' }],
+      output:
+        'const className = `\n  p-2 md:p-4 md:m-2 md:hover:bg-blue-500\n  md:hover:text-white\n`',
+    },
+  ],
+})
+
+// A LEADING quasi (the text between the opening backtick and the first `${}`)
+// takes the block form, never the hanging join: hanging would land its first
+// packed line on the physical line that already holds the code before the
+// backtick — over-width output the per-quasi line measurement can't re-detect.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (leading quasi before a `${}`)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [
+      // Canonical converged form: block-form leading quasi, the `${}` on its
+      // own interior-indented line, the following quasi hanging after it.
+      {
+        code: 'const className = `\n  flex items-center justify-between\n  gap-4 rounded-lg\n  ${cond} px-6 py-3 shadow-md`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+      },
+    ],
+    invalid: [
+      // The leading quasi's line exceeds the budget: it re-wraps as a block
+      // (leading newline preserved), NOT as a hanging join glued onto the
+      // `const className = \`` line.
+      {
+        code: 'const className = `\n  flex items-center justify-between gap-4 rounded-lg\n  ${cond}\n  px-6 py-3 shadow-md\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'tooLong' }, { messageId: 'inconsistentWrapping' }],
+        output:
+          'const className = `\n  flex items-center justify-between\n  gap-4 rounded-lg\n  ${cond} px-6 py-3 shadow-md`',
+      },
+    ],
+  },
+)
+
+// Edge cases pinning the width fixer's design constraints down (PR #126
+// review): important `!`, a Tailwind v4 project prefix, tab indentation, a
+// quasi with `${}` on both sides, and empty / glued fragments.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (width fixer edge cases)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [
+      // Whitespace-only templates: nothing to wrap, no report.
+      {
+        code: 'const className = `   `',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+      },
+      {
+        code: 'const className = `\n  \n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+      },
+      // Canonical prefixed layout stays put (the prefix reads as part of the
+      // variant chain, so `tw:`- and `tw:hover:`-runs group separately).
+      {
+        code: 'const className = `\n  tw:flex tw:items-center tw:gap-2\n  tw:hover:bg-red-500 tw:hover:underline\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+      },
+    ],
+    invalid: [
+      // Important `!` in both spellings (prefix `!flex`, suffix
+      // `items-center!`) and inside a variant (`hover:!bg-red-500`): the `!`
+      // travels with its class and never affects the variant-run grouping.
+      {
+        code: 'const className = `!flex items-center! gap-2 hover:!bg-red-500 hover:!underline focus:!outline-none`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  !flex items-center! gap-2\n  hover:!bg-red-500 hover:!underline\n  focus:!outline-none\n`',
+      },
+      // Tailwind v4 project prefix: `tw:` counts toward the variant chain, so
+      // base utilities (`tw:`) and variants (`tw:hover:`) form separate runs.
+      {
+        code: 'const className = `tw:flex tw:items-center tw:gap-2 tw:hover:bg-red-500 tw:hover:underline`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  tw:flex tw:items-center tw:gap-2\n  tw:hover:bg-red-500 tw:hover:underline\n`',
+      },
+      // Tab-indented source: the tab is reused as the base indent (the width
+      // budget counts it as one column — see packToWidth).
+      {
+        code: 'function C() {\n\treturn <div className={`flex items-center justify-between gap-2 p-4`} />\n}',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'function C() {\n\treturn <div className={`\n\t  flex items-center justify-between\n\t  gap-2 p-4\n\t`} />\n}',
+      },
+      // Quasi with `${}` on BOTH sides: hanging join, one character reserved
+      // on each side for the preserved spaces.
+      {
+        code: 'const className = `${a} flex items-center justify-between gap-2 rounded-lg p-4 ${b} m-2`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `${a} flex items-center justify-between\n  gap-2 rounded-lg p-4 ${b} m-2`',
+      },
+      // A quasi GLUED to a `${}` (no whitespace at the boundary): `${a}flex`
+      // is ONE runtime class, so the fixer must never introduce whitespace
+      // there — reports, but no fix.
+      {
+        code: 'const className = `${a}flex items-center gap-2 p-4 m-2 bg-white text-black rounded-lg shadow`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'tooLong' }],
+      },
+    ],
+  },
+)
+
+// The same edge cases under wrapLines: 'overWidth' — the fix is per-line and
+// greedy, but `!`, a project prefix, tabs, and the `${}` shapes must behave
+// identically.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (wrapLines: overWidth edge cases)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [
+      // Whitespace-only templates: nothing to wrap, no report.
+      {
+        code: 'const className = `   `',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+      },
+      {
+        code: 'const className = `\n  \n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+      },
+    ],
+    invalid: [
+      // Important `!` (prefix, suffix, and inside a variant) travels with its
+      // class; the conforming `!flex` line stays, and the repacked line packs
+      // greedily across the base/hover boundary.
+      {
+        code: 'const className = `\n  !flex\n  items-center! gap-2 hover:!bg-red-500 hover:!underline\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  !flex\n  items-center! gap-2 hover:!bg-red-500\n  hover:!underline\n`',
+      },
+      // Tailwind v4 project prefix: `tw:` never separates from its class, and
+      // the conforming `tw:flex` line stays verbatim.
+      {
+        code: 'const className = `\n  tw:flex\n  tw:items-center tw:gap-2 tw:hover:bg-red-500 tw:hover:underline\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  tw:flex\n  tw:items-center tw:gap-2\n  tw:hover:bg-red-500 tw:hover:underline\n`',
+      },
+      // Tab-indented source: the tab is reused as the base indent in the
+      // single-line block conversion.
+      {
+        code: 'function C() {\n\treturn <div className={`flex items-center justify-between gap-2 p-4`} />\n}',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'function C() {\n\treturn <div className={`\n\t  flex items-center justify-between\n\t  gap-2 p-4\n\t`} />\n}',
+      },
+      // Quasi with `${}` on BOTH sides: hanging form, one character reserved
+      // on each side for the preserved spaces.
+      {
+        code: 'const className = `${a} flex items-center justify-between gap-2 rounded-lg p-4 ${b} m-2`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `${a} flex items-center justify-between\n  gap-2 rounded-lg p-4 ${b} m-2`',
+      },
+      // Single-line LEADING quasi (before the first `${}`): block form with
+      // the `${}` on its own interior-indented line, never a hanging join
+      // glued onto the code before the backtick.
+      {
+        code: 'const className = `flex items-center justify-between gap-4 rounded-lg ${cond}`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+        output:
+          'const className = `\n  flex items-center justify-between\n  gap-4 rounded-lg\n  ${cond}`',
+      },
+      // Glued quasi: warn-only under 'overWidth' too.
+      {
+        code: 'const className = `${a}flex items-center gap-2 p-4 m-2 bg-white text-black rounded-lg shadow`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
       },
     ],
   },

--- a/packages/oxlint-tailwindcss/tests/rules/prefix.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/prefix.test.ts
@@ -17,6 +17,7 @@ import { enforceSortOrder } from '../../src/rules/enforce-sort-order'
 import { enforceCanonical } from '../../src/rules/enforce-canonical'
 import { noDeprecatedClasses } from '../../src/rules/no-deprecated-classes'
 import { noConflictingClasses } from '../../src/rules/no-conflicting-classes'
+import { enforceConsistentLineWrapping } from '../../src/rules/enforce-consistent-line-wrapping'
 import { getLoadedDesignSystem, resetDesignSystem } from '../../src/design-system/loader'
 import { makeFixtureRunner } from '../utils/with-fixture'
 
@@ -310,6 +311,36 @@ run('no-conflicting-classes (prefix)', noConflictingClasses, {
       code: '<div className="tw:flex tw:block" />',
       filename: 'test.tsx',
       errors: [{ messageId: 'conflict' }],
+    },
+  ],
+})
+
+// ── enforce-consistent-line-wrapping (prefix transparent to grouping) ────────
+// With the design system available, the `wrapLines: 'all'` grouping key
+// strips the project prefix: `tw:flex` groups as a base utility (one run with
+// an unprefixed component class), `tw:hover:x` keys as `hover:`. The emitted
+// classes keep the prefix untouched. Without a DS the prefix reads as part of
+// the variant chain — that fallback is locked in the rule's own test file.
+
+run('enforce-consistent-line-wrapping (prefix)', enforceConsistentLineWrapping, {
+  valid: [
+    // Canonical: prefixed base utilities and the unprefixed component class
+    // share one run; the hover run starts its own line.
+    {
+      code: 'const className = `\n  tw:flex my-card tw:items-center\n  tw:hover:underline\n`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all' }],
+    },
+  ],
+  invalid: [
+    // An unprefixed component class between prefixed utilities must NOT
+    // split the base run into three.
+    {
+      code: 'const className = `tw:flex my-card tw:items-center tw:hover:underline`',
+      filename: 'test.tsx',
+      options: [{ printWidth: 40, wrapLines: 'all' }],
+      errors: [{ messageId: 'tooLong' }],
+      output: 'const className = `\n  tw:flex my-card tw:items-center\n  tw:hover:underline\n`',
     },
   ],
 })


### PR DESCRIPTION
Issue: enable migrating from using the printWidth fixers used in eslint-plugin-better-tailwindcss

Where there are components that have classes such as:
```
      flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6
      text-center text-balance
      md:p-12
```
and others with classes like:
```
      has-[[data-slot=input-group-control]:disabled]:opacity-50
      has-[[data-slot=input-group-control]:focus-visible]:ring-4
      has-[[data-slot=input-group-control]:focus-visible]:ring-ring
```
using a strict `classesPerLine` format is problematic - in some cases joining two classes on a single line can create a very long line to read/scroll horizontally, while restricting other lines to only two classes produces a lot of very short lines requiring a lot of vertical scrolling to see the full class set.

Using the `printWidth` option for the `enforce-consistent-line-wrapping` rule will currently produce an error when the `printWidth` is exceeded, but doesn't apply a fix for that error.

Using oxfmt's `sortTailwindcss` results in many class lines being merged, creating lines at 300+ characters long even with the `preserveWhitespace` option enabled. It's also not possible to limit the tailwindcss format to a specific section of a project - working in a legacy monolith that is updating to using tailwindcss means that oxfmt treats all css as tailwind instead of the dedicated section of the project where tailwind is actually used.

Running `eslint-plugin-better-tailwindcss` within oxlint as a jsPlugin adds significant time to the oxlint linting process (its addition for us was about 10 times longer than running oxlint-tailwindcss adds - taking oxlint from 3 seconds to 13 seconds just by adding the better-tailwindcss plugin). That time addition defeats the purpose of migrating away from eslint to oxlint.

This PR adds a fixer to the `printWidth` rule option based on the logic used in `eslint-plugin-better-tailwindcss`'s default fixer for this rule.

New options:
- `wrapLines`, options `overWidth` or `all`: enables the width fixer, and specifies whether to wrap only those lines inside a template that exceed the printWidth or all lines in a template. If not specified, the rule remains in reporting only status (no fixes applied).
- `group`, options `never`, `newLine`, or `emptyLine`, default `newLine`: when `wrapLines` is set to `all`, specifies how variant groups should wrap, mirroring the same `group` option/behaviour and default setting from `eslint-plugin-better-tailwindcss`.

The fixer is only enabled when `wrapLines` is set and `classesPerLine` is not set.

When `wrapLines` is set to `overWidth`, only lines that exceed the printWidth are rewrapped. These are wrapped to fit the printWidth in a greedy algorithm without reordering classes and without grouping by variants.

Changed behaviour:
- Suppress logging errors/warnings if a line containing a single class exceeds the printWidth. Given that there is a single class it is not possible to act on that warning/error, making it only noise.
- Rule is now design-system optional. When using `wrapLines: all` with group set to `newLine` or `emptyLine`, the design-system is consulted for the tailwindcss prefix so that this prefix can be ignored/removed from the classnames when checking for variant groups. If the `entryPoint` is not set, the fixer falls back to treating a prefix as part of the variant group.

PR was prepared using Claude, and tested against our project. I unfortunately do not read/speak Spanish, so I can't check that part of Claude's work - if it needs changing I'm happy to adjust it.