### PR TITLE
ci: run type-aware lint (lint:types) on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Type check
         run: pnpm typecheck
 
+      # Type-aware lint (tsgolint) over the plugin source only. The linux binary
+      # resolves via oxlint-tsgolint's optionalDependencies; the curated error
+      # set (no-floating-promises, etc.) is scoped to src/**/*.ts in .oxlintrc.json.
+      # Deliberately NOT in release.yml — releases stay decoupled from this gate.
+      - name: Type-aware lint
+        run: pnpm lint:types
+
       - name: Build
         run: pnpm build
 


### PR DESCRIPTION
## What

Adds a `Type-aware lint` step (`pnpm lint:types`) to the `build` job in `ci.yml`,
graduating the type-aware guard introduced in #127 from a local-only script to a
PR check.

## Why

`lint:types` runs `oxlint --type-aware` over `packages/oxlint-tailwindcss/src` with a
curated `error` set (`no-floating-promises`, `no-misused-promises`, `await-thenable`,
`no-for-in-array`) that guards the sync/async worker bridge. Until now it only ran
locally; this makes it catch regressions on every PR.

- The linux `tsgolint` binary resolves via `oxlint-tsgolint`'s `optionalDependencies`
  under the existing `pnpm install --frozen-lockfile` — no extra setup.
- **Deliberately not added to `release.yml`** — releases stay decoupled from this gate,
  as designed in #127.
- Type-aware rules are inert without `--type-aware`, so the existing `Lint` step
  (`pnpm lint`) is unchanged.

## Test plan
- [x] `pnpm format:check` clean (yaml edit conforms)
- [x] `pnpm lint:types` clean locally (unchanged since #127)
- [ ] CI green on this PR (the new step runs on ubuntu/macos/windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
