### PR TITLE
Skip prefer-theme-tokens when opacity modifier is a CSS variable

### DIFF
--- a/packages/oxlint-tailwindcss/src/rules/prefer-theme-tokens.ts
+++ b/packages/oxlint-tailwindcss/src/rules/prefer-theme-tokens.ts
@@ -28,6 +28,13 @@ function detectRawVariable(
   return null
 }
 
+/** Opacity/modifier that is itself a CSS custom property (`/(--x)` or `/[var(--x)]`). */
+const CSS_VAR_MODIFIER_RE = /^\/(\(--[\w-]+\)|\[var\(--[\w-]+\)\])$/
+
+function isCssVarModifier(modifier: string): boolean {
+  return CSS_VAR_MODIFIER_RE.test(modifier)
+}
+
 export const preferThemeTokens = defineRule({
   meta: {
     type: 'suggestion',
@@ -70,6 +77,11 @@ export const preferThemeTokens = defineRule({
           const { bare: bareUtility, position } = splitImportant(utility)
           const match = detectRawVariable(bareUtility)
           if (!match) return []
+
+          // #125: when the opacity segment is itself a CSS variable, rewriting
+          // only the color side to a named token is a false positive
+          // (`fill-(--color)/(--opacity)` → `fill-color/(--opacity)`).
+          if (isCssVarModifier(match.modifier)) return []
 
           const candidate = `${match.prefix}-${match.varName}${match.modifier}`
           if (!cache.isValid(candidate)) return []

--- a/packages/oxlint-tailwindcss/tests/rules/prefer-theme-tokens.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/prefer-theme-tokens.test.ts
@@ -49,6 +49,11 @@ describe('prefer-theme-tokens (shadcn-style theme)', () => {
       // Bracket form is CSS-equivalent to `border-border` with this fixture —
       // owned by no-unnecessary-arbitrary-value; the getNamedEquivalent guard silences this rule.
       { code: '<div className="border-[var(--border)]" />', filename: 'test.tsx' },
+      // #125: CSS-variable opacity modifier — both color and opacity are custom properties.
+      // Named rewrite to `fill-color/(--opacity)` is a false positive (bare `fill-(--color)` is silent).
+      { code: '<svg className="fill-(--color)/(--opacity)" />', filename: 'test.tsx' },
+      { code: '<svg className="fill-[var(--color)]/(--opacity)" />', filename: 'test.tsx' },
+      { code: '<svg className="fill-(--color)/[var(--opacity)]" />', filename: 'test.tsx' },
     ],
     invalid: [
       // Paren shorthand — the case from the issue


### PR DESCRIPTION
## Summary

`prefer-theme-tokens` was flagging Tailwind v4 classes like `fill-(--color)/(--opacity)` and suggesting `fill-color/(--opacity)`. Both segments are CSS custom properties; rewriting only the color side is a false positive (bare `fill-(--color)` already stays silent).

Skip the named-token rewrite when the opacity/modifier segment is itself a CSS variable (`/(--…)` or `/[var(--…)]`). Numeric modifiers such as `/80` are unchanged.

Credits @nbazille-ipsos for the report on #125.

Fixes #125

## Test plan

- [x] RED: added valid cases for `fill-(--color)/(--opacity)`, `fill-[var(--color)]/(--opacity)`, `fill-(--color)/[var(--opacity)]` — failed on unmodified main with the reported diagnostic
- [x] GREEN: same file 36/36 after the guard
- [x] Existing invalid cases still fire (`border-(--border)`, `bg-(--primary)/80`, etc.)