### PR TITLE
fix(prefer-theme-tokens): decide by base token, not modifier shape (#125)

### DIFF
--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.10.1
+
+`prefer-theme-tokens` autofixes `prefix-(--var)` → `prefix-name` when a named token exists. Its
+validity gate checked the candidate **with the opacity modifier still attached**
+(`fill-color/(--opacity)`), and the tolerant validity check accepts any string containing
+parentheses or brackets as an arbitrary value — so the modifier's own `(...)`/`[...]` made the gate
+approve `fill-color/…` even when `fill-color` is not a token. The rule then rewrote a **valid**
+class into one that emits no CSS, silently dropping the color and its opacity — a destructive
+autofix ([#125](https://github.com/sergioazoc/oxlint-tailwindcss/issues/125), reported by
+@nbazille-ipsos).
+
+### Bug fixes
+
+- **`prefer-theme-tokens` no longer rewrites `prefix-(--var)/<modifier>` when the color has no named
+  token.** The rule now decides from the **base** token (`prefix-name`) instead of the full string
+  with the modifier, so the decision no longer depends on the modifier's shape. This fixes the
+  reported `fill-(--color)/(--opacity)` case **and** its siblings that a modifier-shape guard would
+  miss — `fill-(--color)/[0.8]`, `fill-(--color)/[50%]`, `fill-[var(--color)]/[0.8]` — all of which
+  were the same destructive rewrite. Legitimate rewrites are preserved: when the color **does** have
+  a named token, `bg-(--primary)/(--opacity)` still becomes `bg-primary/(--opacity)`, keeping the
+  variable opacity verbatim. Supersedes
+  [#129](https://github.com/sergioazoc/oxlint-tailwindcss/pull/129) (thanks @Steve0x2a for the
+  initial fix).
+
 ## 1.10.0
 
 `no-contradicting-variants` and `no-dark-without-light` decide by looking at the _other_ classes in

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/rules/prefer-theme-tokens.ts
+++ b/packages/oxlint-tailwindcss/src/rules/prefer-theme-tokens.ts
@@ -71,8 +71,16 @@ export const preferThemeTokens = defineRule({
           const match = detectRawVariable(bareUtility)
           if (!match) return []
 
-          const candidate = `${match.prefix}-${match.varName}${match.modifier}`
-          if (!cache.isValid(candidate)) return []
+          // Validate the BASE named token (`prefix-name`), NOT the full string with the
+          // modifier attached. `isValid` is tolerant: any string containing brackets/parens
+          // counts as a valid arbitrary value, so a modifier like `/(--opacity)` or `/[0.8]`
+          // would make `fill-color/…` pass even when `fill-color` is not a token — and
+          // rewriting to it yields a class that emits no CSS, dropping the color and its
+          // opacity. The modifier is not part of the token lookup; it rides along verbatim
+          // into the replacement.
+          const baseCandidate = `${match.prefix}-${match.varName}`
+          if (!cache.isValid(baseCandidate)) return []
+          const candidate = `${baseCandidate}${match.modifier}`
 
           // `cache.isValid` only says the name exists. Whether the named token
           // means the SAME thing as the variable the user wrote depends on the
@@ -86,7 +94,6 @@ export const preferThemeTokens = defineRule({
           const target = `--${match.varName}`
           // The modifier (`/80`) is not part of the token lookup: `bg-primary/80`
           // is a user-written value the precompute never saw, `bg-primary` is not.
-          const baseCandidate = `${match.prefix}-${match.varName}`
           const resolves = cache
             .getCssDeclarations(baseCandidate)
             .some((decl) =>

--- a/packages/oxlint-tailwindcss/tests/rules/prefer-theme-tokens.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/prefer-theme-tokens.test.ts
@@ -49,6 +49,16 @@ describe('prefer-theme-tokens (shadcn-style theme)', () => {
       // Bracket form is CSS-equivalent to `border-border` with this fixture —
       // owned by no-unnecessary-arbitrary-value; the getNamedEquivalent guard silences this rule.
       { code: '<div className="border-[var(--border)]" />', filename: 'test.tsx' },
+      // The color side has no named token (`fill-color` does not exist), so the class is valid
+      // Tailwind and must NEVER be rewritten — regardless of the opacity-modifier form. Deciding
+      // by the base token (not the modifier) covers every modifier shape at once: the CSS-variable
+      // forms and the arbitrary-bracket forms that a tolerant validity check would leak through.
+      { code: '<svg className="fill-(--color)/(--opacity)" />', filename: 'test.tsx' },
+      { code: '<svg className="fill-[var(--color)]/(--opacity)" />', filename: 'test.tsx' },
+      { code: '<svg className="fill-(--color)/[var(--opacity)]" />', filename: 'test.tsx' },
+      { code: '<svg className="fill-(--color)/[0.8]" />', filename: 'test.tsx' },
+      { code: '<svg className="fill-(--color)/[50%]" />', filename: 'test.tsx' },
+      { code: '<svg className="fill-[var(--color)]/[0.8]" />', filename: 'test.tsx' },
     ],
     invalid: [
       // Paren shorthand — the case from the issue
@@ -132,6 +142,27 @@ describe('prefer-theme-tokens (shadcn-style theme)', () => {
         filename: 'test.tsx',
         errors: [{ messageId: 'preferNamed' }],
         output: '<div className="bg-primary/50" />',
+      },
+      // Color side HAS a named token (`bg-primary`) and the opacity is a CSS variable — the
+      // rewrite is legitimate and must still fire, keeping the variable modifier verbatim.
+      // Deciding by the base token (not the modifier shape) preserves these.
+      {
+        code: '<div className="bg-(--primary)/(--opacity)" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'preferNamed' }],
+        output: '<div className="bg-primary/(--opacity)" />',
+      },
+      {
+        code: '<div className="bg-[var(--primary)]/(--opacity)" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'preferNamed' }],
+        output: '<div className="bg-primary/(--opacity)" />',
+      },
+      {
+        code: '<div className="bg-(--primary)/[0.5]" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'preferNamed' }],
+        output: '<div className="bg-primary/[0.5]" />',
       },
       // Directional sub-utility (border-l, border-x, etc.)
       {


### PR DESCRIPTION
## Summary

`prefer-theme-tokens` autofixes `prefix-(--var)` → `prefix-name` when a named token exists. Its validity gate checked the candidate **with the opacity modifier still attached** (`fill-color/(--opacity)`), and the tolerant `isValid` accepts any string containing parens/brackets as an arbitrary value — so the modifier's own `(...)`/`[...]` approved `fill-color/…` even though `fill-color` is not a token. The rule then rewrote a **valid** class into one that emits **no CSS**, silently dropping the color and its opacity — a destructive autofix.

**Root cause, not symptom.** #129 patched this by deciding on the **modifier** (skip when opacity is `/(--x)` or `/[var(--x)]`). Verified empirically (11-case matrix × 3 source variants, isolated worktree) that this leaves the same destructive bug for other modifiers and drops legitimate rewrites. This PR fixes it at the source: **decide from the base token (`prefix-name`), not the modifier's shape**. The modifier is preserved verbatim.

## Behavior matrix (fixture: `--primary` has a token, `--color` does not)

| Class written | Correct | `main` today | #129 | This PR |
|---|---|---|---|---|
| `bg-(--primary)/(--opacity)` | rewrite | ✅ | ❌ dropped | ✅ |
| `bg-[var(--primary)]/(--opacity)` | rewrite | ✅ | ❌ dropped | ✅ |
| `bg-(--primary)/[0.5]` | rewrite | ✅ | ✅ | ✅ |
| `fill-(--color)/(--opacity)` ← #125 | silent | 💥 destructive | ✅ | ✅ |
| `fill-(--color)/[0.8]` | silent | 💥 destructive | 💥 still broken | ✅ |
| `fill-(--color)/[50%]` | silent | 💥 destructive | 💥 still broken | ✅ |
| `fill-[var(--color)]/[0.8]` | silent | 💥 destructive | 💥 still broken | ✅ |

`main`: 4 destructive false positives. #129: fixes 1, leaves 3, drops 2 legitimate rewrites. This PR: correct in all 11 cells.

## Why it's safe (coexistence with `enforce-canonical` / `no-unnecessary-arbitrary-value`)

- The fix's fire-set is a **strict subset** of `main`'s (it only removes the "color has no token" group; adds nothing new).
- `no-unnecessary-arbitrary-value` can't fire on any `/`-modifier form (its `arbitraryEquivMap` drops keys with a slash — `sync-loader.ts`).
- The coexistence suite uses no opacity modifiers, so for every existing assertion `candidate == baseCandidate` and the change is identically equivalent.

## Test plan

- [x] 6 new `valid` cases (color without a named token, every modifier shape — including the 3 #129 left broken)
- [x] 3 new `invalid` cases (color with a named token + variable/arbitrary modifier — the legitimate rewrites #129 silenced)
- [x] `prefer-theme-tokens` + coexistence: 80/80
- [x] Full suite: 1844/1844 · `typecheck` · `lint` · `format:check` all clean

Fixes #125. Supersedes #129 (thanks @Steve0x2a for the initial fix, @nbazille-ipsos for the report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)