### PR TITLE
fix(worker): stop a malformed arbitrary value from disabling a rule until restart (#130)

### DIFF
--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.10.2
+
+Typing an **incomplete** arbitrary value in a `className` (e.g. `px-[calc(var(--a)+var(--b)+)]`, a
+`calc()` mid-edit) could make a Tailwind design-system API throw inside the worker
+`enforce-canonical` uses. The worker turns any handler throw into a `null` sentinel, which the host
+treated as a fatal `designSystemUnavailable` diagnostic — and, worse, cached it as **sticky per
+entry point for the whole process**, so the warning stayed even after the class was completed to a
+valid one, clearing only when the editor extension restarted
+([#130](https://github.com/sergioazoc/oxlint-tailwindcss/issues/130), reported by @KoenCa). Whether
+the specific input throws depends on the consumer's resolved Tailwind engine version
+([#114](https://github.com/sergioazoc/oxlint-tailwindcss/issues/114)); the sticky mechanism was
+version-independent.
+
+### Bug fixes
+
+- **A malformed / mid-typing arbitrary value no longer disables a rule until restart.** Two
+  independent fixes: (1) each worker handler now guards its `ds.*` call — `enforce-canonical`
+  (`canonicalizeCandidates`), `enforce-sort-order` (`getClassOrder`), and the declaration service
+  behind `no-unknown-classes` / `no-conflicting-classes` (`candidatesToCss`) — so an
+  incanonicalizable input degrades to a no-op instead of the `null` sentinel; and (2)
+  per-**request** worker failures are no longer remembered as sticky (only genuine init/load
+  failures are), so the next keystroke re-spawns and retries instead of rethrowing the cached error.
+  The declaration service now also resolves one class at a time, so a single malformed class can no
+  longer blank a whole batch and mask a real typo such as `bg-red-5000`.
+
 ## 1.10.1
 
 `prefer-theme-tokens` autofixes `prefix-(--var)` → `prefix-name` when a named token exists. Its

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/canonicalize-service.ts
@@ -65,7 +65,7 @@ export interface CanonicalizeResult {
 // source of truth; when the canonical form resolves through a `var()`/`calc()`
 // whose value a `:root` override can change, the declarations differ and the
 // rewrite is flagged unsafe.
-const CANONICALIZE_HANDLER = `(ds, request) => {
+export const CANONICALIZE_HANDLER = `(ds, request) => {
   const { classes, rem } = request;
   const options = rem ? { rem } : undefined;
   const declsOf = (cls) => {
@@ -79,7 +79,17 @@ const CANONICALIZE_HANDLER = `(ds, request) => {
     return css.slice(open + 1, close).replace(/\\s+/g, ' ').trim();
   };
   return classes.map((cls) => {
-    const r = ds.canonicalizeCandidates([cls], options);
+    // A malformed/mid-typing arbitrary value (e.g. \`px-[calc(var(--a)+)]\`) can
+    // make the Tailwind parser throw on some engine versions (#130). Treat it
+    // as an incanonicalizable no-op — same posture declsOf already takes for
+    // candidatesToCss — instead of letting the throw become the worker's 'null'
+    // sentinel, which the host used to turn into a process-sticky fatal error.
+    let r;
+    try {
+      r = ds.canonicalizeCandidates([cls], options);
+    } catch (e) {
+      return { canonical: cls, safe: true };
+    }
     const canonical = r[0] ?? cls;
     if (canonical === cls) return { canonical: cls, safe: true };
     const a = declsOf(cls);

--- a/packages/oxlint-tailwindcss/src/design-system/declaration-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/declaration-service.ts
@@ -48,7 +48,7 @@ export interface DeclarationResponse {
   invalid: string[]
 }
 
-const DECLARATION_HANDLER = `(ds, request) => {
+export const DECLARATION_HANDLER = `(ds, request) => {
   const decls = {};
   const values = {};
   const invalid = [];
@@ -60,14 +60,28 @@ const DECLARATION_HANDLER = `(ds, request) => {
   // so every user-written value went silently uncompared.
   const prefix = (ds.theme && ds.theme.prefix) || '';
   const pfx = (c) => (prefix && !c.startsWith(prefix + ':')) ? prefix + ':' + c : c;
-  const css = ds.candidatesToCss(request.classes.map(pfx));
+  // Resolve one class at a time rather than a single batch call: a malformed/
+  // mid-typing arbitrary value can make ds.candidatesToCss throw on some engine
+  // versions (#130), and a batched throw blanked the whole request AND masked
+  // real typos (a valid sibling like \`bg-red-5000\` went unflagged), then became
+  // the worker's 'null' sentinel → a process-sticky fatal error. Per-class,
+  // distinguish a THROW (incanonicalizable input → OMIT, so no-unknown-classes
+  // stays lenient instead of flagging a transient false "unknown class") from a
+  // FALSY result (compiles to nothing → invalid).
   for (let i = 0; i < request.classes.length; i++) {
-    if (!css[i]) { invalid.push(request.classes[i]); continue; }
     const cls = request.classes[i];
+    let one;
+    try {
+      const out = ds.candidatesToCss([pfx(cls)]);
+      one = out && out[0];
+    } catch (e) {
+      continue; // omit: neither decls nor invalid
+    }
+    if (!one) { invalid.push(cls); continue; }
     const list = [];
     // The selector carries the prefix, so the scope classifier needs the
     // prefixed name even though the result is keyed by the bare one.
-    walkDeclarations(css[i], pfx(cls), (scope, prop, value) => {
+    walkDeclarations(one, pfx(cls), (scope, prop, value) => {
       list.push([scope, prop, value]);
       if (!(value in values)) {
         const reads = scanVarReads(value);

--- a/packages/oxlint-tailwindcss/src/design-system/ds-worker.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/ds-worker.ts
@@ -309,14 +309,17 @@ export class DesignSystemWorker<Req, Res> {
 
     const result = Atomics.wait(state.controlArray, 1, 0, REQUEST_TIMEOUT)
     if (result === 'timed-out') {
+      // Per-request failure (#130): drop the worker so the next call re-spawns
+      // and retries, but do NOT remember() it as sticky. A request-level failure
+      // is a property of one input, not of the entry point — making it sticky
+      // (as init failures are) let one malformed/transient input permanently
+      // disable the rule for the whole cssPath until the process restarted.
+      // Mirrors the already-non-sticky "payload too large" branch above.
       this.dropWorker(cssPath)
-      throw this.remember(
-        cssPath,
-        new SortServiceError(
-          `${this.opts.serviceName} worker request timed out after ${REQUEST_TIMEOUT}ms.`,
-          // Fixed internal limit, not settings.tailwindcss.timeout.
-          'This is unexpected for typical class lists; please open an issue if it persists.',
-        ),
+      throw new SortServiceError(
+        `${this.opts.serviceName} worker request timed out after ${REQUEST_TIMEOUT}ms.`,
+        // Fixed internal limit, not settings.tailwindcss.timeout.
+        'This is unexpected for typical class lists; please open an issue if it persists.',
       )
     }
 
@@ -328,25 +331,25 @@ export class DesignSystemWorker<Req, Res> {
     try {
       parsed = JSON.parse(responseStr)
     } catch (cause) {
+      // Per-request failure (#130): drop-and-retry, not sticky. See the
+      // request-timeout branch above for the rationale.
       this.dropWorker(cssPath)
-      throw this.remember(
-        cssPath,
-        new SortServiceError(
-          `${this.opts.serviceName} worker returned non-JSON response.`,
-          'This is a bug; please open an issue.',
-          { cause: cause instanceof Error ? cause : undefined },
-        ),
+      throw new SortServiceError(
+        `${this.opts.serviceName} worker returned non-JSON response.`,
+        'This is a bug; please open an issue.',
+        { cause: cause instanceof Error ? cause : undefined },
       )
     }
 
     if (parsed === null) {
+      // Per-request failure (#130): drop-and-retry, not sticky. After the
+      // handler guards land, the only realistic cause here is an oversized
+      // response (the response-side twin of "payload too large"), so a later
+      // request with different input must be free to succeed, not rethrow.
       this.dropWorker(cssPath)
-      throw this.remember(
-        cssPath,
-        new SortServiceError(
-          `${this.opts.serviceName} worker returned null — the request body was rejected or its response did not fit the buffer.`,
-          'This is a bug; please open an issue with the input that triggered it.',
-        ),
+      throw new SortServiceError(
+        `${this.opts.serviceName} worker returned null — the request body was rejected or its response did not fit the buffer.`,
+        'This is a bug; please open an issue with the input that triggered it.',
       )
     }
 

--- a/packages/oxlint-tailwindcss/src/design-system/sort-service.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/sort-service.ts
@@ -11,8 +11,18 @@ import { DesignSystemWorker, makeWorkerScript } from './ds-worker'
 // Handler: sort the requested classes into Tailwind-canonical order.
 // `null` sort indices (unknown classes) sort first, preserving their relative
 // position. The shared protocol/load/loop lives in makeWorkerScript.
-const SORT_HANDLER = `(ds, classes) => {
-  const ordered = ds.getClassOrder(classes);
+export const SORT_HANDLER = `(ds, classes) => {
+  // A malformed/mid-typing arbitrary value can make ds.getClassOrder throw on
+  // some engine versions (#130). Degrade to the input order (no reordering):
+  // the rule reads an unchanged order as "already sorted" and emits nothing,
+  // instead of the throw becoming the worker's 'null' sentinel → a
+  // process-sticky fatal error that disabled the rule until restart.
+  let ordered;
+  try {
+    ordered = ds.getClassOrder(classes);
+  } catch (e) {
+    return classes;
+  }
   return [...ordered]
     .sort((a, b) => {
       if (a[1] === null && b[1] === null) return 0;

--- a/packages/oxlint-tailwindcss/tests/integration/fatal-errors.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/fatal-errors.test.ts
@@ -6,17 +6,25 @@
  * `designSystemUnavailable` diagnostic.
  */
 
-import { beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { resolve } from 'node:path'
 import {
   canonicalizeClassesSync,
   resetCanonicalizeService,
+  CANONICALIZE_HANDLER,
 } from '../../src/design-system/canonicalize-service'
-import { sortClassesSync, resetSortService } from '../../src/design-system/sort-service'
+import {
+  sortClassesSync,
+  resetSortService,
+  SORT_HANDLER,
+} from '../../src/design-system/sort-service'
 import {
   resolveDeclarationsSync,
   resetDeclarationService,
   validateClassesSync,
+  DECLARATION_HANDLER,
 } from '../../src/design-system/declaration-service'
+import { DesignSystemWorker, makeWorkerScript } from '../../src/design-system/ds-worker'
 import { DesignSystemCache } from '../../src/design-system/cache'
 import { type PrecomputedData } from '../../src/design-system/sync-loader'
 import { makeDeclarations } from '../utils/declarations'
@@ -143,5 +151,112 @@ describe('declaration service — fail-loud', () => {
         ).toBe(false)
       }
     }
+  })
+})
+
+/**
+ * Issue #130. A per-REQUEST worker failure (the handler threw, the response
+ * didn't fit the buffer, a timeout, a non-JSON reply) used to be stored as a
+ * process-lifetime sticky error keyed by cssPath — exactly like an INIT failure.
+ * That let one malformed/mid-typing arbitrary value permanently disable a rule
+ * for the whole entry point until the editor's oxlint process restarted.
+ *
+ * The specific trigger is engine-version-dependent (Tailwind 4.3.3 does NOT
+ * throw on `px-[calc(var(--a)+)]` — it echoes it back), so the sticky behavior
+ * is exercised with a custom worker whose handler throws on a sentinel input.
+ */
+describe('per-request worker failure — retryable, not sticky (#130)', () => {
+  const CSS = resolve(__dirname, '../fixtures/default.css')
+  let worker: DesignSystemWorker<unknown, unknown> | null = null
+
+  afterEach(() => {
+    worker?.reset()
+    worker = null
+  })
+
+  test('a per-request handler throw does not poison later valid calls', () => {
+    worker = new DesignSystemWorker({
+      // Load the real DS (so init succeeds), but throw on one sentinel request.
+      workerScript: makeWorkerScript(
+        "(ds, req) => { if (req === '__BOOM__') throw new Error('boom'); return req; }",
+      ),
+      serviceName: 'canonicalize',
+    })
+
+    // The handler throws → the worker replies with the 'null' sentinel → the
+    // per-request null branch throws SortServiceError.
+    expect(() => worker!.callSync(CSS, '__BOOM__')).toThrow(SortServiceError)
+
+    // Regression: the SAME instance + SAME cssPath must retry (re-spawn) and
+    // succeed. With the old sticky remember() this rethrew the error forever.
+    expect(worker!.callSync(CSS, ['flex', 'p-2'])).toEqual(['flex', 'p-2'])
+  })
+})
+
+/**
+ * Issue #130 (RC1). Each worker handler's risky `ds.*` call is guarded so a
+ * Tailwind parser throw on a malformed arbitrary value degrades to a no-op
+ * instead of the 'null' sentinel. Tested by evaluating the exact handler string
+ * that ships (the same one hashed into the on-disk cache key) against a fake
+ * design system whose method throws — no worker, no real Tailwind, so it is
+ * deterministic on 4.3.3.
+ */
+describe('worker handlers — a throwing ds.* degrades to a no-op (#130)', () => {
+  const unreached = () => {
+    throw new Error('preamble helper should not be reached on the throw path')
+  }
+
+  test('canonicalize: a throwing canonicalizeCandidates leaves the class unchanged', () => {
+    const handler = new Function(`return (${CANONICALIZE_HANDLER})`)() as (
+      ds: unknown,
+      req: unknown,
+    ) => unknown
+    const ds = {
+      canonicalizeCandidates() {
+        throw new Error('boom')
+      },
+      candidatesToCss() {
+        throw new Error('boom')
+      },
+    }
+    expect(handler(ds, { classes: ['px-[calc(var(--a)+)]'] })).toEqual([
+      { canonical: 'px-[calc(var(--a)+)]', safe: true },
+    ])
+  })
+
+  test('sort: a throwing getClassOrder leaves the input order unchanged', () => {
+    const handler = new Function(`return (${SORT_HANDLER})`)() as (
+      ds: unknown,
+      classes: string[],
+    ) => string[]
+    const ds = {
+      getClassOrder() {
+        throw new Error('boom')
+      },
+    }
+    expect(handler(ds, ['flex', 'p-2'])).toEqual(['flex', 'p-2'])
+  })
+
+  test('declaration: a throwing class is omitted, a falsy sibling stays invalid', () => {
+    const handler = new Function(
+      'walkDeclarations',
+      'scanVarReads',
+      'isPureVarRead',
+      `return (${DECLARATION_HANDLER})`,
+    )(unreached, unreached, unreached) as (ds: unknown, req: unknown) => unknown
+    const ds = {
+      theme: { prefix: '' },
+      candidatesToCss(arr: string[]) {
+        if (arr[0].includes('calc')) throw new Error('boom')
+        return [''] // compiles to nothing → invalid
+      },
+    }
+    // The malformed class is omitted (so no-unknown-classes stays lenient); the
+    // real typo `bg-red-5000` is still flagged invalid instead of being masked.
+    expect(handler(ds, { classes: ['bg-red-5000', 'px-[calc(var(--a)+)]'] })).toEqual({
+      decls: {},
+      values: {},
+      invalid: ['bg-red-5000'],
+    })
   })
 })


### PR DESCRIPTION
Closes #130.

## Problem

Typing an **incomplete** arbitrary value in a `className` (e.g. `px-[calc(var(--a)+var(--b)+)]`, a `calc()` mid-edit) could make a Tailwind design-system API throw **inside a worker handler**. The worker turns any handler throw into a `null` sentinel, which the host reported as a fatal `designSystemUnavailable` diagnostic — and, worse, cached it as **sticky per entry point for the whole process**. So the warning stayed even after the class was completed to a valid one, clearing only when the editor extension restarted (exactly the reported "warning stays / restart clears it").

Confirmed empirically (custom worker driving the real `DesignSystemWorker`): once a per-request call returns `null`, every subsequent call for the same `cssPath` rethrows the **same** error object with no retry.

> **Reproduction nuance:** whether the *specific* input throws depends on the **consumer's** resolved Tailwind engine version (#114). On the repo's pinned 4.3.3 `canonicalizeCandidates` does **not** throw (it echoes the class back), so the specific input doesn't repro here — but the reporter is on an engine where it does, and the sticky mechanism is version-independent.

## Fix (two independent root causes)

**RC1 — guard each worker handler's risky `ds.*` call** so an incanonicalizable / mid-typing input degrades to a no-op instead of the `null` sentinel. The bug is shared across all three consumers of `DesignSystemWorker`:

| Service | Rule(s) | Guarded call |
| --- | --- | --- |
| canonicalize | `enforce-canonical` | `ds.canonicalizeCandidates` → return the class unchanged |
| sort | `enforce-sort-order` | `ds.getClassOrder` → return the input order (read as "already sorted") |
| declaration | `no-unknown-classes`, `no-conflicting-classes` | `ds.candidatesToCss`, now **one class at a time** (a throw → omit, keeping the rule lenient; a falsy result → `invalid`) |

The declaration change also means one malformed class can no longer blank a whole batch and **mask a real typo** such as `bg-red-5000`.

**RC2 — per-request worker failures are no longer sticky.** In `callSync`, the `timeout` / `non-JSON` / `null` branches now `throw` without `remember()` (they still `dropWorker`), so the next call re-spawns and retries. Init/spawn/DS-load failures and the worker-crash handler stay sticky (correct — those are entry-point-level). This mirrors the already-non-sticky "payload too large" branch.

## Tests

Two new blocks in `tests/integration/fatal-errors.test.ts` (filling a confirmed gap — nothing exercised the per-request `null` branch):
- **non-stickiness:** a custom worker whose handler throws on a sentinel input → asserts a subsequent **valid** call for the same `cssPath` **succeeds** (would rethrow forever before RC2).
- **handler guards:** evaluate the exact shipped handler strings against a fake `ds` whose method throws → assert the no-op (deterministic, no dependence on real Tailwind throwing).

## Verification

- `build` ✅ · `typecheck` ✅ · `lint` ✅ · `lint:types` ✅ · `format:check` ✅
- `fatal-errors.test.ts` 14/14 ✅ · affected rule suites 362/362 ✅ · full suite **1848/1848** ✅
- No new dependencies; `dsFailureCache` (precompute path) untouched. Bumps to `1.10.2` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5Dd1nnS2qp1Vc2f9ZiAHB
