### PR TITLE
fix(worker): bound the retrying of per-request worker failures

### DIFF
--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.10.3
+
+1.10.2 made per-**request** worker failures retryable rather than sticky, so a malformed or
+mid-typing arbitrary value could no longer disable a rule until the process restarted
+([#130](https://github.com/sergioazoc/oxlint-tailwindcss/issues/130)). Retrying was left unbounded,
+though, and a request timeout is not usually a property of one input — a machine slow enough to time
+out one request times out the next as well. Each retry then waits the full 30 s again, so a batch
+lint pays it once per remaining class list instead of once. On CI that reads as the job hanging: a
+studyguide-ui lint went from 86 s to 601 s and was killed by the runner's 10-minute no-output limit,
+and a studyplanner-fe lint took 527 s for 15 reported timeouts.
+
+### Bug fixes
+
+- **A per-request worker failure is still retried, but no longer forever.** After
+  `maxConsecutiveRequestFailures` (default 3) consecutive failures for one entry point the error
+  becomes sticky, so the remaining calls fail immediately instead of each paying the request timeout
+  again. Any successful request resets the count, so unrelated failures spread across a long run
+  never accumulate. #130's behaviour is unchanged for the case it was about: a single transient or
+  malformed input still recovers on the next call.
+
 ## 1.10.2
 
 Typing an **incomplete** arbitrary value in a `className` (e.g. `px-[calc(var(--a)+var(--b)+)]`, a

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/design-system/ds-worker.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/ds-worker.ts
@@ -34,6 +34,15 @@ const DATA_OFFSET = LENGTH_OFFSET + 4 // 20 bytes
 const INIT_TIMEOUT = 60_000 // 60 s to load DS (raised in v1 to avoid spurious timeouts on slow CI)
 const REQUEST_TIMEOUT = 30_000 // 30 s per request
 
+// Consecutive per-request failures for one cssPath before the error goes sticky.
+// #130 made these failures retryable so a mid-typing arbitrary value could not
+// disable a rule until restart. Retrying without a bound, though, costs the full
+// REQUEST_TIMEOUT again for every later class list once a machine is slow enough
+// to time out at all — on a batch lint that is O(files) x 30 s. The budget keeps
+// a transient failure recoverable while capping the pathological case; any
+// success resets it.
+const MAX_CONSECUTIVE_REQUEST_FAILURES = 3
+
 // LRU bound on live workers (#77). In a monorepo linted in one oxlint run the
 // plugin can resolve several entry points, and oxlint feeds files in
 // nondeterministic order — a singleton worker tore itself down and re-loaded
@@ -138,6 +147,13 @@ export interface DesignSystemWorkerOptions {
   workerScript: string
   /** Human-readable name shown in error messages. */
   serviceName: 'sort' | 'canonicalize' | 'declarations'
+  /** Per-request wait before giving up. Defaults to `REQUEST_TIMEOUT`; overridden in tests. */
+  requestTimeoutMs?: number
+  /**
+   * Consecutive per-request failures for one cssPath before the error becomes
+   * sticky. Defaults to `MAX_CONSECUTIVE_REQUEST_FAILURES`; overridden in tests.
+   */
+  maxConsecutiveRequestFailures?: number
 }
 
 export class DesignSystemWorker<Req, Res> {
@@ -156,6 +172,8 @@ export class DesignSystemWorker<Req, Res> {
   // lastError/lastErrorCssPath pair was cleared on ANY cssPath switch, so it
   // never stayed sticky across the alternating-file pattern #77 describes.
   private errors = new Map<string, SortServiceError>()
+  // Consecutive per-request failures per cssPath, reset by any success.
+  private requestFailures = new Map<string, number>()
 
   constructor(private readonly opts: DesignSystemWorkerOptions) {}
 
@@ -163,6 +181,21 @@ export class DesignSystemWorker<Req, Res> {
   private remember(cssPath: string, err: SortServiceError): SortServiceError {
     this.errors.set(cssPath, err)
     return err
+  }
+
+  /**
+   * Handle a per-request failure: drop the worker so the next call re-spawns and
+   * retries (#130), but stop retrying once the same cssPath has failed
+   * `maxConsecutiveRequestFailures` times in a row. Without that bound a machine
+   * slow enough to time out once pays the full request timeout again for every
+   * remaining class list.
+   */
+  private failRequest(cssPath: string, err: SortServiceError): SortServiceError {
+    this.dropWorker(cssPath)
+    const failures = (this.requestFailures.get(cssPath) ?? 0) + 1
+    this.requestFailures.set(cssPath, failures)
+    const budget = this.opts.maxConsecutiveRequestFailures ?? MAX_CONSECUTIVE_REQUEST_FAILURES
+    return failures >= budget ? this.remember(cssPath, err) : err
   }
 
   /**
@@ -307,19 +340,22 @@ export class DesignSystemWorker<Req, Res> {
     Atomics.store(state.controlArray, 0, 1)
     Atomics.notify(state.controlArray, 0)
 
-    const result = Atomics.wait(state.controlArray, 1, 0, REQUEST_TIMEOUT)
+    const requestTimeout = this.opts.requestTimeoutMs ?? REQUEST_TIMEOUT
+    const result = Atomics.wait(state.controlArray, 1, 0, requestTimeout)
     if (result === 'timed-out') {
       // Per-request failure (#130): drop the worker so the next call re-spawns
-      // and retries, but do NOT remember() it as sticky. A request-level failure
-      // is a property of one input, not of the entry point — making it sticky
-      // (as init failures are) let one malformed/transient input permanently
-      // disable the rule for the whole cssPath until the process restarted.
-      // Mirrors the already-non-sticky "payload too large" branch above.
-      this.dropWorker(cssPath)
-      throw new SortServiceError(
-        `${this.opts.serviceName} worker request timed out after ${REQUEST_TIMEOUT}ms.`,
-        // Fixed internal limit, not settings.tailwindcss.timeout.
-        'This is unexpected for typical class lists; please open an issue if it persists.',
+      // and retries, rather than remembering it as sticky straight away. A
+      // request-level failure is a property of one input, not of the entry
+      // point — making it sticky immediately (as init failures are) let one
+      // malformed/transient input permanently disable the rule for the whole
+      // cssPath until the process restarted. `failRequest` bounds the retrying.
+      throw this.failRequest(
+        cssPath,
+        new SortServiceError(
+          `${this.opts.serviceName} worker request timed out after ${requestTimeout}ms.`,
+          // Fixed internal limit, not settings.tailwindcss.timeout.
+          'This is unexpected for typical class lists; please open an issue if it persists.',
+        ),
       )
     }
 
@@ -331,27 +367,35 @@ export class DesignSystemWorker<Req, Res> {
     try {
       parsed = JSON.parse(responseStr)
     } catch (cause) {
-      // Per-request failure (#130): drop-and-retry, not sticky. See the
+      // Per-request failure (#130): drop-and-retry, bounded. See the
       // request-timeout branch above for the rationale.
-      this.dropWorker(cssPath)
-      throw new SortServiceError(
-        `${this.opts.serviceName} worker returned non-JSON response.`,
-        'This is a bug; please open an issue.',
-        { cause: cause instanceof Error ? cause : undefined },
+      throw this.failRequest(
+        cssPath,
+        new SortServiceError(
+          `${this.opts.serviceName} worker returned non-JSON response.`,
+          'This is a bug; please open an issue.',
+          { cause: cause instanceof Error ? cause : undefined },
+        ),
       )
     }
 
     if (parsed === null) {
-      // Per-request failure (#130): drop-and-retry, not sticky. After the
-      // handler guards land, the only realistic cause here is an oversized
-      // response (the response-side twin of "payload too large"), so a later
-      // request with different input must be free to succeed, not rethrow.
-      this.dropWorker(cssPath)
-      throw new SortServiceError(
-        `${this.opts.serviceName} worker returned null — the request body was rejected or its response did not fit the buffer.`,
-        'This is a bug; please open an issue with the input that triggered it.',
+      // Per-request failure (#130): drop-and-retry, bounded. After the handler
+      // guards land, the only realistic cause here is an oversized response (the
+      // response-side twin of "payload too large"), so a later request with
+      // different input must be free to succeed, not rethrow.
+      throw this.failRequest(
+        cssPath,
+        new SortServiceError(
+          `${this.opts.serviceName} worker returned null — the request body was rejected or its response did not fit the buffer.`,
+          'This is a bug; please open an issue with the input that triggered it.',
+        ),
       )
     }
+
+    // A success clears the budget, so unrelated failures spread across a long
+    // run never accumulate into a sticky error.
+    this.requestFailures.delete(cssPath)
 
     return parsed as Res
   }
@@ -360,6 +404,7 @@ export class DesignSystemWorker<Req, Res> {
     for (const state of this.workers.values()) this.terminateWorker(state.worker)
     this.workers.clear()
     this.errors.clear()
+    this.requestFailures.clear()
   }
 
   /** Terminate and forget the worker for a single cssPath (on request failure). */

--- a/packages/oxlint-tailwindcss/tests/integration/fatal-errors.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/fatal-errors.test.ts
@@ -194,6 +194,64 @@ describe('per-request worker failure — retryable, not sticky (#130)', () => {
 })
 
 /**
+ * Retrying per-request failures (#130) must be bounded. A machine slow enough to
+ * time out one request will time out the next as well, and each retry waits the
+ * full request timeout again — on a batch lint that is O(files) x 30 s, which is
+ * enough to exhaust a CI step's no-output limit. After the budget the error goes
+ * sticky, so the remaining calls fail immediately instead of each paying the
+ * timeout; any success in between clears the budget.
+ */
+describe('per-request failures are retried, but not forever', () => {
+  const CSS = resolve(__dirname, '../fixtures/default.css')
+  let worker: DesignSystemWorker<unknown, unknown> | null = null
+
+  afterEach(() => {
+    worker?.reset()
+    worker = null
+  })
+
+  test('stops paying the request timeout once the budget is spent', () => {
+    // A handler that never replies, so every request hits the timeout.
+    worker = new DesignSystemWorker({
+      workerScript: makeWorkerScript('(ds, req) => { while (true) {} }'),
+      serviceName: 'canonicalize',
+      requestTimeoutMs: 50,
+      maxConsecutiveRequestFailures: 3,
+    })
+
+    for (let i = 0; i < 3; i++) {
+      expect(() => worker!.callSync(CSS, ['flex'])).toThrow(/timed out after 50ms/)
+    }
+
+    // Budget spent: this must return immediately rather than wait out another
+    // timeout. Before the bound, every later call paid the full 50 ms again.
+    const startedAt = Date.now()
+    expect(() => worker!.callSync(CSS, ['flex'])).toThrow(SortServiceError)
+    expect(Date.now() - startedAt).toBeLessThan(50)
+  })
+
+  test('a success between failures clears the budget', () => {
+    // Times out only on the sentinel, so a valid call in between succeeds.
+    worker = new DesignSystemWorker({
+      workerScript: makeWorkerScript(
+        "(ds, req) => { if (req === '__HANG__') { while (true) {} } return req; }",
+      ),
+      serviceName: 'canonicalize',
+      requestTimeoutMs: 50,
+      maxConsecutiveRequestFailures: 2,
+    })
+
+    expect(() => worker!.callSync(CSS, '__HANG__')).toThrow(SortServiceError)
+    expect(worker!.callSync(CSS, ['flex', 'p-2'])).toEqual(['flex', 'p-2'])
+
+    // The success reset the count, so this failure is the first of a new run and
+    // the next valid call still works — the error never went sticky.
+    expect(() => worker!.callSync(CSS, '__HANG__')).toThrow(SortServiceError)
+    expect(worker!.callSync(CSS, ['flex'])).toEqual(['flex'])
+  })
+})
+
+/**
  * Issue #130 (RC1). Each worker handler's risky `ds.*` call is guarded so a
  * Tailwind parser throw on a malformed arbitrary value degrades to a no-op
  * instead of the 'null' sentinel. Tested by evaluating the exact handler string


### PR DESCRIPTION
## What & why

1.10.2 made per-request worker failures retryable rather than sticky (#130), so a malformed or mid-typing arbitrary value can no longer disable a rule until the process restarts. That fix is right; the retrying is just unbounded.

A request **timeout**, unlike the `null` sentinel #130 was about, is usually not a property of one input. A machine slow enough to time out one request times out the next as well, and each retry waits the full `REQUEST_TIMEOUT` again — so a batch lint pays 30s *per remaining class list* instead of once.

We hit this on CI. Two of our repos on 1.10.2:

| | before | with 1.10.0 (pre-#132) |
|---|---|---|
| studyguide-ui | **601s**, killed by the runner's 10-minute no-output limit | 86s |
| studyplanner-fe | **527s**, 15 reported timeouts | 95s |

15 timeouts × 30s ≈ 450s, which is most of that 527s. A third repo with the same config and *more* arbitrary-value classes (196, vs 154 and 57) stayed green at 84s, so this only bites once something makes requests slow enough to time out at all — but when it does, the cost is O(files) rather than O(1).

## The change

`failRequest` keeps the drop-and-retry, but after `maxConsecutiveRequestFailures` (default 3) consecutive failures for one entry point the error becomes sticky, so the rest of the run fails fast instead of each call paying the timeout again. Any successful request clears the count, so unrelated failures spread across a long run never accumulate into a sticky error.

The case #130 was about is unchanged: a single transient or malformed input still recovers on the next call. After #132's handler guards an incanonicalizable value degrades to a no-op rather than reaching this path at all, so the budget realistically only trips on genuine timeouts and oversized responses — where retrying forever is pure cost.

Applied to all three per-request branches (`timed-out`, non-JSON, `null`) since they share the same drop-and-retry rationale.

`requestTimeoutMs` is added alongside so the regression test doesn't have to wait 30s. Both new options are optional and default to the existing constants, so behaviour is unchanged for callers that don't set them.

## Tests

Two blocks in `tests/integration/fatal-errors.test.ts`, next to the existing #130 ones:

- **`stops paying the request timeout once the budget is spent`** — a handler that never replies, `requestTimeoutMs: 50`, budget 3. After the budget the next call must return in under 50ms rather than wait out another timeout. Verified it fails without the fix: with the bound removed it takes ~410ms and the assertion trips.
- **`a success between failures clears the budget`** — guards the over-correction, i.e. that this doesn't quietly reintroduce #130 for interleaved traffic.

The existing `per-request worker failure — retryable, not sticky (#130)` test passes unchanged.

`pnpm format && pnpm lint && pnpm typecheck && pnpm build && pnpm test` all clean — 72 files, 1850 tests. (The e2e files need `pnpm build` first, which caught me out initially.)

## Notes

- Patch bump to 1.10.3 with a CHANGELOG entry, per CONTRIBUTING.
- The default of 3 is a guess at the right shape rather than a tuned number — happy to change it, make it configurable through `settings.tailwindcss`, or bound by cumulative time instead of count if you'd prefer.