### PR TITLE
fix(enforce-consistent-line-wrapping): resolve PR #126 review follow-ups

### DIFF
--- a/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
@@ -69,6 +69,13 @@ wrappearlo), así que la regla saca el warning y te deja decidir. Un fragmento d
 a un `${}` sin whitespace (`` `${a}flex …` `` — una sola clase en runtime) tampoco se autofixea
 nunca: cualquier whitespace introducido en ese borde partiría esa clase en dos.
 
+Alrededor de una interpolación, el layout `"all"` pone el run de clases que bordea un `${}` en su
+**propia línea nueva** (nunca colgando inline después de la expresión), así que toda línea reescrita
+queda dentro de `printWidth`. Una salvedad: el ancho de la expresión `${…}` en sí es opaco para la
+regla, que mide cada fragmento estático por separado. Por eso una sola línea física que escribas a
+mano con un fragmento corto junto a una interpolación ancha puede exceder `printWidth` sin ser
+reportada.
+
 `wrapLines` solo aplica cuando `classesPerLine` **no** está seteado — si no, `classesPerLine` es
 dueño del layout.
 
@@ -123,6 +130,14 @@ ignora.
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
 ```
+
+### `entryPoint`
+
+`string`, opcional.
+
+Override por-regla de `settings.tailwindcss.entryPoint`. La regla consulta el design system solo
+para el prefix de proyecto de Tailwind v4, y solo bajo `wrapLines: "all"` con `group` `"newLine"` o
+`"emptyLine"` (ver arriba); en cualquier otro caso no tiene efecto. Casi nunca hace falta.
 
 ## Ejemplos
 

--- a/packages/docs/es/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/enforce-consistent-line-wrapping.md
@@ -1,6 +1,7 @@
 # enforce-consistent-line-wrapping
 
-> Warn when a class string exceeds the configured print width
+> Warn (and optionally autofix) when a class string exceeds the configured print width or
+> classes-per-line budget
 
 ## Qué hace esta regla
 
@@ -73,6 +74,13 @@ wrappearlo), así que la regla saca el warning y te deja decidir. Un fragmento d
 a un `${}` sin whitespace (`` `${a}flex …` `` — una sola clase en runtime) tampoco se autofixea
 nunca: cualquier whitespace introducido en ese borde partiría esa clase en dos.
 
+Alrededor de una interpolación, el layout `"all"` pone el run de clases que bordea un `${}` en su
+**propia línea nueva** (nunca colgando inline después de la expresión), así que toda línea reescrita
+queda dentro de `printWidth`. Una salvedad: el ancho de la expresión `${…}` en sí es opaco para la
+regla, que mide cada fragmento estático por separado. Por eso una sola línea física que escribas a
+mano con un fragmento corto junto a una interpolación ancha puede exceder `printWidth` sin ser
+reportada.
+
 `wrapLines` solo aplica cuando `classesPerLine` **no** está seteado — si no, `classesPerLine` es
 dueño del layout.
 
@@ -127,6 +135,14 @@ ignora.
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
 ```
+
+### `entryPoint`
+
+`string`, opcional.
+
+Override por-regla de `settings.tailwindcss.entryPoint`. La regla consulta el design system solo
+para el prefix de proyecto de Tailwind v4, y solo bajo `wrapLines: "all"` con `group` `"newLine"` o
+`"emptyLine"` (ver arriba); en cualquier otro caso no tiene efecto. Casi nunca hace falta.
 
 ## Ejemplos
 

--- a/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/_extras/enforce-consistent-line-wrapping.md
@@ -67,6 +67,12 @@ so the rule surfaces the warning and lets you decide. A template fragment **glue
 no whitespace (`` `${a}flex …` `` — one runtime class) is also never autofixed: any whitespace
 introduced at the boundary would split that class in two.
 
+Around an interpolation, the `"all"` layout puts the class run bordering a `${}` on its **own fresh
+line** (never hanging inline after the expression), so every rewritten line stays within
+`printWidth`. One caveat: the width of the `${…}` expression itself is opaque to the rule, which
+measures each static fragment on its own. So a single physical line you hand-write with a short
+fragment beside a wide interpolation can still exceed `printWidth` without being reported.
+
 `wrapLines` only applies when `classesPerLine` is **not** set — `classesPerLine` owns the layout
 otherwise.
 
@@ -121,6 +127,14 @@ ignored.
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
 ```
+
+### `entryPoint`
+
+`string`, optional.
+
+Per-rule override of `settings.tailwindcss.entryPoint`. The rule consults the design system only for
+the Tailwind v4 project prefix, and only under `wrapLines: "all"` with `group` `"newLine"` or
+`"emptyLine"` (see above); everywhere else it has no effect. Almost never needed.
 
 ## Examples
 

--- a/packages/docs/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/rules/enforce-consistent-line-wrapping.md
@@ -1,6 +1,7 @@
 # enforce-consistent-line-wrapping
 
-> Warn when a class string exceeds the configured print width
+> Warn (and optionally autofix) when a class string exceeds the configured print width or
+> classes-per-line budget
 
 ## What this rule does
 
@@ -71,6 +72,12 @@ so the rule surfaces the warning and lets you decide. A template fragment **glue
 no whitespace (`` `${a}flex …` `` — one runtime class) is also never autofixed: any whitespace
 introduced at the boundary would split that class in two.
 
+Around an interpolation, the `"all"` layout puts the class run bordering a `${}` on its **own fresh
+line** (never hanging inline after the expression), so every rewritten line stays within
+`printWidth`. One caveat: the width of the `${…}` expression itself is opaque to the rule, which
+measures each static fragment on its own. So a single physical line you hand-write with a short
+fragment beside a wide interpolation can still exceed `printWidth` without being reported.
+
 `wrapLines` only applies when `classesPerLine` is **not** set — `classesPerLine` owns the layout
 otherwise.
 
@@ -125,6 +132,14 @@ ignored.
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }
 ```
+
+### `entryPoint`
+
+`string`, optional.
+
+Per-rule override of `settings.tailwindcss.entryPoint`. The rule consults the design system only for
+the Tailwind v4 project prefix, and only under `wrapLines: "all"` with `group` `"newLine"` or
+`"emptyLine"` (see above); everywhere else it has no effect. Almost never needed.
 
 ## Examples
 

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -25,8 +25,11 @@ autofix for template literals — **off by default and opt-in via the new `wrapL
     `inconsistentWrapping`.
 
   In both modes class **order is never changed** — the fixer only chooses where the line breaks go.
-  Template fragments glued to a `${}` with no whitespace (`` `${a}flex …` `` — one runtime class)
-  are never autofixed: introducing whitespace at the boundary would split the class in two.
+  Under `"all"`, a class run that borders a `${}` interpolation starts on its own fresh line rather
+  than hanging inline after the expression, so no rewritten line exceeds `printWidth` (the width of
+  the `${…}` expression itself stays opaque to the rule). Template fragments glued to a `${}` with
+  no whitespace (`` `${a}flex …` `` — one runtime class) are never autofixed: introducing whitespace
+  at the boundary would split the class in two.
 
 - **`enforce-consistent-line-wrapping`: new `group` option** (`"newLine" | "emptyLine" | "never"`,
   default `"newLine"`), controlling how the `wrapLines: "all"` layout separates variant groups. It
@@ -52,6 +55,14 @@ autofix for template literals — **off by default and opt-in via the new `wrapL
   the variant chain. It never reports `designSystemUnavailable`, and the design system is only
   consulted for these two specific fixers so no performance penalty is applied to the rule if those
   fixers are not used.
+
+### Fixed
+
+- **`enforce-consistent-line-wrapping`: `classesPerLine` no longer splits a class glued to a `${}`
+  interpolation on `--fix`.** For a template like `` `${a}flex md:block` `` — where `${a}flex` is a
+  single runtime class — the `classesPerLine` fixer is now warn-only, matching the `wrapLines`
+  fixer's `glued`-boundary guard. Previously it inserted a space at the boundary and rewrote the
+  class to `` `${a} flex …` ``, silently splitting it in two.
 
 ## 1.10.2
 

--- a/packages/oxlint-tailwindcss/src/rules/consistent-variant-order.ts
+++ b/packages/oxlint-tailwindcss/src/rules/consistent-variant-order.ts
@@ -6,6 +6,7 @@ import {
   extractUtility,
   isPseudoElementVariant,
   isSelectorBarrier,
+  stripProjectPrefix,
 } from '../utils/class-parser'
 import { createLazyOptions } from '../utils/context'
 import { type VariantFacts } from '../utils/class-parser'
@@ -204,12 +205,7 @@ export const consistentVariantOrder = defineRule({
 
     function reorderClass(cls: string): string | null {
       const { priorityOf, prefix, factsFor } = resolveForFile()
-      let pfx = ''
-      let body = cls
-      if (prefix && cls.startsWith(prefix + ':')) {
-        pfx = prefix + ':'
-        body = cls.slice(prefix.length + 1)
-      }
+      const { prefix: pfx, body } = stripProjectPrefix(cls, prefix)
 
       const variants = extractVariants(body)
       if (variants.length < 2) return null

--- a/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-consistent-line-wrapping.ts
@@ -2,7 +2,7 @@ import { defineRule } from '@oxlint/plugins'
 import { createExtractorVisitors, preserveSpaces, type ClassLocation } from '../utils/extractors'
 import { splitClasses } from '../utils/class-splitter'
 import { createLazyOptions, safeSourceCode } from '../utils/context'
-import { getVariantPrefix } from '../utils/class-parser'
+import { getVariantPrefix, stripProjectPrefix } from '../utils/class-parser'
 import { createLazyLoader } from '../design-system/loader'
 import { softGetDS } from '../utils/fatal'
 
@@ -16,15 +16,18 @@ import { softGetDS } from '../utils/fatal'
  * directly before it, `preserveTrailingSpace` that one sits directly after.
  *
  * The fixers wrap a quasi according to what borders it:
- *  - opening backtick before it (whole template, or a leading quasi):
- *    BLOCK form — classes move onto their own indented lines below the
- *    backtick;
- *  - `${}` before it: HANGING form — the first packed line stays beside the
- *    interpolation, continuation lines are indented below it;
+ *  - the WIDTH fixer (`wrapLines`) always uses BLOCK form — every class run
+ *    moves onto its own indented line below the backtick, INCLUDING a quasi
+ *    that follows a `${}` (it starts on a fresh line rather than hanging
+ *    inline). Nothing ever shares a physical row with the opaque `${expr}`,
+ *    so no emitted line can exceed `printWidth`;
+ *  - the `classesPerLine` fixer uses BLOCK form for a standalone quasi but a
+ *    HANGING join for a fragment adjacent to a `${}` (the first chunk stays
+ *    beside the interpolation, continuation chunks indented below it);
  *  - GLUED to a `${}` (no whitespace at the boundary, as in `${a}flex`):
- *    never autofixed, warn-only — the quasi text concatenates with the
- *    interpolation into ONE runtime class, so inserting whitespace at the
- *    boundary would split that class in two.
+ *    never autofixed by EITHER fixer, warn-only — the quasi text concatenates
+ *    with the interpolation into ONE runtime class, so inserting whitespace at
+ *    the boundary would split that class in two.
  */
 
 /**
@@ -100,8 +103,7 @@ function packToWidth(classes: string[], indent: string, width: number): string[]
  * prefix. Grouping only: emitted classes are never rewritten.
  */
 function groupingKey(cls: string, prefix: string): string {
-  const bare = prefix !== '' && cls.startsWith(prefix + ':') ? cls.slice(prefix.length + 1) : cls
-  return getVariantPrefix(bare)
+  return getVariantPrefix(stripProjectPrefix(cls, prefix).body)
 }
 
 /**
@@ -152,7 +154,8 @@ export const enforceConsistentLineWrapping = defineRule({
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Warn when a class string exceeds the configured print width',
+      description:
+        'Warn (and optionally autofix) when a class string exceeds the configured print width or classes-per-line budget',
     },
     fixable: 'whitespace',
     schema: [
@@ -208,7 +211,10 @@ export const enforceConsistentLineWrapping = defineRule({
      */
     function deriveBaseIndent(loc: ClassLocation): string {
       const sc = safeSourceCode(context)
-      const line = loc.node.loc?.start.line
+      // Anchor on the enclosing template's opening backtick line (shared by all
+      // its quasis) so a multi-`${}` template derives ONE base indent instead of
+      // staircasing — each quasi's own source line drifts deeper after wrapping.
+      const line = loc.templateLine ?? loc.node.loc?.start.line
       if (sc?.lines && typeof line === 'number' && line >= 1 && line <= sc.lines.length) {
         const src = sc.lines[line - 1] ?? ''
         const m = /^[ \t]*/.exec(src)
@@ -256,9 +262,22 @@ export const enforceConsistentLineWrapping = defineRule({
     /**
      * `wrapLines: 'all'` fixer (also the single-line conversion for
      * 'overWidth', which passes `group: 'never'`): the WHOLE quasi is
-     * re-laid-out into lines packed to `printWidth` per the `group` mode,
-     * in the block or hanging form its position dictates (see the quasi
-     * note at the top of the file).
+     * re-laid-out into `printWidth`-packed lines per the `group` mode, in the
+     * BLOCK form regardless of position — every class run lands on its own
+     * indented line below the backtick.
+     *
+     * A quasi that follows a `${}` (`preserveLeadingSpace`) starts on its own
+     * fresh interior-indented line rather than hanging inline after the
+     * interpolation, and a `${}` that follows the quasi
+     * (`preserveTrailingSpace`) lands alone on the closing interior-indented
+     * line. So no emitted line ever shares its physical row with the opaque
+     * `${expr}`, and every line stays within `printWidth` — bounding the
+     * hanging-join over-width case that per-quasi measurement cannot re-detect.
+     *
+     * The returned value BEGINS with `\n` and ENDS with indentation, so the
+     * newlines already separate it from any bordering `${}`: it must NOT be run
+     * through `preserveSpaces`, which would prepend a stray space before the
+     * leading `\n`.
      */
     function rewrapTemplateToWidth(
       loc: ClassLocation,
@@ -270,33 +289,12 @@ export const enforceConsistentLineWrapping = defineRule({
       const interiorIndent = baseIndent + INDENT_UNIT
       const classes = splitClasses(loc.value)
       if (classes.length === 0) return loc.value
-      if (!loc.preserveLeadingSpace) {
-        // Block form. Keyed off `preserveLeadingSpace` ALONE: a leading quasi
-        // must not take the hanging form below — its first line would land on
-        // the code before the backtick, over-width in the source yet
-        // invisible to the per-quasi line measurement. A `${}` after the
-        // quasi goes on its own interior-indented line.
-        const packed = packGroupedToWidth(classes, interiorIndent, printWidth, group, prefix)
-        const close = loc.preserveTrailingSpace ? interiorIndent : baseIndent
-        // `''` entries (blank group separators) take no indent.
-        return (
-          '\n' + packed.map((c) => (c === '' ? c : interiorIndent + c)).join('\n') + '\n' + close
-        )
-      }
-      // Hanging form. One character is reserved per bordering `${}` for the
-      // boundary space `preserveSpaces` re-adds after packing — without the
-      // reserve a line packed to exactly `printWidth` lands at
-      // `printWidth + 1` and the fix never converges.
-      const trailingReserve = loc.preserveTrailingSpace ? 1 : 0
-      return packGroupedToWidth(
-        classes,
-        interiorIndent,
-        printWidth - 1 - trailingReserve,
-        group,
-        prefix,
-      )
-        .map((c, i) => (i === 0 || c === '' ? c : interiorIndent + c))
-        .join('\n')
+      const packed = packGroupedToWidth(classes, interiorIndent, printWidth, group, prefix)
+      // A following `${}` sits on the closing interior-indented line; otherwise
+      // the closing backtick aligns with the statement's base indent.
+      const close = loc.preserveTrailingSpace ? interiorIndent : baseIndent
+      // `''` entries (blank group separators) take no indent.
+      return '\n' + packed.map((c) => (c === '' ? c : interiorIndent + c)).join('\n') + '\n' + close
     }
 
     /**
@@ -312,7 +310,10 @@ export const enforceConsistentLineWrapping = defineRule({
       const lines = loc.value.split('\n')
       if (lines.length === 1) {
         // group 'never' does no grouping, so the prefix is irrelevant.
-        return preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth, 'never', ''))
+        // rewrapTemplateToWidth returns the final block value (leading `\n`,
+        // boundary spacing handled by newlines) — never run it through
+        // preserveSpaces.
+        return rewrapTemplateToWidth(loc, printWidth, 'never', '')
       }
       const interiorIndent = deriveBaseIndent(loc) + INDENT_UNIT
       // Reserve for the boundary space before a `${}` after the quasi,
@@ -381,14 +382,15 @@ export const enforceConsistentLineWrapping = defineRule({
           !glued &&
           (maxLine > printWidth || (wrapLines === 'all' && isMultiline))
         ) {
-          // Compare the FINAL value (boundary spaces included), or an
-          // already-canonical quasi re-reports with a no-op fix. Equal values
-          // need no warn-only fallback: at a fixed point of either fixer
-          // every multi-class line fits the budget, and over-budget
+          // Both fixers return their FINAL value (block form begins with `\n`
+          // and handles `${}` boundaries via newlines, so neither is run
+          // through `preserveSpaces`), or an already-canonical quasi re-reports
+          // with a no-op fix. Equal values need no warn-only fallback: at a
+          // fixed point every multi-class line fits the budget, and over-budget
           // single-class lines were already excluded from `maxLine`.
           const fixedValue =
             wrapLines === 'all'
-              ? preserveSpaces(loc, rewrapTemplateToWidth(loc, printWidth, group, prefix))
+              ? rewrapTemplateToWidth(loc, printWidth, group, prefix)
               : rewrapOverBudgetLinesToWidth(loc, printWidth)
           if (fixedValue !== loc.value) {
             context.report({
@@ -416,7 +418,10 @@ export const enforceConsistentLineWrapping = defineRule({
 
           if (maxPerLine > classesPerLine) {
             const data = { count: String(maxPerLine), max: String(classesPerLine) }
-            if (loc.node.type === 'TemplateElement') {
+            // Warn-only for a glued quasi (`${a}flex`): `preserveSpaces` would
+            // inject a boundary space and split the one runtime class in two,
+            // the same corruption the width fixer's `!glued` guard prevents.
+            if (loc.node.type === 'TemplateElement' && !glued) {
               const fixedValue = rewrapTemplate(loc, lines, classesPerLine)
               context.report({
                 node: loc.node,

--- a/packages/oxlint-tailwindcss/src/rules/enforce-sort-order.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-sort-order.ts
@@ -1,7 +1,7 @@
 import { defineRule } from '@oxlint/plugins'
 import { createExtractorVisitors, preserveSpaces, type ClassLocation } from '../utils/extractors'
 import { rebuildClassString, splitClassesWithSeparators } from '../utils/class-splitter'
-import { splitUtilityAndVariant } from '../utils/class-parser'
+import { splitUtilityAndVariant, stripProjectPrefix } from '../utils/class-parser'
 import { createLazyLoader } from '../design-system/loader'
 import { sortClassesSync } from '../design-system/sort-service'
 import { createLazyOptions } from '../utils/context'
@@ -84,8 +84,7 @@ export const enforceSortOrder = defineRule({
         // (`tw:` → '') sorts first and the first REAL variant drives ordering.
         // Without this every prefixed group collapses to first variant `tw`
         // (priority MAX) and the order between groups is unstable.
-        const stripKey = (k: string): string =>
-          cache.prefix && k.startsWith(cache.prefix + ':') ? k.slice(cache.prefix.length + 1) : k
+        const stripKey = (k: string): string => stripProjectPrefix(k, cache.prefix).body
 
         const sortedGroupKeys = [...groups.keys()].sort((ka, kb) => {
           const a = stripKey(ka)

--- a/packages/oxlint-tailwindcss/src/utils/class-parser.ts
+++ b/packages/oxlint-tailwindcss/src/utils/class-parser.ts
@@ -105,6 +105,23 @@ export function splitUtilityAndVariant(cls: string): { utility: string; variant:
 }
 
 /**
+ * Strips a Tailwind v4 project prefix (`@import "tailwindcss" prefix(tw)` → `tw`)
+ * off a class, returning the matched prefix marker (`"tw:"`, or `""`) and the
+ * remaining body. The project prefix is structurally a variant but pinned FIRST
+ * (`tw:hover:flex`, never `hover:tw:flex`), so grouping/ordering rules strip it
+ * before reading the real variant chain — the prefix invariant shared by
+ * enforce-sort-order, consistent-variant-order and enforce-consistent-line-wrapping.
+ * `prefix === ""` (no project prefix / no design system) or a non-matching class
+ * passes through untouched.
+ */
+export function stripProjectPrefix(cls: string, prefix: string): { prefix: string; body: string } {
+  if (prefix !== '' && cls.startsWith(prefix + ':')) {
+    return { prefix: prefix + ':', body: cls.slice(prefix.length + 1) }
+  }
+  return { prefix: '', body: cls }
+}
+
+/**
  * Checks if a class has an arbitrary value (bracket syntax in the utility part).
  * Distinguishes from arbitrary variants: [&>svg]:w-4 does NOT have an arbitrary value,
  * but w-[200px] does.

--- a/packages/oxlint-tailwindcss/src/utils/extractors.ts
+++ b/packages/oxlint-tailwindcss/src/utils/extractors.ts
@@ -32,6 +32,15 @@ export interface ClassLocation {
   /** Preserve a trailing space (quasi followed by template expression) */
   preserveTrailingSpace?: boolean
   /**
+   * Line of the enclosing template literal's opening backtick, shared by EVERY
+   * quasi of the same template. Lets a fixer derive ONE base indent for the
+   * whole template instead of re-reading each quasi's own (possibly deeper,
+   * post-wrap) source line — which staircases the indentation of multi-`${}`
+   * templates. Optional and additive: only enforce-consistent-line-wrapping
+   * reads it; every other rule ignores it.
+   */
+  templateLine?: number
+  /**
    * Extraction site of this string (issue #117). Optional and purely additive:
    * per-class rules ignore it. Relational rules gate on `jsx-native`.
    */
@@ -646,6 +655,7 @@ function appendFromTemplateLiteral(
         range: [start, start + value.length],
         preserveLeadingSpace: i > 0,
         preserveTrailingSpace: i < node.quasis.length - 1,
+        templateLine: node.loc?.start.line,
       })
     }
   }

--- a/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/enforce-consistent-line-wrapping.test.ts
@@ -277,10 +277,10 @@ ruleTester.run(
         filename: 'test.tsx',
         options: [{ printWidth: 20, wrapLines: 'all' }],
       },
-      // Fragment adjacent to `${}` already in the canonical hanging layout:
-      // the preserved leading space must not read as "inconsistent".
+      // Fragment adjacent to `${}` already in the canonical block layout: the
+      // run after the `${}` starts on its own fresh line, so it is a fixpoint.
       {
-        code: 'const className = `${base} flex items-center gap-2\n  hover:bg-red-500 hover:underline`',
+        code: 'const className = `${base}\n  flex items-center gap-2\n  hover:bg-red-500 hover:underline\n`',
         filename: 'test.tsx',
         options: [{ printWidth: 40, wrapLines: 'all' }],
       },
@@ -315,15 +315,15 @@ ruleTester.run(
         errors: [{ messageId: 'inconsistentWrapping' }],
         output: 'const className = `\n  flex\n  hover:underline\n  items-center\n`',
       },
-      // Fragment adjacent to `${}`: hanging join (no leading/trailing
-      // newline), one character reserved for the preserved leading space.
+      // Fragment adjacent to `${}`: the run after the interpolation starts on
+      // its own fresh interior-indented line (block form), not hanging inline.
       {
         code: 'const className = `${base} flex items-center gap-2 hover:bg-red-500 hover:underline`',
         filename: 'test.tsx',
         options: [{ printWidth: 40, wrapLines: 'all' }],
         errors: [{ messageId: 'tooLong' }],
         output:
-          'const className = `${base} flex items-center gap-2\n  hover:bg-red-500 hover:underline`',
+          'const className = `${base}\n  flex items-center gap-2\n  hover:bg-red-500 hover:underline\n`',
       },
       // Nested JSX: base indent derived from the source line, and the indent
       // counts against the width budget when packing.
@@ -378,15 +378,15 @@ ruleTester.run('enforce-consistent-line-wrapping (group option)', enforceConsist
       output:
         'const className = `\n  flex items-center gap-2\n\n  hover:bg-red-500 hover:underline\n\n  focus:outline-none\n`',
     },
-    // emptyLine: hanging fragment after a `${}` — the blank separator works
-    // in the hanging join too.
+    // emptyLine: fragment after a `${}` — block form, with a blank line
+    // separating the base run from the hover run.
     {
       code: 'const className = `${base} flex items-center gap-2 hover:bg-red-500 hover:underline`',
       filename: 'test.tsx',
       options: [{ printWidth: 40, wrapLines: 'all', group: 'emptyLine' }],
       errors: [{ messageId: 'tooLong' }],
       output:
-        'const className = `${base} flex items-center gap-2\n\n  hover:bg-red-500 hover:underline`',
+        'const className = `${base}\n  flex items-center gap-2\n\n  hover:bg-red-500 hover:underline\n`',
     },
     // never: the same input the newLine layout splits into four run-per-line
     // lines packs greedily into two.
@@ -430,15 +430,17 @@ ruleTester.run(
     ],
     invalid: [
       // The leading quasi's line exceeds the budget: it re-wraps as a block
-      // (leading newline preserved), NOT as a hanging join glued onto the
-      // `const className = \`` line.
+      // (leading newline preserved), NOT glued onto the `const className = \``
+      // line. The trailing quasi (`px-6 …`) already fits and — sharing the
+      // template's base indent — is a fixpoint, so ONLY the leading quasi
+      // reports.
       {
         code: 'const className = `\n  flex items-center justify-between gap-4 rounded-lg\n  ${cond}\n  px-6 py-3 shadow-md\n`',
         filename: 'test.tsx',
         options: [{ printWidth: 40, wrapLines: 'all' }],
-        errors: [{ messageId: 'tooLong' }, { messageId: 'inconsistentWrapping' }],
+        errors: [{ messageId: 'tooLong' }],
         output:
-          'const className = `\n  flex items-center justify-between\n  gap-4 rounded-lg\n  ${cond} px-6 py-3 shadow-md`',
+          'const className = `\n  flex items-center justify-between\n  gap-4 rounded-lg\n  ${cond}\n  px-6 py-3 shadow-md\n`',
       },
     ],
   },
@@ -515,15 +517,15 @@ ruleTester.run(
         output:
           'function C() {\n\treturn <div className={`\n\t  flex items-center justify-between\n\t  gap-2 p-4\n\t`} />\n}',
       },
-      // Quasi with `${}` on BOTH sides: hanging join, one character reserved
-      // on each side for the preserved spaces.
+      // Quasi with `${}` on BOTH sides: block form — the run starts on its own
+      // fresh line and the trailing `${b}` lands on the closing indented line.
       {
         code: 'const className = `${a} flex items-center justify-between gap-2 rounded-lg p-4 ${b} m-2`',
         filename: 'test.tsx',
         options: [{ printWidth: 40, wrapLines: 'all' }],
         errors: [{ messageId: 'tooLong' }],
         output:
-          'const className = `${a} flex items-center justify-between\n  gap-2 rounded-lg p-4 ${b} m-2`',
+          'const className = `${a}\n  flex items-center justify-between\n  gap-2 rounded-lg p-4\n  ${b} m-2`',
       },
       // A quasi GLUED to a `${}` (no whitespace at the boundary): `${a}flex`
       // is ONE runtime class, so the fixer must never introduce whitespace
@@ -590,15 +592,15 @@ ruleTester.run(
         output:
           'function C() {\n\treturn <div className={`\n\t  flex items-center justify-between\n\t  gap-2 p-4\n\t`} />\n}',
       },
-      // Quasi with `${}` on BOTH sides: hanging form, one character reserved
-      // on each side for the preserved spaces.
+      // Quasi with `${}` on BOTH sides: single-line block conversion — the run
+      // starts on a fresh line and the trailing `${b}` lands on the closing line.
       {
         code: 'const className = `${a} flex items-center justify-between gap-2 rounded-lg p-4 ${b} m-2`',
         filename: 'test.tsx',
         options: [{ printWidth: 40, wrapLines: 'overWidth' }],
         errors: [{ messageId: 'tooLong' }],
         output:
-          'const className = `${a} flex items-center justify-between\n  gap-2 rounded-lg p-4 ${b} m-2`',
+          'const className = `${a}\n  flex items-center justify-between\n  gap-2 rounded-lg p-4\n  ${b} m-2`',
       },
       // Single-line LEADING quasi (before the first `${}`): block form with
       // the `${}` on its own interior-indented line, never a hanging join
@@ -617,6 +619,72 @@ ruleTester.run(
         filename: 'test.tsx',
         options: [{ printWidth: 40, wrapLines: 'overWidth' }],
         errors: [{ messageId: 'tooLong' }],
+      },
+    ],
+  },
+)
+
+// The `glued`-quasi guard covers BOTH sides and BOTH fixers: a class fused to a
+// `${}` is one runtime token, so no fixer may inject whitespace at the boundary.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (glued quasi is never split)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [],
+    invalid: [
+      // TRAILING-glued (`…rounded-lg${a}`): the last class fuses with the `${}`.
+      // Warn-only under 'all' — the width branch's `!glued` gate skips the fix.
+      {
+        code: 'const className = `flex items-center gap-2 p-4 m-2 bg-white text-black rounded-lg${a}`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'tooLong' }],
+      },
+      // Trailing-glued under 'overWidth' too.
+      {
+        code: 'const className = `flex items-center gap-2 p-4 m-2 bg-white text-black rounded-lg${a}`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'overWidth' }],
+        errors: [{ messageId: 'tooLong' }],
+      },
+      // classesPerLine + leading-glued (`${a}flex`): `${a}flex` is ONE runtime
+      // class, so the per-line fixer is warn-only here — without the `!glued`
+      // gate, preserveSpaces would rewrite it to `${a} flex` and split it.
+      {
+        code: 'const className = `${a}flex md:block`',
+        filename: 'test.tsx',
+        options: [{ classesPerLine: 1 }],
+        errors: [{ messageId: 'tooManyPerLine' }],
+      },
+    ],
+  },
+)
+
+// Multi-`${}` templates derive ONE base indent from the opening backtick line
+// (issue 3882024707 part 1) so wrapping is consistent across every quasi and
+// idempotent in a single pass — no staircase.
+ruleTester.run(
+  'enforce-consistent-line-wrapping (multi-`${}` no staircase)',
+  enforceConsistentLineWrapping,
+  {
+    valid: [
+      // Both quasis wrap at the SAME interior indent — a stable fixpoint.
+      {
+        code: 'const className = `${a}\n  flex items-center gap-2\n  ${b}\n  hover:bg-red-500 hover:underline\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+      },
+    ],
+    invalid: [
+      // A trailing quasi staircased one level deeper than the first is
+      // normalized BACK to the shared base indent, not pushed deeper still.
+      {
+        code: 'const className = `${a}\n  flex items-center gap-2\n  ${b}\n    hover:bg-red-500 hover:underline\n`',
+        filename: 'test.tsx',
+        options: [{ printWidth: 40, wrapLines: 'all' }],
+        errors: [{ messageId: 'inconsistentWrapping' }],
+        output:
+          'const className = `${a}\n  flex items-center gap-2\n  ${b}\n  hover:bg-red-500 hover:underline\n`',
       },
     ],
   },


### PR DESCRIPTION
Follow-ups from the [PR #126](https://github.com/sergioazoc/oxlint-tailwindcss/pull/126) review. All land in the **still-unpublished 1.11.0** (no re-bump; npm is still at 1.10.0, publish only happens on `main:release`).

## Correctness

- **`classesPerLine` no longer splits a class glued to a `${}` on `--fix`** (🔴 the twin of review comment 3882024700). The `!glued` guard now gates the `classesPerLine` autofix too — it previously protected only the width fixer — so `` `${a}flex md:block` `` is **warn-only** instead of being rewritten to `` `${a} flex …` ``, which silently split one runtime class in two. Confirmed pre-existing (also on `main` before #126); the #126 fix only covered one of the two fixers.
- **`wrapLines: "all"` bounds every line at an interpolation** (review comment 3882024707 part 2, previously unanswered). A class run bordering a `${}` now starts on its **own fresh line** instead of hanging inline after the expression, so no rewritten line can exceed `printWidth`. `rewrapTemplateToWidth` returns the final block value and is no longer run through `preserveSpaces` on the `"all"` / overWidth-single-line paths. Residual limitation (documented): the `${…}` expression width is opaque to the per-quasi measurement, so a hand-written single physical line with a short fragment beside a wide interpolation can still exceed `printWidth` without being reported.
- **Multi-`${}` templates no longer staircase** (review comment 3882024707 part 1, previously unanswered). Each quasi now derives **one** base indent from the template's opening backtick line via a new additive `ClassLocation.templateLine` (set in `appendFromTemplateLiteral`), so wrapping is consistent across quasis and idempotent in a single pass.

## Convention / DRY

- Hoisted the project-prefix strip idiom (triplicated by hand in `enforce-sort-order`, `consistent-variant-order`, and the new `groupingKey`) into **`stripProjectPrefix`** in `utils/class-parser.ts`; all three rules now consume it (the prefix invariant). Behavior-preserving — the two siblings' suites pass unchanged.

## Docs

- `meta.docs.description` broadened to mention the autofix (the last unresolved doc nit from review item #3); docs regenerated.
- Documented the rule-level `entryPoint` option (EN + ES), the fresh-line interpolation layout, and the residual measurement limitation.

## Tests

- `classesPerLine` + glued and trailing-glued (`` `flex${a}` ``) are warn-only; multi-`${}` no-staircase idempotency; updated the interpolation-layout expected outputs. Full suite green (1907 tests), `lint` / `format:check` / `typecheck` / `build` / `lint:types` all clean; the #14 whitespace-vs-wrapping integration suites stay green.