### PR TITLE
feat: attributePatterns + bounded self-healing worker retries (#134, #145)

### DIFF
--- a/packages/docs/es/settings.md
+++ b/packages/docs/es/settings.md
@@ -66,6 +66,20 @@ solo si tu proyecto define un root size distinto de 16 en `<html>`.
 Cuánto espera el plugin al worker (hilo) que precalcula el design system. CI lentos pueden necesitar
 subirlo; no deberías necesitar bajarlo.
 
+Esto rige **solo el precompute loader**. Los worker services de sort / canonicalize / declaration
+que usan las reglas dependientes del design system durante el linteo tienen su propio timeout de
+**30 s por request** que este ajuste no mueve. Si una máquina lenta-pero-funcional o un runner de CI
+reporta `worker request timed out after 30000ms` sobre listas de clases válidas, súbelo con la
+variable de entorno `OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT` (milisegundos) para que el request
+se complete en vez de fallar:
+
+```bash
+OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT=60000 oxlint
+```
+
+Un timeout ya no cuesta O(archivos): tras unos pocos timeouts consecutivos para un mismo entry point
+el resto del run falla rápido, y el estado se auto-sana cuando la máquina se recupera.
+
 ## `debug`
 
 `boolean`, default `false`. También se activa con la variable de entorno `DEBUG=oxlint-tailwindcss`.
@@ -118,6 +132,18 @@ El plugin escanea estas ubicaciones por defecto:
 | Tags                 | `` tw`...` `` (tagged template literals)                                                                           |
 | Patrones de variable | `/^classNames?$/`, `/^classes$/`, `/^styles?$/`                                                                    |
 
+`attributes`, `callees` y `tags` matchean por **nombre exacto**. Dos ejes matchean por **regex**, y
+su alcance difiere — fíjate cuál necesitas:
+
+- **`attributePatterns`** matchea **nombres de atributos JSX**. Úsalo para convenciones `*ClassName`
+  sin listar cada prop — p. ej. `["ClassName$"]` captura `contentContainerClassName` y
+  `tintColorClassName` en componentes de React Native / Uniwind. Es aditivo a la lista exacta de
+  `attributes`; vacío por defecto, así que el match exacto sigue siendo el default.
+- **`variablePatterns`** matchea **solo nombres de declaración de variables**
+  (`const fooClassName = "..."`), **no** atributos JSX. Su default `/^classNames?$/` coincide en
+  escritura con el atributo `className`, pero son cosas distintas — una entrada de
+  `variablePatterns` nunca afecta props JSX.
+
 Agrega más sin perder los defaults:
 
 ```jsonc
@@ -125,6 +151,7 @@ Agrega más sin perder los defaults:
   "settings": {
     "tailwindcss": {
       "attributes": ["xyzClassName"],
+      "attributePatterns": ["ClassName$"],
       "callees": ["myHelper"],
       "tags": ["css"],
       "variablePatterns": ["^tw[A-Z]"]
@@ -162,6 +189,7 @@ Las exclusiones de `variablePatterns` matchean contra `RegExp.source` literal.
       "debug": false,                      // opcional
       "allowUntestedEngine": false,        // opcional
       "attributes": [],                    // opcional
+      "attributePatterns": [],             // opcional
       "callees": [],                       // opcional
       "tags": [],                          // opcional
       "variablePatterns": [],              // opcional

--- a/packages/docs/es/setup.md
+++ b/packages/docs/es/setup.md
@@ -169,8 +169,9 @@ y plugins como `@tailwindcss/typography`.
 
 - **Ajustar extractors**: por defecto el plugin escanea `className` / `class`, ~14 callees (`cn`,
   `clsx`, `cva`, `twMerge`, …), templates con `tw`, y variables que matchean `/^classNames?$/`,
-  `/^classes$/`, `/^styles?$/`. Agrega `attributes`, `callees`, `tags`, `variablePatterns`, o quita
-  defaults vía `exclude`. Mira la [referencia de settings](/es/settings).
+  `/^classes$/`, `/^styles?$/`. Agrega `attributes`, `attributePatterns` (regex para props tipo
+  `*ClassName`), `callees`, `tags`, `variablePatterns`, o quita defaults vía `exclude`. Mira la
+  [referencia de settings](/es/settings).
 - **Ajustar timeouts**: `settings.tailwindcss.timeout` (ms, default 60000) limita cuánto espera el
   plugin al worker (hilo) que precomputa el design system. CI lento puede necesitar subirlo.
 - **Logging de debug**: `settings.tailwindcss.debug: true` (o `DEBUG=oxlint-tailwindcss`) loguea qué

--- a/packages/docs/settings.md
+++ b/packages/docs/settings.md
@@ -65,6 +65,20 @@ only if your project sets a non-16 root size on `<html>`.
 How long the plugin waits for the worker thread that precomputes the design system. Slow CI machines
 may need this raised; you should not need it lowered.
 
+This governs the **precompute loader** only. The sort / canonicalize / declaration worker services
+that the design-system-dependent rules use while linting have their own **30 s per-request** timeout
+that this setting does not move. If a slow-but-functional machine or CI runner reports
+`worker request timed out after 30000ms` on valid class lists, raise it with the
+`OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT` environment variable (milliseconds) so the request
+completes instead of failing:
+
+```bash
+OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT=60000 oxlint
+```
+
+A timeout no longer costs O(files): after a few consecutive timeouts for one entry point the rest of
+the run fails fast, and the state self-heals once the machine recovers.
+
 ## `debug`
 
 `boolean`, default `false`. Also activated by the `DEBUG=oxlint-tailwindcss` environment variable.
@@ -117,6 +131,17 @@ The plugin scans these locations by default:
 | Tags              | `` tw`...` `` (tagged template literals)                                                                           |
 | Variable patterns | `/^classNames?$/`, `/^classes$/`, `/^styles?$/`                                                                    |
 
+`attributes`, `callees`, and `tags` match **exact names**. Two axes match by **regex**, and their
+scope differs — mind which one you want:
+
+- **`attributePatterns`** matches **JSX attribute names**. Use it for `*ClassName` conventions so
+  you don't list every prop — e.g. `["ClassName$"]` catches `contentContainerClassName` and
+  `tintColorClassName` on React Native / Uniwind components. Additive to the exact `attributes`
+  list; empty by default, so exact matching stays the default.
+- **`variablePatterns`** matches **variable declaration names only** (`const fooClassName = "..."`),
+  **not** JSX attributes. Its default `/^classNames?$/` overlaps in spelling with the `className`
+  attribute, but the two are unrelated — a `variablePatterns` entry never affects JSX props.
+
 Add more without losing the defaults:
 
 ```jsonc
@@ -124,6 +149,7 @@ Add more without losing the defaults:
   "settings": {
     "tailwindcss": {
       "attributes": ["xyzClassName"],
+      "attributePatterns": ["ClassName$"],
       "callees": ["myHelper"],
       "tags": ["css"],
       "variablePatterns": ["^tw[A-Z]"]
@@ -161,6 +187,7 @@ Or remove from the defaults:
       "debug": false,                      // optional
       "allowUntestedEngine": false,        // optional
       "attributes": [],                    // optional
+      "attributePatterns": [],             // optional
       "callees": [],                       // optional
       "tags": [],                          // optional
       "variablePatterns": [],              // optional

--- a/packages/docs/setup.md
+++ b/packages/docs/setup.md
@@ -166,8 +166,9 @@ plugins like `@tailwindcss/typography`.
 
 - **Adjust extractors**: by default the plugin scans `className` / `class`, ~14 callees (`cn`,
   `clsx`, `cva`, `twMerge`, …), `tw` tagged templates, and variables matching `/^classNames?$/`,
-  `/^classes$/`, `/^styles?$/`. Add `attributes`, `callees`, `tags`, `variablePatterns`, or remove
-  defaults via `exclude`. See [settings reference](/settings).
+  `/^classes$/`, `/^styles?$/`. Add `attributes`, `attributePatterns` (regex for `*ClassName`-style
+  props), `callees`, `tags`, `variablePatterns`, or remove defaults via `exclude`. See
+  [settings reference](/settings).
 - **Tune timeouts**: `settings.tailwindcss.timeout` (ms, default 60000) bounds how long the plugin
   waits for the worker thread that precomputes the design system. Slow CI may need this raised.
 - **Debug logging**: `settings.tailwindcss.debug: true` (or `DEBUG=oxlint-tailwindcss`) logs which

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 1.13.0
+
+Two changes: a new `attributePatterns` extractor setting for regex JSX attribute matching
+([#134](https://github.com/sergioazoc/oxlint-tailwindcss/issues/134)), and a bounded, self-healing
+retry for worker per-request failures that fixes a timeout-cost regression introduced in 1.10.2
+([#145](https://github.com/sergioazoc/oxlint-tailwindcss/issues/145)).
+
+### New features
+
+- **`settings.tailwindcss.attributePatterns`** (reported by @hirbod). Regex patterns (as strings)
+  matched against JSX attribute names, additive to the exact `attributes` list. `["ClassName$"]`
+  scans every `*ClassName` prop without enumerating them — for React Native / Uniwind and component
+  libraries that expose many class props. Empty by default, so exact matching stays the default and
+  existing configs are unaffected. It mirrors `variablePatterns`, and like it, an invalid regex
+  source is skipped rather than crashing the lint.
+- **`OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT` environment variable.** Overrides the sort /
+  canonicalize / declaration worker services' per-request timeout (default `30000` ms). Raise it on
+  a slow-but-functional machine or CI runner whose cold canonicalize sits near the default, so the
+  request **completes** (the rule keeps working) instead of timing out and failing fast. Unlike
+  `settings.tailwindcss.timeout`, which governs the precompute loader only, this env var applies to
+  the worker services — the knob the previous timeout error hint said didn't exist.
+
+### Bug fixes
+
+- **A timed-out (or otherwise failing) worker request no longer costs O(files)** (reported by
+  @jvdburgh). Since 1.10.2 ([#132](https://github.com/sergioazoc/oxlint-tailwindcss/pull/132)) a
+  timed-out request dropped the worker and retried without remembering it — right for a malformed
+  input (the #130 case), wrong for a timeout: a machine slow enough to time out once times out
+  again, and dropping the worker resets the design system to **cold**, so every remaining class list
+  re-paid the full 30 s timeout (a CI lint went from ~90 s to over ten minutes). Per-request
+  failures (timeout, oversized/`null` response, non-JSON) are now **bounded**: after 3 consecutive
+  failures for one entry point the error goes sticky and the rest of the run fails fast. Any success
+  clears the budget, and the sticky **expires after a backoff window** so a long-lived editor
+  process self-heals rather than staying dead until restart. The #130 fix is unchanged: a single
+  malformed / mid-typing input still recovers on the next call.
+
+### Docs
+
+- Clarified that `variablePatterns` matches **variable declaration names only**, not JSX attributes
+  — its default `/^classNames?$/` reads like the `className` attribute, but the two are unrelated.
+  Use the new `attributePatterns` for JSX props.
+
 ## 1.12.0
 
 Maintenance release: dev-toolchain dependency updates plus a new opt-in cache-location override. No

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -34,8 +34,8 @@ Read the story behind this plugin:
   possible.
 - **Variable detection** — Lints variables matching `/^classNames?$/`, `/^classes$/`, `/^styles?$/`
   (e.g. `className`, `classNames`, `classes`, `styles`) automatically.
-- **Customizable** — Extend class detection with custom attributes, callees, tags, and variable
-  patterns.
+- **Customizable** — Extend class detection with custom attributes, attribute patterns (regex, for
+  `*ClassName` props), callees, tags, and variable patterns.
 - **Component class support** — Recognizes `@layer components { .btn {} }` in your CSS.
 
 Full documentation: **https://oxlint-tailwindcss.pages.dev** (English) ·
@@ -165,6 +165,18 @@ For slow environments (large monorepos, CI), you can increase the design system 
 }
 ```
 
+This `timeout` governs the **precompute loader** only. The sort/canonicalize/declaration worker
+services used while linting have a separate **30 s per-request** timeout. If a slow-but-functional
+machine or CI runner reports `worker request timed out after 30000ms` on valid class lists, raise it
+with the `OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT` environment variable (milliseconds):
+
+```bash
+OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT=60000 oxlint
+```
+
+A timeout no longer costs O(files): after a few consecutive timeouts for one entry point the rest of
+the run fails fast, and the state self-heals once the machine recovers.
+
 ### Root font size
 
 The `enforce-canonical` rule converts px-based arbitrary values to named classes (e.g. `p-[2px]` →
@@ -230,8 +242,11 @@ entries are appended to the built-in defaults:
   "jsPlugins": ["oxlint-tailwindcss"],
   "settings": {
     "tailwindcss": {
-      // Additional JSX attribute names to scan
+      // Additional JSX attribute names to scan (exact match)
       "attributes": ["xyzClassName", "classNames", "overlayClassName"],
+      // Regex patterns for JSX attribute names — catches *ClassName conventions
+      // (React Native / Uniwind) without listing every prop
+      "attributePatterns": ["ClassName$"],
       // Additional function names to scan
       "callees": ["myHelper"],
       // Additional tagged template tags to scan
@@ -249,6 +264,12 @@ entries are appended to the built-in defaults:
 
 This applies to all 24 rules at once. For example, adding `"classNames"` to `attributes` makes every
 rule lint `<Input classNames={{ root: "..." }} />`.
+
+> **`attributePatterns` vs `variablePatterns`** — both match by regex, but on different things.
+> `attributePatterns` matches **JSX attribute names** (`contentContainerClassName`,
+> `tintColorClassName`, …); `variablePatterns` matches **variable declaration names only**
+> (`const fooClassName = "..."`), never JSX attributes — despite its default `/^classNames?$/`
+> looking like the `className` attribute.
 
 To **remove** specific items from the built-in defaults, use `exclude`:
 

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/design-system/ds-worker.ts
+++ b/packages/oxlint-tailwindcss/src/design-system/ds-worker.ts
@@ -9,10 +9,14 @@
  * — SharedArrayBuffer layout, state machine, lifecycle, fail-loud — and each
  * service shrinks to ~40 LOC of singleton + public signature.
  *
- * v1: failures throw `SortServiceError`. The error is sticky for the lifetime
- * of the process (per cssPath) so subsequent calls don't pay another
- * init-timeout cost. Callers wrap via `safeGetDS` to surface the failure as a
- * single `designSystemUnavailable` diagnostic.
+ * v1: failures throw `SortServiceError`. Init/spawn/crash/DS-load failures are
+ * HARD sticky per cssPath for the process lifetime, so subsequent calls don't
+ * pay another init-timeout cost. Per-request failures (timeout / non-JSON /
+ * null) are SOFT sticky (#145): unbounded retrying re-pays the full request
+ * timeout on every class list (O(files)), so after a few consecutive failures
+ * the error goes sticky for a backoff window and the rest of the run fails fast;
+ * any success clears it. Callers wrap via `safeGetDS` to surface the failure as
+ * a single `designSystemUnavailable` diagnostic.
  */
 
 import { Worker } from 'node:worker_threads'
@@ -33,6 +37,35 @@ const LENGTH_OFFSET = HEADER_INTS * 4 // 16 bytes
 const DATA_OFFSET = LENGTH_OFFSET + 4 // 20 bytes
 const INIT_TIMEOUT = 60_000 // 60 s to load DS (raised in v1 to avoid spurious timeouts on slow CI)
 const REQUEST_TIMEOUT = 30_000 // 30 s per request
+
+// After this many consecutive per-request failures for one entry point, the
+// error goes SOFT-sticky so the rest of the run fails fast instead of re-paying
+// the timeout on every remaining class list (#145). Any success resets the
+// count, so a single transient blip never trips it.
+const MAX_CONSECUTIVE_REQUEST_FAILURES = 3
+
+// How long a SOFT (per-request) sticky error lasts before a retry is allowed
+// again (#145). Unlike init/spawn/crash/DS-load failures — HARD sticky for the
+// whole process — a per-request sticky expires: after this window `ensure()`
+// lets one attempt through, so a long-lived editor self-heals when the machine
+// recovers instead of staying dead until restart (the #130 symptom).
+const REQUEST_STICKY_BACKOFF_MS = 60_000
+
+/**
+ * Per-request timeout override for slow-but-functional machines (#145). A
+ * machine whose cold canonicalize sits close to the 30 s default times out
+ * spuriously; raising this lets the request COMPLETE (the rule keeps working)
+ * rather than only failing fast. An env var — not a `settings.tailwindcss` key —
+ * keeps the documented invariant that worker services don't read
+ * `settings.tailwindcss.timeout`, and sidesteps the settings-timing problem
+ * (settings throw inside `createOnce`). Read once per worker construction.
+ */
+function envRequestTimeout(): number | undefined {
+  const raw = process.env.OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT
+  if (raw === undefined || raw === '') return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
 
 // LRU bound on live workers (#77). In a monorepo linted in one oxlint run the
 // plugin can resolve several entry points, and oxlint feeds files in
@@ -138,6 +171,18 @@ export interface DesignSystemWorkerOptions {
   workerScript: string
   /** Human-readable name shown in error messages. */
   serviceName: 'sort' | 'canonicalize' | 'declarations'
+  /**
+   * Per-request timeout in ms. Precedence: this option >
+   * `OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT` env var > the 30 s default.
+   * Exists mainly as a test seam — a real timeout test would otherwise wait the
+   * full default; users tune it via the env var (#145).
+   */
+  requestTimeoutMs?: number
+  /**
+   * Consecutive per-request failures for one entry point before the error goes
+   * soft-sticky (default {@link MAX_CONSECUTIVE_REQUEST_FAILURES}). Test seam (#145).
+   */
+  maxConsecutiveRequestFailures?: number
 }
 
 export class DesignSystemWorker<Req, Res> {
@@ -156,12 +201,49 @@ export class DesignSystemWorker<Req, Res> {
   // lastError/lastErrorCssPath pair was cleared on ANY cssPath switch, so it
   // never stayed sticky across the alternating-file pattern #77 describes.
   private errors = new Map<string, SortServiceError>()
+  // Per-request (SOFT) sticky state, kept separate from `errors` (which is HARD
+  // sticky: init/spawn/crash/DS-load, never retried in-process). A per-request
+  // failure — timeout, oversized response, non-JSON — is bounded, not permanent
+  // (#145): `failRequest` counts consecutive failures per cssPath and, past
+  // MAX_CONSECUTIVE_REQUEST_FAILURES, records a soft sticky good for
+  // REQUEST_STICKY_BACKOFF_MS; `ensure` fast-fails until it expires, then lets
+  // one retry through; any success (in `callSync`) clears both. This bounds the
+  // O(files) timeout cost without reintroducing the #130 "dead until restart".
+  private requestFailCount = new Map<string, number>()
+  private requestStick = new Map<string, { err: SortServiceError; until: number }>()
 
-  constructor(private readonly opts: DesignSystemWorkerOptions) {}
+  /** Resolved per-request timeout (option > env var > REQUEST_TIMEOUT). */
+  private readonly requestTimeoutMs: number
+  /** Resolved consecutive-failure budget before a per-request error goes soft-sticky. */
+  private readonly maxConsecutiveRequestFailures: number
 
-  /** Record an error as sticky for `cssPath` and return it for `throw`. */
+  constructor(private readonly opts: DesignSystemWorkerOptions) {
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? envRequestTimeout() ?? REQUEST_TIMEOUT
+    this.maxConsecutiveRequestFailures =
+      opts.maxConsecutiveRequestFailures ?? MAX_CONSECUTIVE_REQUEST_FAILURES
+  }
+
+  /** Record an error as HARD sticky for `cssPath` and return it for `throw`. */
   private remember(cssPath: string, err: SortServiceError): SortServiceError {
     this.errors.set(cssPath, err)
+    return err
+  }
+
+  /**
+   * Handle a per-request (SOFT) failure (#145): drop the worker so the next call
+   * re-spawns, count consecutive failures for this cssPath, and once the budget
+   * is spent record a soft sticky good for a backoff window so the rest of the
+   * run fails fast instead of re-paying the timeout per class list. A later
+   * success (see `callSync`) clears the count and the soft sticky. Returns the
+   * error for `throw` (mirrors `remember`).
+   */
+  private failRequest(cssPath: string, err: SortServiceError): SortServiceError {
+    this.dropWorker(cssPath)
+    const count = (this.requestFailCount.get(cssPath) ?? 0) + 1
+    this.requestFailCount.set(cssPath, count)
+    if (count >= this.maxConsecutiveRequestFailures) {
+      this.requestStick.set(cssPath, { err, until: Date.now() + REQUEST_STICKY_BACKOFF_MS })
+    }
     return err
   }
 
@@ -172,8 +254,19 @@ export class DesignSystemWorker<Req, Res> {
    * cssPath rethrow without retrying.
    */
   private ensure(cssPath: string): ReadyState {
+    // HARD sticky (init/spawn/crash/DS-load): never retried in this process.
     const sticky = this.errors.get(cssPath)
     if (sticky) throw sticky
+
+    // SOFT sticky (per-request budget spent, #145): fast-fail until the backoff
+    // window elapses, then clear it and let one attempt through — a success then
+    // resets the budget, so a long-lived process self-heals.
+    const soft = this.requestStick.get(cssPath)
+    if (soft) {
+      if (Date.now() < soft.until) throw soft.err
+      this.requestStick.delete(cssPath)
+      this.requestFailCount.delete(cssPath)
+    }
 
     const existing = this.workers.get(cssPath)
     if (existing) {
@@ -307,19 +400,24 @@ export class DesignSystemWorker<Req, Res> {
     Atomics.store(state.controlArray, 0, 1)
     Atomics.notify(state.controlArray, 0)
 
-    const result = Atomics.wait(state.controlArray, 1, 0, REQUEST_TIMEOUT)
+    const result = Atomics.wait(state.controlArray, 1, 0, this.requestTimeoutMs)
     if (result === 'timed-out') {
-      // Per-request failure (#130): drop the worker so the next call re-spawns
-      // and retries, but do NOT remember() it as sticky. A request-level failure
-      // is a property of one input, not of the entry point — making it sticky
-      // (as init failures are) let one malformed/transient input permanently
-      // disable the rule for the whole cssPath until the process restarted.
-      // Mirrors the already-non-sticky "payload too large" branch above.
-      this.dropWorker(cssPath)
-      throw new SortServiceError(
-        `${this.opts.serviceName} worker request timed out after ${REQUEST_TIMEOUT}ms.`,
-        // Fixed internal limit, not settings.tailwindcss.timeout.
-        'This is unexpected for typical class lists; please open an issue if it persists.',
+      // Per-request failure: bounded drop-and-retry (#145). A timeout is usually
+      // a property of the MACHINE, not the input — a machine slow enough to time
+      // out once times out again, and dropWorker resets the DS to cold, so an
+      // unbounded retry re-pays the full timeout on every remaining class list
+      // (O(files)). failRequest goes soft-sticky after a few consecutive
+      // failures so the rest of the run fails fast. If the machine is merely
+      // slow, raise OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT so the request
+      // completes instead of failing.
+      throw this.failRequest(
+        cssPath,
+        new SortServiceError(
+          `${this.opts.serviceName} worker request timed out after ${this.requestTimeoutMs}ms.`,
+          // Not settings.tailwindcss.timeout (that governs the precompute loader
+          // only); raise OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT instead.
+          'A slow machine or CI runner can cause this. If the class lists are valid, raise OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT; otherwise please open an issue.',
+        ),
       )
     }
 
@@ -331,28 +429,36 @@ export class DesignSystemWorker<Req, Res> {
     try {
       parsed = JSON.parse(responseStr)
     } catch (cause) {
-      // Per-request failure (#130): drop-and-retry, not sticky. See the
-      // request-timeout branch above for the rationale.
-      this.dropWorker(cssPath)
-      throw new SortServiceError(
-        `${this.opts.serviceName} worker returned non-JSON response.`,
-        'This is a bug; please open an issue.',
-        { cause: cause instanceof Error ? cause : undefined },
+      // Per-request failure: bounded drop-and-retry (#145). See the request-
+      // timeout branch above for the rationale.
+      throw this.failRequest(
+        cssPath,
+        new SortServiceError(
+          `${this.opts.serviceName} worker returned non-JSON response.`,
+          'This is a bug; please open an issue.',
+          { cause: cause instanceof Error ? cause : undefined },
+        ),
       )
     }
 
     if (parsed === null) {
-      // Per-request failure (#130): drop-and-retry, not sticky. After the
-      // handler guards land, the only realistic cause here is an oversized
-      // response (the response-side twin of "payload too large"), so a later
-      // request with different input must be free to succeed, not rethrow.
-      this.dropWorker(cssPath)
-      throw new SortServiceError(
-        `${this.opts.serviceName} worker returned null — the request body was rejected or its response did not fit the buffer.`,
-        'This is a bug; please open an issue with the input that triggered it.',
+      // Per-request failure: bounded drop-and-retry (#145). After #132's handler
+      // guards the only realistic cause is an oversized response, so a later
+      // request with different input must be free to succeed — but repeated
+      // failures still go soft-sticky so the run doesn't stall.
+      throw this.failRequest(
+        cssPath,
+        new SortServiceError(
+          `${this.opts.serviceName} worker returned null — the request body was rejected or its response did not fit the buffer.`,
+          'This is a bug; please open an issue with the input that triggered it.',
+        ),
       )
     }
 
+    // Success clears any per-request failure budget / soft sticky for this
+    // cssPath (#145), so failures spread across a long run never accumulate.
+    this.requestFailCount.delete(cssPath)
+    this.requestStick.delete(cssPath)
     return parsed as Res
   }
 
@@ -360,6 +466,8 @@ export class DesignSystemWorker<Req, Res> {
     for (const state of this.workers.values()) this.terminateWorker(state.worker)
     this.workers.clear()
     this.errors.clear()
+    this.requestFailCount.clear()
+    this.requestStick.clear()
   }
 
   /** Terminate and forget the worker for a single cssPath (on request failure). */

--- a/packages/oxlint-tailwindcss/src/types.ts
+++ b/packages/oxlint-tailwindcss/src/types.ts
@@ -50,6 +50,14 @@ export interface PluginSettings {
   timeout?: number
   /** Additional JSX attribute names to scan for Tailwind classes (added to defaults) */
   attributes?: string[]
+  /**
+   * Regex patterns (as strings) matched against JSX attribute NAMES, additive to
+   * the exact `attributes` list. Lets `*ClassName` conventions (React Native /
+   * Uniwind, component libraries) be scanned without listing every prop, e.g.
+   * `["ClassName$"]`. Note: `variablePatterns` matches variable declaration
+   * names only, NOT JSX attributes — use this for attributes.
+   */
+  attributePatterns?: string[]
   /** Additional function names to scan for Tailwind classes (added to defaults) */
   callees?: string[]
   /** Additional tagged template tag names to scan (added to defaults) */

--- a/packages/oxlint-tailwindcss/src/utils/extractors.ts
+++ b/packages/oxlint-tailwindcss/src/utils/extractors.ts
@@ -75,6 +75,7 @@ export function preserveSpaces(loc: ClassLocation, fixed: string): string {
 
 export interface ExtractorConfig {
   attributes: string[]
+  attributePatterns: RegExp[]
   callees: string[]
   tags: string[]
   variablePatterns: RegExp[]
@@ -84,6 +85,10 @@ const DEFAULT_VARIABLE_PATTERNS = [/^classNames?$/, /^classes$/, /^styles?$/]
 
 export const DEFAULT_EXTRACTOR_CONFIG: ExtractorConfig = {
   attributes: ['className', 'class'],
+  // No default attribute patterns — exact `attributes` matching is the default
+  // (#134). Opt in via `settings.tailwindcss.attributePatterns` for props like
+  // `*ClassName` (React Native / Uniwind).
+  attributePatterns: [],
   callees: [
     'cn',
     'clsx',
@@ -181,6 +186,11 @@ export function getExtractorConfig(context: {
       tw.attributes,
       exclude?.attributes,
     ),
+    // Regex matching for JSX attribute NAMES (#134), additive to the exact
+    // `attributes` list. compileRegexList skips invalid sources instead of
+    // throwing (same graceful degradation as variablePatterns). No defaults, so
+    // nothing to exclude.
+    attributePatterns: compileRegexList(tw.attributePatterns),
     callees: mergeUnique(DEFAULT_EXTRACTOR_CONFIG.callees, tw.callees, exclude?.callees),
     tags: mergeUnique(DEFAULT_EXTRACTOR_CONFIG.tags, tw.tags, exclude?.tags),
     variablePatterns: [
@@ -283,7 +293,15 @@ export function extractFromJSXAttribute(
   config: ExtractorConfig = DEFAULT_EXTRACTOR_CONFIG,
 ): ClassLocation[] {
   const name = node.name.type === 'JSXIdentifier' ? node.name.name : undefined
-  if (!name || !config.attributes.includes(name)) return []
+  // Exact `attributes` match, or a regex `attributePatterns` match (#134) — the
+  // latter lets `*ClassName` conventions (React Native / Uniwind) be caught
+  // without listing every prop. Exact-match stays the default (patterns empty).
+  if (
+    !name ||
+    (!config.attributes.includes(name) && !config.attributePatterns.some((p) => p.test(name)))
+  ) {
+    return []
+  }
 
   if (!node.value) return []
 

--- a/packages/oxlint-tailwindcss/tests/integration/fatal-errors.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/fatal-errors.test.ts
@@ -6,7 +6,7 @@
  * `designSystemUnavailable` diagnostic.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { resolve } from 'node:path'
 import {
   canonicalizeClassesSync,
@@ -189,6 +189,91 @@ describe('per-request worker failure — retryable, not sticky (#130)', () => {
 
     // Regression: the SAME instance + SAME cssPath must retry (re-spawn) and
     // succeed. With the old sticky remember() this rethrew the error forever.
+    expect(worker!.callSync(CSS, ['flex', 'p-2'])).toEqual(['flex', 'p-2'])
+  })
+})
+
+/**
+ * Issue #145. #130 made every per-request failure retryable — right for a
+ * malformed input, wrong for a TIMEOUT: a machine slow enough to time out once
+ * times out again, and `dropWorker` resets the DS to cold, so an unbounded retry
+ * re-pays the full timeout on every remaining class list (O(files) — a CI run
+ * went from ~90s to >10min). The fix BOUNDS the retrying: after a few
+ * consecutive per-request failures for one entry point the error goes
+ * SOFT-sticky (fast-fail), any success clears the budget, and the sticky expires
+ * after a backoff window so a long-lived editor self-heals (never the #130
+ * "dead until restart"). `requestTimeoutMs` / `maxConsecutiveRequestFailures`
+ * are test seams so this doesn't wait the shipped 30s.
+ */
+describe('per-request worker failure — bounded, self-healing (#145)', () => {
+  const CSS = resolve(__dirname, '../fixtures/default.css')
+  let worker: DesignSystemWorker<unknown, unknown> | null = null
+
+  afterEach(() => {
+    worker?.reset()
+    worker = null
+    vi.useRealTimers()
+  })
+
+  test('stops paying the request timeout once the budget is spent', () => {
+    worker = new DesignSystemWorker({
+      // A handler that never replies stands in for one that is merely slow.
+      workerScript: makeWorkerScript('(ds, req) => { while (true) {} }'),
+      serviceName: 'canonicalize',
+      requestTimeoutMs: 50,
+      maxConsecutiveRequestFailures: 2,
+    })
+
+    // Each call within budget waits out the (short) timeout and re-spawns cold.
+    for (let i = 0; i < 2; i++) {
+      expect(() => worker!.callSync(CSS, ['flex'])).toThrow(SortServiceError)
+    }
+
+    // Budget spent → the next call must fast-fail via the soft sticky instead of
+    // waiting out another timeout (+ cold re-spawn). Without the bound it would.
+    const start = Date.now()
+    expect(() => worker!.callSync(CSS, ['flex'])).toThrow(SortServiceError)
+    expect(Date.now() - start).toBeLessThan(50)
+  })
+
+  test('a success between failures clears the budget', () => {
+    worker = new DesignSystemWorker({
+      // Throw on a sentinel (→ null branch), echo anything else back.
+      workerScript: makeWorkerScript(
+        "(ds, req) => { if (req === '__BOOM__') throw new Error('boom'); return req; }",
+      ),
+      serviceName: 'canonicalize',
+      maxConsecutiveRequestFailures: 2,
+    })
+
+    // Two NON-consecutive failures (a success in between) must NOT trip the
+    // budget — otherwise interleaved traffic would quietly reintroduce #130.
+    expect(() => worker!.callSync(CSS, '__BOOM__')).toThrow(SortServiceError) // count → 1
+    expect(worker!.callSync(CSS, ['flex'])).toEqual(['flex']) // success → count reset to 0
+    expect(() => worker!.callSync(CSS, '__BOOM__')).toThrow(SortServiceError) // count → 1 (not 2)
+    // Still healthy: not soft-sticky, so a valid call succeeds.
+    expect(worker!.callSync(CSS, ['flex', 'p-2'])).toEqual(['flex', 'p-2'])
+  })
+
+  test('the soft sticky expires so a recovered machine self-heals', () => {
+    vi.useFakeTimers()
+    worker = new DesignSystemWorker({
+      workerScript: makeWorkerScript(
+        "(ds, req) => { if (req === '__BOOM__') throw new Error('boom'); return req; }",
+      ),
+      serviceName: 'canonicalize',
+      maxConsecutiveRequestFailures: 1, // one failure → soft-sticky immediately
+    })
+
+    // Budget 1: the first failure makes it soft-sticky.
+    expect(() => worker!.callSync(CSS, '__BOOM__')).toThrow(SortServiceError)
+    // Within the backoff window a valid call still fast-fails (soft sticky).
+    expect(() => worker!.callSync(CSS, ['flex'])).toThrow(SortServiceError)
+
+    // Past the backoff window the sticky expires: the next call retries and
+    // succeeds (a long-lived process is never dead until restart). Atomics.wait
+    // uses real time, so faking Date only moves the backoff clock.
+    vi.advanceTimersByTime(120_000)
     expect(worker!.callSync(CSS, ['flex', 'p-2'])).toEqual(['flex', 'p-2'])
   })
 })

--- a/packages/oxlint-tailwindcss/tests/rules/no-duplicate-classes.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-duplicate-classes.test.ts
@@ -206,6 +206,40 @@ describe('custom extractor settings', () => {
     ],
   })
 
+  // Custom attribute patterns (#134): regex matching for JSX attribute NAMES,
+  // additive to the exact `attributes` list (React Native / Uniwind *ClassName).
+  settingsTester.run('no-duplicate-classes (custom attributePatterns)', noDuplicateClasses, {
+    valid: [
+      // Without settings, a *ClassName prop is ignored...
+      { code: '<ScrollView contentContainerClassName="flex flex" />', filename: 'test.tsx' },
+      // ...and an attribute the pattern does NOT match is left alone.
+      {
+        code: '<ScrollView somethingElse="flex flex" />',
+        filename: 'test.tsx',
+        settings: { tailwindcss: { attributePatterns: ['ClassName$'] } },
+      },
+    ],
+    invalid: [
+      // A prop matched by the pattern is scanned.
+      {
+        code: '<ScrollView contentContainerClassName="flex flex items-center" />',
+        filename: 'test.tsx',
+        settings: { tailwindcss: { attributePatterns: ['ClassName$'] } },
+        errors: [{ messageId: 'duplicate' }],
+        output: '<ScrollView contentContainerClassName="flex items-center" />',
+      },
+      // Additive: the default `className` attribute still works when a
+      // (non-matching) pattern is configured — patterns don't replace exact names.
+      {
+        code: '<div className="flex flex" />',
+        filename: 'test.tsx',
+        settings: { tailwindcss: { attributePatterns: ['^tw[A-Z]'] } },
+        errors: [{ messageId: 'duplicate' }],
+        output: '<div className="flex" />',
+      },
+    ],
+  })
+
   // Custom callees
   settingsTester.run('no-duplicate-classes (custom callees)', noDuplicateClasses, {
     valid: [

--- a/packages/oxlint-tailwindcss/tests/utils/extractors.test.ts
+++ b/packages/oxlint-tailwindcss/tests/utils/extractors.test.ts
@@ -1,6 +1,8 @@
 import type { ESTree } from '@oxlint/plugins'
 import { describe, expect, it } from 'vitest'
 import {
+  DEFAULT_EXTRACTOR_CONFIG,
+  type ExtractorConfig,
   extractFromCallExpression,
   extractFromJSXAttribute,
   extractFromTaggedTemplate,
@@ -117,5 +119,54 @@ describe('extractor origin (issue #117)', () => {
     const locs = extractFromVariableDeclarator(declarator)
     expect(locs).toHaveLength(1)
     expect(locs[0].origin).toBe('variable')
+  })
+})
+
+/**
+ * Issue #134: `attributePatterns` matches JSX attribute NAMES by regex, additive
+ * to the exact `attributes` list — so `*ClassName` conventions (React Native /
+ * Uniwind) are caught without listing every prop.
+ */
+describe('attributePatterns — regex JSX attribute matching (#134)', () => {
+  const withPatterns = (patterns: RegExp[]): ExtractorConfig => ({
+    ...DEFAULT_EXTRACTOR_CONFIG,
+    attributePatterns: patterns,
+  })
+  const namedAttr = (attrName: string, value: string): ESTree.JSXAttribute => {
+    const a = {
+      type: 'JSXAttribute',
+      name: { type: 'JSXIdentifier', name: attrName },
+      value: { type: 'Literal', value, range: RANGE },
+    } as unknown as ESTree.JSXAttribute
+    ;(a as unknown as { parent: unknown }).parent = {
+      type: 'JSXOpeningElement',
+      name: { type: 'JSXIdentifier', name: 'ScrollView' },
+    }
+    return a
+  }
+
+  it('extracts a *ClassName prop matched by a pattern', () => {
+    const locs = extractFromJSXAttribute(
+      namedAttr('contentContainerClassName', 'p-4'),
+      withPatterns([/ClassName$/]),
+    )
+    expect(locs).toHaveLength(1)
+    expect(locs[0].value).toBe('p-4')
+  })
+
+  it('ignores an attribute no pattern matches', () => {
+    expect(
+      extractFromJSXAttribute(namedAttr('data-foo', 'p-4'), withPatterns([/ClassName$/])),
+    ).toHaveLength(0)
+  })
+
+  it('is additive: the default exact `attributes` still match under a pattern', () => {
+    expect(
+      extractFromJSXAttribute(namedAttr('className', 'p-4'), withPatterns([/^tw[A-Z]/])),
+    ).toHaveLength(1)
+  })
+
+  it('matches nothing extra with the default empty patterns', () => {
+    expect(extractFromJSXAttribute(namedAttr('contentContainerClassName', 'p-4'))).toHaveLength(0)
   })
 })


### PR DESCRIPTION
Combined PR for two reviewed issues. Release as **1.13.0** (minor).

## #134 — `attributePatterns` (regex JSX attribute matching)

JSX attribute detection was exact-match only, so React Native / Uniwind props like `contentContainerClassName` / `tintColorClassName` had to be listed one by one in `attributes`.

- New `settings.tailwindcss.attributePatterns`: regex patterns (as strings) matched against JSX attribute **names**, additive to the exact `attributes` list. `["ClassName$"]` scans every `*ClassName` prop. Empty by default → exact matching stays the default, existing configs unaffected.
- Mirrors `variablePatterns` and reuses `compileRegexList` (invalid sources skipped, not thrown). Touches only `extractors.ts` + `types.ts` — no rule changes (all 24 rules funnel through `createExtractorVisitors`).
- Deliberately **no** `exclude.attributePatterns` (there are no default attribute patterns to exclude).
- **Docs**: clarified that `variablePatterns` matches variable declaration names only, not JSX attributes — closing the ambiguity the issue flagged.

Closes #134.

## #145 — bounded, self-healing worker per-request retries

Since #132, a timed-out worker request dropped the worker and retried **without** remembering it. A timeout is a property of the **machine**, not the input, and `dropWorker` resets the design system to **cold**, so every remaining class list re-paid the full 30 s timeout — O(files). A CI lint went from ~90 s to >10 min.

- Per-request failures (timeout / oversized-`null` / non-JSON) now go **soft-sticky** after 3 consecutive failures per entry point (rest of the run fails fast) — kept in a separate map from the hard-sticky init/crash errors.
- Any **success clears** the budget; the soft-sticky **expires after a backoff window**, so a long-lived editor self-heals when the machine recovers (never the #130 "dead until restart").
- New `OXLINT_TAILWINDCSS_WORKER_REQUEST_TIMEOUT` env var lets slow-but-functional machines raise the per-request timeout so the request **completes** instead of failing fast.
- The #130 fix is unchanged: a single malformed / mid-typing input still recovers on the next call.

Closes #145.

## Verification

`pnpm format:check && pnpm lint && pnpm typecheck && pnpm build && pnpm test` — all clean. **1918 tests pass**; 3 new #145 tests (`fatal-errors.test.ts`) + #134 coverage in `no-duplicate-classes` and `extractors` unit tests. `pnpm -C packages/docs generate` produces no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXfwpR9ciUsTFf6UYtmaCK