### PR TITLE
fix(no-contradicting-variants): don't flag responsive resets (#150)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,10 +160,17 @@ Core sync/async bridge: `@tailwindcss/node`'s `__unstable__loadDesignSystem` is 
 DS-dependent rules: `no-unknown-classes`, `no-conflicting-classes`, `enforce-canonical`,
 `enforce-sort-order`, `no-unnecessary-arbitrary-value`, `prefer-theme-tokens`.
 `consistent-variant-order`, `no-contradicting-variants`, and `enforce-consistent-line-wrapping` are
-the DS-optional rules: their static fallbacks (variant order, the pseudo-element/barrier name lists,
-and prefix-unaware variant-run grouping respectively) are themselves deterministic, so a missing
-entryPoint is tolerated silently — none may ever emit `designSystemUnavailable`.
-`enforce-consistent-line-wrapping` consults the DS ONLY for the project prefix (so
+the DS-optional rules: their static fallbacks (variant order; the pseudo-element/barrier name lists
+plus the `display`/`visibility` property groups; and prefix-unaware variant-run grouping
+respectively) are themselves deterministic, so a missing entryPoint is tolerated silently — none may
+ever emit `designSystemUnavailable`. `no-contradicting-variants` also runs a **responsive-reset
+guard (#150)**: before flagging `V:util` redundant against an unconditional base `util`, it
+suppresses the report when a sibling with a DIFFERENT utility writes an overlapping CSS property
+(`md:hidden` overriding `display` between `block` and `lg:block`) — that variant is load-bearing,
+not redundant. Property source is `cache.getCssProperties` with an entryPoint, else the static
+`display`/`visibility` groups; sibling scan skips `changesTarget` variants (other box) and
+same-utility siblings (same value). Strictly report-reducing, so it can never introduce a new false
+positive. `enforce-consistent-line-wrapping` consults the DS ONLY for the project prefix (so
 `wrapLines: 'all'` grouping treats `tw:` as transparent, matching the prefix invariant); everything
 else it does is DS-free. `no-deprecated-classes` is DS-independent outright (guard removed in #69):
 it consults only the hardcoded `DEPRECATED_MAP`, so it never loads the design system and never emits

--- a/packages/docs/es/rules/_extras/no-contradicting-variants.md
+++ b/packages/docs/es/rules/_extras/no-contradicting-variants.md
@@ -22,6 +22,16 @@ comporta igual que antes — nunca reporta que falte el design system.
 El match es por identidad exacta de la utility, así que `bg-white hover:bg-blue-500` queda intacto
 (valores distintos), igual que `flex hover:items-center` (utilities distintas).
 
+"La base aplica sin condiciones" sólo se sostiene cuando nada más pisa su propiedad. Una clase
+responsive que restablece una propiedad que un breakpoint intermedio le quitó es **load-bearing**,
+no redundante: en `block md:hidden lg:block` la base es `block`, pero `md:hidden` pone
+`display: none` desde `md` hacia arriba, y `lg:block` restaura `display: block` desde `lg` hacia
+arriba — quitarla deja el elemento oculto en pantallas grandes. La regla lo detecta y se queda
+callada cuando una clase hermana con una utility _distinta_ escribe una propiedad CSS que se solapa.
+Sin entry point esto cubre los grupos cerrados `display` y `visibility`; con uno configurado usa las
+propiedades que el design system reporta de verdad, así que se extiende a cualquier propiedad
+(`text-align`, `position`, utilities que define el proyecto, …).
+
 ## Opciones
 
 | Opción       | Tipo     | Por defecto | Descripción                                              |
@@ -63,6 +73,9 @@ design system.
 <div className="absolute after:absolute" />
 <div className="shrink-0 [&>svg]:shrink-0" />
 <div className="flex *:data-[slot=select-value]:flex" />
+
+// Reset responsive — `lg:block` restaura `display` después de que `md:hidden` lo quitó
+<div className="block md:hidden lg:block" />
 ```
 
 ## Interacciones con otras reglas

--- a/packages/docs/es/rules/no-contradicting-variants.md
+++ b/packages/docs/es/rules/no-contradicting-variants.md
@@ -27,6 +27,16 @@ comporta igual que antes — nunca reporta que falte el design system.
 El match es por identidad exacta de la utility, así que `bg-white hover:bg-blue-500` queda intacto
 (valores distintos), igual que `flex hover:items-center` (utilities distintas).
 
+"La base aplica sin condiciones" sólo se sostiene cuando nada más pisa su propiedad. Una clase
+responsive que restablece una propiedad que un breakpoint intermedio le quitó es **load-bearing**,
+no redundante: en `block md:hidden lg:block` la base es `block`, pero `md:hidden` pone
+`display: none` desde `md` hacia arriba, y `lg:block` restaura `display: block` desde `lg` hacia
+arriba — quitarla deja el elemento oculto en pantallas grandes. La regla lo detecta y se queda
+callada cuando una clase hermana con una utility _distinta_ escribe una propiedad CSS que se solapa.
+Sin entry point esto cubre los grupos cerrados `display` y `visibility`; con uno configurado usa las
+propiedades que el design system reporta de verdad, así que se extiende a cualquier propiedad
+(`text-align`, `position`, utilities que define el proyecto, …).
+
 ## Opciones
 
 | Opción       | Tipo     | Por defecto | Descripción                                              |
@@ -68,6 +78,9 @@ design system.
 <div className="absolute after:absolute" />
 <div className="shrink-0 [&>svg]:shrink-0" />
 <div className="flex *:data-[slot=select-value]:flex" />
+
+// Reset responsive — `lg:block` restaura `display` después de que `md:hidden` lo quitó
+<div className="block md:hidden lg:block" />
 ```
 
 ## Interacciones con otras reglas

--- a/packages/docs/rules/_extras/no-contradicting-variants.md
+++ b/packages/docs/rules/_extras/no-contradicting-variants.md
@@ -21,6 +21,15 @@ behaves exactly as before — it never reports a missing design system.
 The match is by exact utility identity, so `bg-white hover:bg-blue-500` is left alone (different
 values), as is `flex hover:items-center` (different utilities).
 
+"The base applies unconditionally" only holds when nothing else overrides its property. A responsive
+class that re-establishes a property an intermediate breakpoint took away is **load-bearing**, not
+redundant: in `block md:hidden lg:block` the base is `block`, but `md:hidden` sets `display: none`
+from `md` up, and `lg:block` restores `display: block` from `lg` up — removing it leaves the element
+hidden on large screens. The rule detects this and stays quiet when a sibling with a _different_
+utility writes an overlapping CSS property. Without an entry point this covers the closed `display`
+and `visibility` groups; with one configured it uses the properties the design system actually
+reports, so it extends to every property (`text-align`, `position`, project-defined utilities, …).
+
 ## Options
 
 | Option       | Type     | Default | Description                                             |
@@ -62,6 +71,9 @@ missing design system.
 <div className="absolute after:absolute" />
 <div className="shrink-0 [&>svg]:shrink-0" />
 <div className="flex *:data-[slot=select-value]:flex" />
+
+// Responsive reset — `lg:block` restores `display` after `md:hidden` removed it
+<div className="block md:hidden lg:block" />
 ```
 
 ## Interactions with other rules

--- a/packages/docs/rules/no-contradicting-variants.md
+++ b/packages/docs/rules/no-contradicting-variants.md
@@ -26,6 +26,15 @@ behaves exactly as before — it never reports a missing design system.
 The match is by exact utility identity, so `bg-white hover:bg-blue-500` is left alone (different
 values), as is `flex hover:items-center` (different utilities).
 
+"The base applies unconditionally" only holds when nothing else overrides its property. A responsive
+class that re-establishes a property an intermediate breakpoint took away is **load-bearing**, not
+redundant: in `block md:hidden lg:block` the base is `block`, but `md:hidden` sets `display: none`
+from `md` up, and `lg:block` restores `display: block` from `lg` up — removing it leaves the element
+hidden on large screens. The rule detects this and stays quiet when a sibling with a _different_
+utility writes an overlapping CSS property. Without an entry point this covers the closed `display`
+and `visibility` groups; with one configured it uses the properties the design system actually
+reports, so it extends to every property (`text-align`, `position`, project-defined utilities, …).
+
 ## Options
 
 | Option       | Type     | Default | Description                                             |
@@ -67,6 +76,9 @@ missing design system.
 <div className="absolute after:absolute" />
 <div className="shrink-0 [&>svg]:shrink-0" />
 <div className="flex *:data-[slot=select-value]:flex" />
+
+// Responsive reset — `lg:block` restores `display` after `md:hidden` removed it
+<div className="block md:hidden lg:block" />
 ```
 
 ## Interactions with other rules

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.11.1
+
+`no-contradicting-variants` flags a variant class as redundant when the same utility already applies
+unconditionally (`flex hover:flex`). It decided by exact utility identity alone, with no notion of
+the responsive cascade, so `block md:hidden lg:block` reported `lg:block` as redundant against the
+base `block` — missing that `md:hidden` sets `display: none` from `md` up and `lg:block` restores
+`display: block` from `lg` up. Acting on the finding (removing `lg:block`) leaves the element hidden
+on large screens, a rendering regression on one of Tailwind's most common mobile-first patterns
+([#150](https://github.com/sergioazoc/oxlint-tailwindcss/issues/150), reported by @ftzi).
+
+### Bug fixes
+
+- **`no-contradicting-variants` no longer flags a responsive class that re-establishes a property an
+  intermediate class overrode.** Before reporting `V:util` redundant against an unconditional base
+  `util`, the rule now checks whether a sibling with a _different_ utility writes an overlapping CSS
+  property; if so, the variant is a load-bearing reset (`md:hidden` → `lg:block`) and stays
+  unflagged. With an `entryPoint` the property comes from the design system (covers `text-align`,
+  `position`, project-defined utilities, …); without one it falls back to the closed
+  `display`/`visibility` groups. The change only ever suppresses a report, so it cannot introduce a
+  new false positive — genuinely redundant pairs like `flex hover:flex` and `flex dark:flex` report
+  exactly as before.
+
 ## 1.11.0
 
 The first release since 1.10.2, consolidating everything landed on `main` in the meantime: an opt-in

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -528,6 +528,9 @@ unconditionally.
 <div className="hover:flex dark:flex" />
 <div className="absolute after:absolute" />
 <div className="shrink-0 [&>svg]:shrink-0" />
+
+// ✅ OK — responsive reset: lg:block restores display after md:hidden removed it
+<div className="block md:hidden lg:block" />
 ```
 
 Only flags when the exact same utility exists both as base and with a conditional variant. Variants
@@ -539,7 +542,14 @@ are not flagged.
 are override fragments where the "redundant" variant is often load-bearing (it beats a same-group
 class the component merges in), so they are skipped to avoid false positives.
 
-**No options.** **No autofix.**
+**Responsive resets (issue #150):** the base only "applies unconditionally" if nothing else
+overrides its property. A variant that re-establishes a property an intermediate class took away
+(`lg:block` after `md:hidden`) is load-bearing and not flagged. With an `entryPoint` this uses the
+CSS properties the design system reports (any property); without one it falls back to the closed
+`display`/`visibility` groups.
+
+**Options:** `entryPoint` (per-rule override of `settings.tailwindcss.entryPoint`; optional — the
+rule is DS-optional and never reports a missing design system). **No autofix.**
 
 ---
 

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/rules/no-contradicting-variants.ts
+++ b/packages/oxlint-tailwindcss/src/rules/no-contradicting-variants.ts
@@ -6,9 +6,44 @@ import {
   changesTarget,
   extractUtility,
   extractVariants,
+  splitImportant,
 } from '../utils/class-parser'
 import { createLazyLoader } from '../design-system/loader'
 import { softGetDS } from '../utils/fatal'
+
+// Static fallback for the CSS property a utility declares, used when no entry
+// point is configured (this rule is DS-OPTIONAL). Only the closed, stable groups
+// where "which property does this touch?" is unambiguous without the design
+// system: `display` and `visibility`. With an entry point, `getCssProperties`
+// supersedes this and extends coverage to every property. Composite utilities
+// that touch more than their nominal property (`sr-only`/`not-sr-only`) are
+// deliberately omitted — the static claim has to be exact.
+const STATIC_PROP_GROUPS = new Map<string, string>([
+  ['block', 'display'],
+  ['inline-block', 'display'],
+  ['inline', 'display'],
+  ['flex', 'display'],
+  ['inline-flex', 'display'],
+  ['grid', 'display'],
+  ['inline-grid', 'display'],
+  ['table', 'display'],
+  ['inline-table', 'display'],
+  ['table-caption', 'display'],
+  ['table-cell', 'display'],
+  ['table-column', 'display'],
+  ['table-column-group', 'display'],
+  ['table-footer-group', 'display'],
+  ['table-header-group', 'display'],
+  ['table-row-group', 'display'],
+  ['table-row', 'display'],
+  ['flow-root', 'display'],
+  ['contents', 'display'],
+  ['list-item', 'display'],
+  ['hidden', 'display'],
+  ['visible', 'visibility'],
+  ['invisible', 'visibility'],
+  ['collapse', 'visibility'],
+])
 
 export const noContradictingVariants = defineRule({
   meta: {
@@ -41,14 +76,24 @@ export const noContradictingVariants = defineRule({
     // emitted `designSystemUnavailable` and must not start.
     const getDS = createLazyLoader(context)
 
-    function variantFactsLookup(): (variant: string) => VariantFacts | undefined {
-      const ds = softGetDS(getDS)
-      if (!ds) return () => undefined
-      return (variant) => ds.cache.getVariantFacts(variant)
-    }
-
     function check(locations: ClassLocation[]) {
-      const factsFor = variantFactsLookup()
+      const ds = softGetDS(getDS)
+      const cache = ds ? ds.cache : null
+      const factsFor = (v: string): VariantFacts | undefined =>
+        ds ? ds.cache.getVariantFacts(v) : undefined
+
+      // The CSS property names a bare utility declares on its own box. Prefers
+      // the design system (covers every property + project-defined utilities);
+      // falls back to the static display/visibility groups so the rule keeps
+      // working without an entry point.
+      const propsOf = (bare: string): readonly string[] => {
+        if (cache) {
+          const props = cache.getCssProperties(bare)
+          if (props.length > 0) return props
+        }
+        const group = STATIC_PROP_GROUPS.get(bare)
+        return group ? [group] : []
+      }
 
       for (const loc of locations) {
         // Composition guard (issue #117): this relational check is only sound on
@@ -67,7 +112,8 @@ export const noContradictingVariants = defineRule({
         }
 
         // Check variant classes against base classes
-        for (const cls of classes) {
+        for (let i = 0; i < classes.length; i++) {
+          const cls = classes[i]
           const variants = extractVariants(cls)
           if (variants.length === 0) continue
 
@@ -76,13 +122,37 @@ export const noContradictingVariants = defineRule({
 
           const utility = extractUtility(cls)
           // Only report if the exact same utility exists as a base class
-          if (baseUtilities.has(utility)) {
-            context.report({
-              node: loc.node,
-              messageId: 'redundantVariant',
-              data: { variantClass: cls, baseClass: utility },
+          if (!baseUtilities.has(utility)) continue
+
+          // Responsive-reset guard (issue #150): the base only "applies
+          // unconditionally" if nothing else overrides its property. When a
+          // sibling with a DIFFERENT utility writes an overlapping CSS property,
+          // this variant is re-establishing it (`block md:hidden lg:block`), so
+          // it's load-bearing, not redundant. Strictly report-reducing.
+          const bare = splitImportant(utility).bare
+          const candidateProps = propsOf(bare)
+          if (candidateProps.length > 0) {
+            const overridden = classes.some((other, j) => {
+              if (j === i) return false
+              // A sibling on another box (pseudo-element/child selector) can't
+              // override this element's property.
+              const otherVariants = extractVariants(other)
+              if (otherVariants.some((v) => changesTarget(v, factsFor(v)))) return false
+              const otherBare = splitImportant(extractUtility(other)).bare
+              // Same utility (the base itself, or another variant of it) is not
+              // an override — it computes to the same value.
+              if (otherBare === bare) return false
+              const otherProps = propsOf(otherBare)
+              return otherProps.some((p) => candidateProps.includes(p))
             })
+            if (overridden) continue
           }
+
+          context.report({
+            node: loc.node,
+            messageId: 'redundantVariant',
+            data: { variantClass: cls, baseClass: utility },
+          })
         }
       }
     }

--- a/packages/oxlint-tailwindcss/tests/rules/no-contradicting-variants-entrypoint.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-contradicting-variants-entrypoint.test.ts
@@ -26,6 +26,21 @@ describe('per-rule entryPoint option (no settings at all)', () => {
         filename: 'test.tsx',
         options: [{ entryPoint: CUSTOM }],
       },
+      // Responsive reset (issue #150) resolved via the design system's real
+      // properties: `md:hidden` overrides `display`, so `lg:block` is a
+      // load-bearing reset, not redundant.
+      {
+        code: '<div className="block md:hidden lg:block" />',
+        filename: 'test.tsx',
+        options: [{ entryPoint: CUSTOM }],
+      },
+      // DS-only win: `text-align` is not in the static fallback table, so this
+      // is caught only because the design system reports the property.
+      {
+        code: '<div className="text-left md:text-center lg:text-left" />',
+        filename: 'test.tsx',
+        options: [{ entryPoint: CUSTOM }],
+      },
     ],
     invalid: [
       // Same code, NO entry point anywhere -> static fallback doesn't know
@@ -44,6 +59,23 @@ describe('per-rule entryPoint option (no settings at all)', () => {
       // And the option does not break the ordinary case.
       {
         code: '<div className="flex hover:flex" />',
+        filename: 'test.tsx',
+        options: [{ entryPoint: CUSTOM }],
+        errors: [{ messageId: 'redundantVariant' }],
+      },
+      // Property specificity: `top` and `bottom` don't overlap, so `md:bottom-0`
+      // does NOT override `top-0` — `lg:top-0` is genuinely redundant.
+      {
+        code: '<div className="top-0 md:bottom-0 lg:top-0" />',
+        filename: 'test.tsx',
+        options: [{ entryPoint: CUSTOM }],
+        errors: [{ messageId: 'redundantVariant' }],
+      },
+      // The overriding sibling styles another box: `after:hidden` targets
+      // `::after`, so it can't reset the element's own `display` — `lg:block`
+      // stays redundant against the base `block`.
+      {
+        code: '<div className="block after:hidden lg:block" />',
         filename: 'test.tsx',
         options: [{ entryPoint: CUSTOM }],
         errors: [{ messageId: 'redundantVariant' }],

--- a/packages/oxlint-tailwindcss/tests/rules/no-contradicting-variants.test.ts
+++ b/packages/oxlint-tailwindcss/tests/rules/no-contradicting-variants.test.ts
@@ -30,6 +30,18 @@ ruleTester.run('no-contradicting-variants', noContradictingVariants, {
     // Child/descendant selectors target different elements
     { code: '<div className="flex *:data-[slot=select-value]:flex" />', filename: 'test.tsx' },
     { code: '<div className="flex *:[span]:last:flex" />', filename: 'test.tsx' },
+    // Responsive reset (issue #150): a sibling overrides `display` between the
+    // base and the repeated utility, so the repeat is load-bearing. The static
+    // `display`/`visibility` fallback covers these without an entry point.
+    { code: '<div className="block md:hidden lg:block" />', filename: 'test.tsx' },
+    { code: '<div className="flex md:hidden lg:flex" />', filename: 'test.tsx' },
+    { code: '<div className="grid md:hidden lg:grid" />', filename: 'test.tsx' },
+    { code: '<div className="visible md:invisible lg:visible" />', filename: 'test.tsx' },
+    // Multi-breakpoint: `lg:flex` resets after `md:hidden`; `xl:hidden` has no
+    // base counterpart so it is never a candidate.
+    { code: '<div className="flex md:hidden lg:flex xl:hidden" />', filename: 'test.tsx' },
+    // Different utilities, no base match — not reported today; lock it in.
+    { code: '<div className="hidden md:block" />', filename: 'test.tsx' },
     // Composition guard (issue #117): "base + variant:same-utility is redundant"
     // only holds for the element's FINAL class list. In a `cn`/`twMerge`
     // fragment or a custom component's `className`, the variant is often
@@ -68,6 +80,20 @@ ruleTester.run('no-contradicting-variants', noContradictingVariants, {
       code: '<div className="flex hover:flex dark:flex" />',
       filename: 'test.tsx',
       errors: [{ messageId: 'redundantVariant' }, { messageId: 'redundantVariant' }],
+    },
+    // The responsive-reset guard must NOT over-suppress: the sibling
+    // (`md:items-center`) touches a different property, so `dark:flex` is still
+    // redundant against the unconditional `flex`.
+    {
+      code: '<div className="flex md:items-center dark:flex" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'redundantVariant' }],
+    },
+    // Single display utility, no overriding sibling — genuine redundancy.
+    {
+      code: '<div className="block hover:block" />',
+      filename: 'test.tsx',
+      errors: [{ messageId: 'redundantVariant' }],
     },
   ],
 })


### PR DESCRIPTION
## Summary

`no-contradicting-variants` reported `lg:block` as redundant in
`block md:hidden lg:block`, but it's a **load-bearing responsive reset**: `md:hidden`
sets `display: none` from `md` up and `lg:block` restores `display: block` from `lg` up.
Removing it hides the element on large screens — a rendering regression on one of
Tailwind's most common mobile-first patterns. Fixes #150.

Root cause: the rule compared only by exact utility identity, with no notion of a
sibling overriding the same CSS property in between.

## Fix

Before flagging `V:util` redundant against an unconditional base `util`, the rule now
suppresses the report when a sibling with a **different** utility writes an overlapping
CSS property (a necessary reset):

- **With `entryPoint`** → property comes from the design system (`cache.getCssProperties`),
  covering every property (`text-align`, `position`, project-defined utilities, …).
- **Without `entryPoint`** → static fallback over the closed `display`/`visibility` groups,
  so the DS-optional contract is preserved (never emits `designSystemUnavailable`).

The sibling scan skips `changesTarget` variants (other box) and same-utility siblings
(same value). The change is **strictly report-reducing** — it can only drop a report,
never add one — so `flex hover:flex` and `flex dark:flex` report exactly as before.

## Tests

- New `valid`/`invalid` cases in both `no-contradicting-variants.test.ts` (static fallback)
  and `no-contradicting-variants-entrypoint.test.ts` (DS path), including the exact #150
  repro and controls against over-suppression (`flex md:items-center dark:flex`,
  `top-0 md:bottom-0 lg:top-0`, `block after:hidden lg:block`).
- Full suite: 1930/1930. lint / format:check / typecheck / build green.
- End-to-end repro with the built plugin (real oxlint, with and without `entryPoint`):
  FP gone, control still reports.

## Release

Patch **1.11.1**. Updates CHANGELOG, package README, CLAUDE.md, and rule docs (EN/ES).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXfwpR9ciUsTFf6UYtmaCK