### PR TITLE
fix: enforce-canonical cedes variable-syntax to the dedicated rule + docs truthfulness sweep (#152)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,9 @@ That's it — the push fast-forwards `release` to `main` and `release.yml` takes
 ## Architecture
 
 oxlint plugin with 24 Tailwind CSS v4 linting rules. Uses `@oxlint/plugins`' `createOnce` API (runs
-once per lint session; returned visitors run on every matching AST node).
+once per lint session; returned visitors run on every matching AST node). This document covers the
+error-prone subsystems, not every rule; the canonical per-rule reference (all 24, with options and
+defaults) is `packages/docs/rules/index.md`.
 
 **v1.0.0 philosophy — deterministic, explicit, fail-loud.** The plugin used to auto-detect the CSS
 entry point, fall back to a module-level `lastLoadedPath`, and silently skip rules when the design
@@ -157,23 +159,31 @@ Core sync/async bridge: `@tailwindcss/node`'s `__unstable__loadDesignSystem` is 
    key, and the engine guard all independently agree on ONE engine per `cssPath` — no threading. In
    a monorepo, packages pinned to different Tailwind versions each get their own engine.
 
-DS-dependent rules: `no-unknown-classes`, `no-conflicting-classes`, `enforce-canonical`,
-`enforce-sort-order`, `no-unnecessary-arbitrary-value`, `prefer-theme-tokens`.
-`consistent-variant-order`, `no-contradicting-variants`, and `enforce-consistent-line-wrapping` are
-the DS-optional rules: their static fallbacks (variant order; the pseudo-element/barrier name lists
-plus the `display`/`visibility` property groups; and prefix-unaware variant-run grouping
-respectively) are themselves deterministic, so a missing entryPoint is tolerated silently — none may
-ever emit `designSystemUnavailable`. `no-contradicting-variants` also runs a **responsive-reset
-guard (#150)**: before flagging `V:util` redundant against an unconditional base `util`, it
-suppresses the report when a sibling with a DIFFERENT utility writes an overlapping CSS property
-(`md:hidden` overriding `display` between `block` and `lg:block`) — that variant is load-bearing,
-not redundant. Property source is `cache.getCssProperties` with an entryPoint, else the static
+DS-dependent rules (the 7 users of `safeGetDS`, which reports `designSystemUnavailable`):
+`no-unknown-classes`, `no-conflicting-classes`, `enforce-canonical`, `enforce-sort-order`,
+`no-unnecessary-arbitrary-value`, `prefer-scale-token`, `prefer-theme-tokens`. The **DS-optional**
+rules use `softGetDS` instead — they consult the DS when an entryPoint is configured but fall back
+to a deterministic static path when it isn't, so a missing entryPoint is tolerated silently and none
+may ever emit `designSystemUnavailable`. There are 8: `consistent-variant-order`,
+`no-contradicting-variants`, `enforce-consistent-line-wrapping`, `no-dark-without-light`,
+`enforce-shorthand`, `enforce-logical`, `enforce-physical` (these last two reach `softGetDS` through
+the shared directional mapper in `enforce-logical.ts`), and `no-deprecated-classes`.
+`consistent-variant-order`, `no-contradicting-variants`, and `enforce-consistent-line-wrapping` have
+static fallbacks (variant order; the pseudo-element/barrier name lists plus the
+`display`/`visibility` property groups; and prefix-unaware variant-run grouping respectively) that
+are themselves deterministic. `no-contradicting-variants` also runs a **responsive-reset guard
+(#150)**: before flagging `V:util` redundant against an unconditional base `util`, it suppresses the
+report when a sibling with a DIFFERENT utility writes an overlapping CSS property (`md:hidden`
+overriding `display` between `block` and `lg:block`) — that variant is load-bearing, not redundant.
+Property source is `cache.getCssProperties` with an entryPoint, else the static
 `display`/`visibility` groups; sibling scan skips `changesTarget` variants (other box) and
 same-utility siblings (same value). Strictly report-reducing, so it can never introduce a new false
 positive. `enforce-consistent-line-wrapping` consults the DS ONLY for the project prefix (so
 `wrapLines: 'all'` grouping treats `tw:` as transparent, matching the prefix invariant); everything
-else it does is DS-free. `no-deprecated-classes` is DS-independent outright (guard removed in #69):
-it consults only the hardcoded `DEPRECATED_MAP`, so it never loads the design system and never emits
+else it does is DS-free. `no-deprecated-classes` is DS-optional, not DS-independent (#69 removed the
+hard DS requirement, not DS use itself): with an entryPoint it prefers the richer rename map the
+precompute derives from `canonicalizeCandidates`, and falls back to the hardcoded `DEPRECATED_MAP`
+when none is configured. Because it goes through `softGetDS` it never emits
 `designSystemUnavailable`.
 
 ## Extraction System
@@ -197,6 +207,9 @@ the extractor config lazily from `settings.tailwindcss`.
 - `tags: string[]` — additional tagged template tags
 - `variablePatterns: string[]` — additional regex patterns for variable names (as strings, compiled
   to RegExp)
+- `attributePatterns: string[]` — regex patterns matched against JSX attribute NAMES (as strings,
+  compiled to RegExp; default `[]`, #134). Distinct from `variablePatterns`, which matches variable
+  names. Additive; not covered by `exclude`.
 - `exclude: { attributes?, callees?, tags?, variablePatterns? }` — remove specific items from
   defaults. For `variablePatterns`, exclusions match against `RegExp.source`.
 
@@ -239,6 +252,9 @@ AST visitors: `JSXAttribute`, `CallExpression`, `TaggedTemplateExpression`, `Var
   retain oxlint's strict `RuleContext`) catches plugin-fatal errors and reports
   `designSystemUnavailable`. Constants `DS_UNAVAILABLE_MESSAGE_ID` + `DS_UNAVAILABLE_MESSAGE` are
   spread into each rule's `meta.messages` so the messageId can't drift between rule and reporter.
+  `softGetDS(getDS)` is the quiet sibling: it returns the DS or `null`, swallowing the fatal instead
+  of reporting it — the mechanism every DS-optional rule uses to fall back to its static path (so
+  those rules never emit `designSystemUnavailable`).
 - **`utils/allowlist.ts`** — `compileRegexList(patterns)` + `matchesAny(value, list)`, shared
   between the directional rules.
 
@@ -511,8 +527,8 @@ AST visitors: `JSXAttribute`, `CallExpression`, `TaggedTemplateExpression`, `Var
   full init — tracking the path makes it genuinely sticky. On entry-point change it cleans up and
   re-inits. Failures throw `SortServiceError` — no silent fallback to heuristic sort or precomputed
   canonicalize.
-- **Suggestions API**: 11 rules provide `suggest` in `context.report()` for IDE quick-fixes. All use
-  `messageId: 'suggestReplace'` with `hasSuggestions: true` in meta. The 9 rules that emit
+- **Suggestions API**: 12 rules provide `suggest` in `context.report()` for IDE quick-fixes (the 12
+  with `hasSuggestions: true` in meta). All use `messageId: 'suggestReplace'`. The 9 rules that emit
   autofix-then-suggestions delegate the loop to `reportClassReplacements` in `utils/report.ts`.
 - **Directional rules** (`enforce-logical` ↔ `enforce-physical`): both consume
   `createDirectionalMapper(context, { mappings, messageId })` from `enforce-logical.ts`. The mapping

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Classes are detected in `className`/`class` attributes, 14 utility helpers (`cn`
 ## Requirements
 
 - Node.js ≥ 20
-- Tailwind CSS v4
+- Tailwind CSS v4.1+ (4.0.x is not supported)
 - oxlint ≥ 1.43.0
 
 ## Repository structure

--- a/packages/docs/es/index.md
+++ b/packages/docs/es/index.md
@@ -25,7 +25,7 @@ features:
   - title: Nativo de Tailwind v4
     details: |
       Llama a `@tailwindcss/node` directamente para entender tus tokens
-      `@theme` custom, tus variables de shadcn, tu plugin de typography.
+      `@theme` personalizados, tus variables de shadcn, tu plugin de tipografía.
       Sin necesidad de mantener una config paralela.
   - title: Coexiste con oxfmt y Prettier
     details: |

--- a/packages/docs/es/interop.md
+++ b/packages/docs/es/interop.md
@@ -5,10 +5,10 @@
 `sortTailwindcss` de [oxfmt](https://oxc.rs/docs/guide/usage/formatter). Las tres herramientas
 coinciden byte a byte **si leen el mismo CSS**.
 
-El catch: por defecto, prettier-plugin-tailwindcss (y oxfmt, que delega en él) lee el `theme.css`
+La salvedad: por defecto, prettier-plugin-tailwindcss (y oxfmt, que delega en él) lee el `theme.css`
 empacado dentro del paquete npm `tailwindcss` — **no el CSS de tu proyecto**. Si tu proyecto tiene
-un bloque `@theme { ... }` con tokens custom, oxfmt no se entera y su orden va a desacordar con
-`enforce-sort-order` en esos tokens.
+un bloque `@theme { ... }` con tokens personalizados, oxfmt no se entera y su orden va a discrepar
+con `enforce-sort-order` en esos tokens.
 
 ## El fix: alinear el stylesheet
 

--- a/packages/docs/es/migration/v0-to-v1.md
+++ b/packages/docs/es/migration/v0-to-v1.md
@@ -2,7 +2,7 @@
 
 v1.0.0 alinea `oxlint-tailwindcss` con la filosofía de config determinista que el resto del
 ecosistema (prettier-plugin-tailwindcss, oxfmt, better-tailwindcss) ya sigue. El trade-off es un
-setting obligatorio a cambio de "configuralo una vez, no falla más".
+setting obligatorio a cambio de "configúralo una vez, no falla más".
 
 Esta página lista cada breaking change con un before/after lado a lado.
 
@@ -31,7 +31,7 @@ explícitamente.
 ### Monorepo con múltiples CSS
 
 ```jsonc
-// v0.x — array de strings, el plugin eligea el más cercano por path
+// v0.x — array de strings, el plugin elegía el más cercano por prefijo de ruta
 {
   "settings": {
     "tailwindcss": {
@@ -83,7 +83,7 @@ plugin estaba auto-detectando — necesitas declarar qué encontraba.
 v0.x saltaba reglas DS-dependientes silenciosamente cuando el design system no podía cargarse
 (faltaba `@tailwindcss/node`, CSS inválido, worker timeout, etc.).
 
-v1.0.0 surfacea fallas como un único diagnóstico `designSystemUnavailable` por archivo. El mensaje
+v1.0.0 expone las fallas como un único diagnóstico `designSystemUnavailable` por archivo. El mensaje
 embebe un hint accionable — usualmente la ruta exacta que el plugin intentó, o el timeout que se
 alcanzó.
 
@@ -93,7 +93,7 @@ El fix está en el hint.
 ## Removido: fallback heurístico de sort
 
 `enforce-sort-order` solía caer a un sort heurístico basado en prefix cuando su worker thread
-timeouteaba. Máquinas distintas podían producir output distinto para el mismo input.
+expiraba. Máquinas distintas podían producir output distinto para el mismo input.
 
 v1.0.0 remueve el fallback. Si el worker falla, la regla emite un diagnóstico fatal en lugar de
 adivinar.
@@ -111,7 +111,7 @@ v1.0.0 usa solo content hash — el mtime es un fast path in-memory dentro del p
 
 ## Cambiado: timeouts
 
-Defaults subidos para reducir failures espurios en hardware lento / CI:
+Defaults subidos para reducir fallas espurias en hardware lento / CI:
 
 | Constante                              | v0.x | v1.0.0 |
 | -------------------------------------- | ---- | ------ |
@@ -150,8 +150,8 @@ Para tener shape-parity con `enforce-logical`:
 - El nombre de cada regla, el `messageId` y los campos `data` están intactos. `enforce-sort-order`
   sigue emitiendo `unsorted`, `no-unknown-classes` sigue emitiendo `unknown`, etc.
 - Los patrones default del extractor (attributes, callees, tags, variable patterns) son los mismos.
-  Los settings custom `attributes`, `callees`, `tags`, `variablePatterns` y `exclude` funcionan como
-  antes.
+  Los ajustes personalizados `attributes`, `callees`, `tags`, `variablePatterns` y `exclude`
+  funcionan como antes.
 - La ruta del disk cache (`os.tmpdir()/oxlint-tailwindcss/`) es la misma.
 - Performance: el costo runtime por archivo es igual o ligeramente más rápido (menos branches de
   fallback).

--- a/packages/docs/es/monorepo.md
+++ b/packages/docs/es/monorepo.md
@@ -7,7 +7,7 @@ ya estructura su config.
 ## Patrón A — un solo config raíz con mapping de globs
 
 Un `.oxlintrc.json` en la raíz. `entryPoint` es un array de objetos `{ files, use }`, evaluados en
-orden de declaración; el primer glob que matchea el archivo lintado gana.
+orden de declaración; el primer glob que coincide con el archivo lintado gana.
 
 ```jsonc
 // /my-monorepo/.oxlintrc.json
@@ -34,7 +34,7 @@ Cuándo conviene:
 
 - Todos tus packages comparten las mismas reglas.
 - Quieres una sola fuente de verdad de qué se lintea cómo.
-- Ya estás usando `overrides` de oxlint para customización por regla en la raíz.
+- Ya estás usando `overrides` de oxlint para personalización por regla en la raíz.
 
 Un entry de fallback `"**"` al final es recomendado — sin él, cualquier archivo fuera de los globs
 explícitos va a fallar con `MissingEntryPointError`.
@@ -49,7 +49,7 @@ my-monorepo/
 ├── .oxlintrc.json                       # base de reglas (opcional entryPoint para archivos top-level)
 ├── packages/
 │   ├── ui/
-│   │   ├── .oxlintrc.json               # extends ../../.oxlintrc.json, setea entryPoint
+│   │   ├── .oxlintrc.json               # extends ../../.oxlintrc.json, define entryPoint
 │   │   ├── src/styles.css
 │   │   └── src/Button.tsx
 │   ├── admin/
@@ -109,7 +109,7 @@ encuentran strings de clases. No hace falta deshabilitar el plugin por archivo.
 
 Activa `settings.tailwindcss.debug` (o la variable `DEBUG=oxlint-tailwindcss`) y oxlint va a
 imprimir una línea por archivo mostrando qué CSS cargó el plugin para ese archivo. Útil cuando un
-glob matchea el mapping equivocado.
+glob coincide con el mapping equivocado.
 
 ## Motores de Tailwind por package
 
@@ -117,5 +117,5 @@ Para cada entry point CSS resuelto, el plugin carga el motor de Tailwind (`@tail
 el `node_modules` de ese package, así los packages fijados a versiones distintas de Tailwind se
 lintean cada uno con el motor con el que compilan. El guard de versión corre por package también —
 un motor más viejo que v4.1, un major futuro, o un drift de major respecto del build de ese package
-falla fuerte (ver [`allowUntestedEngine`](/es/settings#allowuntestedengine)). No tenés que hacer
+falla fuerte (ver [`allowUntestedEngine`](/es/settings#allowuntestedengine)). No tienes que hacer
 nada para esto; sigue la misma resolución de entry point por archivo de arriba.

--- a/packages/docs/es/rules/_extras/consistent-variant-order.md
+++ b/packages/docs/es/rules/_extras/consistent-variant-order.md
@@ -3,17 +3,24 @@
 Reordena los prefijos de variants dentro de una sola clase para que la cadena se escriba siempre
 igual. `hover:dark:bg-red` y `dark:hover:bg-red` producen el mismo CSS en Tailwind v4, pero un orden
 inconsistente ensucia grep, code reviews y diffs. Esta regla elige un orden canónico y reescribe
-todo para que matchee, con autofix sobre el primer ofensor y sugerencias de editor sobre el resto.
+todo para que coincida, con autofix sobre el primer ofensor y sugerencias de editor sobre el resto.
 
 Los pseudo-elements (`before`, `after`, `file`, `placeholder`, `selection`, `marker`, `backdrop`,
 `first-line`, `first-letter`, `details-content`) quedan siempre pinneados innermost — lo más cerca
 posible de la utility — porque en Tailwind v4 un pseudo-element puesto antes de una variant que
 selecciona elemento produce CSS roto del estilo `&::before { &>svg { … } }`.
 
+Con un entry point configurado, qué variants son esas surge de los selectores que genera el design
+system en lugar de esa lista fija, así que una variant que define tu proyecto también se maneja:
+`@custom-variant thumb (&::-webkit-slider-thumb)` queda pinneada innermost como `before:`, y
+`@custom-variant child (& > *)` se vuelve una barrera de reordenamiento porque mover una variant de
+estado a través de un combinador cambia qué elemento se selecciona.
+
 DS-opcional — cuando `settings.tailwindcss.entryPoint` está configurado, la regla usa la tabla de
-prioridad de variants del design system. Cuando no, cae a un orden estático built-in. Ambos
-fallbacks son determinísticos; esta es la única regla DS-dependiente que tolera silenciosamente un
-entry point faltante.
+prioridad de variants del design system y el comportamiento derivado de variants de arriba. Cuando
+no, cae a un orden estático built-in y la lista fija. Ambos caminos son determinísticos, y un entry
+point faltante se tolera silenciosamente (`no-contradicting-variants` es la otra regla que hace
+esto).
 
 ## Opciones
 
@@ -21,10 +28,10 @@ entry point faltante.
 
 `string[]`, opcional.
 
-Lista de prioridad custom. Los variants aparecen en el orden que listas; lo que no listas ordena
-después, en su posición original. Úsalo cuando tu team tiene un house style distinto al default de
-Tailwind (e.g. prefieres `dark:` outermost en toda cadena). El pin de pseudo-elements sigue
-aplicando sin importar dónde los pongas en tu lista.
+Lista de prioridad personalizada. Los variants aparecen en el orden que listas; lo que no listas
+ordena después, en su posición original. Úsalo cuando tu team tiene un house style distinto al
+default de Tailwind (e.g. prefieres `dark:` outermost en toda cadena). El pin de pseudo-elements
+sigue aplicando sin importar dónde los pongas en tu lista.
 
 ```jsonc
 {
@@ -87,7 +94,7 @@ proyecto; casi nunca se necesita.
 
 - **Confías en `prettier-plugin-tailwindcss` también para ordenar variants**: el formatter lo hace,
   la regla es redundante. Dejar ambas activadas es seguro pero es trabajo extra.
-- **Orden custom de variants que es difícil de expresar como una lista plana** (e.g. el orden
+- **Orden personalizado de variants que es difícil de expresar como una lista plana** (e.g. el orden
   depende de la utility): desactívala y confía en el review.
 - **Código generado** donde el orden de variants codifica un significado que no quieres que se
   reescriba.

--- a/packages/docs/es/rules/_extras/enforce-canonical.md
+++ b/packages/docs/es/rules/_extras/enforce-canonical.md
@@ -3,11 +3,12 @@
 Le pregunta al design system cuál es la forma canónica de cada utility en tu código y reescribe las
 que no lo son. "Canónico" es lo que devuelve `canonicalizeCandidates()` de `@tailwindcss/node` — la
 misma fuente de verdad que usan prettier-plugin-tailwindcss, oxfmt y las herramientas oficiales de
-Tailwind. Ejemplos: `-m-0` → `m-0` (no necesitas el negativo para un cero), `bg-gradient-to-r` →
-`bg-linear-to-r`, `break-words` → `wrap-break-word`, `start-2` → `inset-s-2`, `flex-grow-1` →
-`grow`, `flex-grow-[2]` → `grow-2` (un valor arbitrario cuya forma nombrada emite el mismo CSS),
+Tailwind. Ejemplos: `-m-0` → `m-0` (no necesitas el negativo para un cero), `start-2` → `inset-s-2`,
+`flex-grow-[2]` → `grow-2` (un valor arbitrario cuya forma nombrada emite el mismo CSS),
 `text-[var(--color-text)]/90` → `text-(--color-text)/90`. El auto-fix corrige el primer hit, las
-sugerencias cubren el resto en el mismo string.
+sugerencias cubren el resto en el mismo string. Los renombres de v3 (`bg-gradient-to-r` →
+`bg-linear-to-r`, `break-words` → `wrap-break-word`) son propiedad de `no-deprecated-classes`, no de
+esta regla — ver Interacciones.
 
 Las clases con nombre resuelven contra un `canonicalMap` precomputado en memoria (sub-microsegundo).
 Los valores arbitrarios (`p-[2px]`, `bg-(--c)`) pasan por el worker `canonicalize-service` porque
@@ -20,9 +21,9 @@ silencio.
 
 ## Opciones
 
-Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, defaultea
-a `settings.tailwindcss.entryPoint`). Configura el entry point en `settings.tailwindcss.entryPoint`
-para todo el proyecto en vez de por-regla cuando puedas.
+Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, por
+defecto es `settings.tailwindcss.entryPoint`). Configura el entry point en
+`settings.tailwindcss.entryPoint` para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Ejemplos
 
@@ -32,9 +33,6 @@ para todo el proyecto en vez de por-regla cuando puedas.
 // El negativo-de-cero es simplemente cero
 <div className="-m-0 -mt-0" />
 
-// Spellings v3 que el canonicalize oficial reescribe
-<div className="bg-gradient-to-r break-words" />
-
 // Shorthand de inset lógico → canónico inset-s-* / inset-e-*
 <div className="start-2 end-4" />
 
@@ -42,7 +40,7 @@ para todo el proyecto en vez de por-regla cuando puedas.
 <div className="flex-grow-[2]" />
 
 // Variants e important se preservan
-<div className="hover:!break-words" />
+<div className="hover:!flex-grow-[2]" />
 ```
 
 ### ✓ Correcto
@@ -50,13 +48,11 @@ para todo el proyecto en vez de por-regla cuando puedas.
 ```tsx
 <div className="m-0 mt-0" />
 
-<div className="bg-linear-to-r wrap-break-word" />
-
 <div className="inset-s-2 inset-e-4" />
 
 <div className="grow-2" />
 
-<div className="hover:!wrap-break-word" />
+<div className="hover:!grow-2" />
 ```
 
 ## Interacciones con otras reglas
@@ -76,7 +72,7 @@ para todo el proyecto en vez de por-regla cuando puedas.
   reportaba dos veces con el mismo fix; el mensaje de la otra regla ("deprecada en v4") es el más
   accionable de los dos. Acá queda todo lo que es actual-pero-no-canónico: `-m-0` → `m-0`, `start-2`
   → `inset-s-2`, y las formas con valor arbitrario como `flex-grow-[2]` → `grow-2` (la lista de
-  renombres tiene spellings, no valores). Mantén ambas activas — con solo esta los renombres quedan
+  renombres tiene grafías, no valores). Mantén ambas activas — con solo esta los renombres quedan
   sin reportar.
 - **`prefer-scale-token`**: la mitad solo-reporte de lo que esta regla cedió en #78. Una reescritura
   cuyo CSS emitido difiere textualmente (`p-[10px]` → `p-2.5`, donde el token llega por

--- a/packages/docs/es/rules/_extras/enforce-consistent-important-position.md
+++ b/packages/docs/es/rules/_extras/enforce-consistent-important-position.md
@@ -3,7 +3,7 @@
 Tailwind v4 soporta dos sintaxis para el modificador `!important`: prefijo (`!flex`, la forma de la
 era v3) y sufijo (`flex!`, la forma canónica de v4). Las dos producen el mismo CSS, pero mezclarlas
 dentro de un proyecto deja el codebase inconsistente y rompe el copy-paste entre archivos. Esta
-regla elige una posición y reescribe cada ofensor para que matchee. Autofix sobre el primer hit por
+regla elige una posición y reescribe cada ofensor para que coincida. Autofix sobre el primer hit por
 location, sugerencia de editor sobre los siguientes.
 
 DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. Es una transformación de string
@@ -15,17 +15,17 @@ pura, así que corre en todos lados, incluyendo proyectos que todavía no cablea
 
 `'prefix' | 'suffix'`, default `'suffix'`.
 
-`'suffix'` es la forma canónica de Tailwind v4 (`flex!`, `hover:text-red!`) y matchea lo que
-produciría `enforce-canonical`, así que es la elección recomendada para proyectos nuevos. `'prefix'`
-mantiene la forma de v3 (`!flex`, `hover:!text-red`) — elegila solo si tu codebase todavía está en
-el spelling de v3 y no quieres migrar todavía.
+`'suffix'` es la forma canónica de Tailwind v4 (`flex!`, `hover:text-red!`), así que es la elección
+recomendada para proyectos nuevos. `'prefix'` mantiene la forma de v3 (`!flex`, `hover:!text-red`) —
+elígela solo si tu codebase todavía está en la grafía de v3 y no quieres migrar todavía.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-important-position": ["error", { "position": "suffix" }] }
 ```
 
-Nota: setear `position: 'prefix'` va a entrar en conflicto con `enforce-canonical`, que normaliza a
-sufijo. Usa una o la otra.
+Nota: `enforce-canonical` preserva la posición del `!` que escribiste (no la normaliza), así que
+cualquier valor de `position` compone con él sin problemas. Esta regla es la única fuente de verdad
+para la posición del `!`.
 
 ## Ejemplos
 
@@ -59,9 +59,9 @@ sufijo. Usa una o la otra.
 
 ## Interacciones con otras reglas
 
-- **`enforce-canonical`**: con `position: 'suffix'` (el default) las dos reglas concuerdan. Con
-  `position: 'prefix'` se pelean — canonical reescribe a sufijo en cada pasada del fix. Quedate con
-  sufijo a menos que tengas una razón fuerte.
+- **`enforce-canonical`**: preserva la posición del `!` que escribiste (prefijo, sufijo o ninguno)
+  en vez de normalizarla, así que nunca se pelea con esta regla sin importar el `position` que
+  elijas. Esta regla es la única fuente de verdad para la posición del `!`.
 - **`enforce-sort-order`**: independiente de la posición del important. Tanto la forma prefijo como
   la sufijo ordenan igual.
 - **`no-unknown-classes`**: hace lookup de la utility bare, sacando `!` de cualquier lado, así que
@@ -71,5 +71,6 @@ sufijo. Usa una o la otra.
 
 - **El codebase mezcla las dos formas a propósito** (e.g. archivos legacy de v3 conviviendo con
   archivos frescos de v4 durante una migración). Reactívala cuando termine la migración.
-- **Ya estás corriendo `enforce-canonical`** y confías en que normalice la posición del `!` como
-  parte de la canonicalización — dejar esta regla activada es inocuo pero redundante.
+- **No te importa la consistencia de la posición del `!`.** Ninguna otra regla la impone —
+  `enforce-canonical` preserva la posición que hayas escrito — así que desactivar esta deja la
+  posición del `!` sin chequear.

--- a/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/_extras/enforce-consistent-line-wrapping.md
@@ -44,7 +44,7 @@ autofix es opt-in vía `wrapLines`.
 
 ### `wrapLines`
 
-`"overWidth" | "all"`, opcional. Sin default — igual que `classesPerLine`, dejarlo sin setear
+`"overWidth" | "all"`, opcional. Sin default — igual que `classesPerLine`, dejarlo sin establecer
 significa que el fixer está apagado y `printWidth` solo reporta.
 
 Activa el **autofix basado en el width** para template literals. Los dos modos difieren tanto en
@@ -76,7 +76,7 @@ regla, que mide cada fragmento estático por separado. Por eso una sola línea f
 mano con un fragmento corto junto a una interpolación ancha puede exceder `printWidth` sin ser
 reportada.
 
-`wrapLines` solo aplica cuando `classesPerLine` **no** está seteado — si no, `classesPerLine` es
+`wrapLines` solo aplica cuando `classesPerLine` **no** está establecido — si no, `classesPerLine` es
 dueño del layout.
 
 ```jsonc
@@ -123,9 +123,9 @@ Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un tem
 `classesPerLine` por línea. Dentro de string literals (`"…"`) la regla reporta `tooManyPerLine` pero
 no autofixea — los string literals no pueden cruzar líneas con seguridad sin intervención manual.
 
-Setear `classesPerLine` cambia el fixer de template literals a este modo por chunks y apaga el fixer
-basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta, y `wrapLines` se
-ignora.
+Establecer `classesPerLine` cambia el fixer de template literals a este modo por chunks y apaga el
+fixer basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta, y
+`wrapLines` se ignora.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }

--- a/packages/docs/es/rules/_extras/enforce-consistent-variable-syntax.md
+++ b/packages/docs/es/rules/_extras/enforce-consistent-variable-syntax.md
@@ -61,17 +61,27 @@ team prefiere la forma larga por grepability.
 
 ## Interacciones con otras reglas
 
-- **`enforce-canonical`**: no toca la sintaxis de variables. Canonical normaliza nombres de utility;
-  esta regla normaliza la forma de la variable. Las dos corren juntas sin problemas.
-- **`no-unnecessary-arbitrary-value`**: también apunta a valores arbitrarios pero para el caso del
-  equivalente nombrado (`bg-[#ff0000]` → `bg-red-500`). Disjunta de esta regla.
-- **`prefer-theme-tokens`**: cuando una variable CSS matchea un token `@theme`, esa regla swappea a
-  la utility nombrada (`bg-(--primary)` → `bg-primary` si `--primary` está declarado en `@theme`).
-  Ejecuta esa antes que esta si quieres las dos transformaciones.
+- **`enforce-canonical`**: esta regla es la única dueña de la sintaxis de variables. Como `bg-(--x)`
+  es la forma canónica de Tailwind, `enforce-canonical` reportaría el mismo swap `bg-[var(--x)]` →
+  `bg-(--x)`; en cambio, **cede** la conversión pura bracket↔paren a esta regla (igual que cede los
+  renombres de v3 a `no-deprecated-classes`). Eso evita un diagnóstico duplicado y, cuando esta
+  regla está en modo `explicit`, una pelea de autofix. `enforce-canonical` sigue manejando las
+  canonicalizaciones de variables que _no_ son un swap simple: un valor que mapea a un token
+  nombrado (`rounded-[var(--radius-sm)]` → `rounded-sm`) o una forma con modificador de opacidad
+  (`text-[var(--color-text)]/90` → `text-(--color-text)/90`).
+- **`no-unnecessary-arbitrary-value`**: en su mayoría disjunta — convierte un valor arbitrario a su
+  equivalente nombrado (`bg-[#ff0000]` → `bg-red-500`). Solo se solapan cuando el valor de una
+  variable coincide con una utility nombrada: sobre `bg-[var(--color-red-500)]` esa regla dispara (→
+  `bg-red-500`) y esta también (→ `bg-(--color-red-500)`). Proponen destinos distintos, así que
+  activa la que refleje tu política — o ejecuta `no-unnecessary-arbitrary-value` primero si
+  prefieres la utility nombrada.
+- **`prefer-theme-tokens`**: cuando una variable CSS coincide con un token `@theme`, esa regla
+  cambia a la utility nombrada (`bg-(--primary)` → `bg-primary` si `--primary` está declarado en
+  `@theme`). Ejecuta esa antes que esta si quieres las dos transformaciones.
 
 ## Cuándo desactivarla
 
-- **Apuntas a tooling más viejo que Tailwind v4**: la forma shorthand no está soportada. Seteá
+- **Apuntas a tooling más viejo que Tailwind v4**: la forma shorthand no está soportada. Configura
   `syntax: 'explicit'` en vez de desactivarla, así obtienes el rewrite en la dirección segura.
 - **Codebase con sintaxis mixta en plena migración** donde la consistencia todavía no es el
   objetivo.

--- a/packages/docs/es/rules/_extras/enforce-logical.md
+++ b/packages/docs/es/rules/_extras/enforce-logical.md
@@ -40,9 +40,9 @@ block.
 `string[]`, default `[]`.
 
 Patrones regex (compilados lazy, los inválidos se saltean en silencio). Las clases cuyo string
-completo matchee algún patrón bypassean el rewrite. Úsalo para casos puntuales donde genuinamente
-quieres dirección física — e.g. un ícono que siempre tiene que estar a la izquierda visual sin
-importar el writing direction.
+completo coincida con algún patrón bypassean el rewrite. Úsalo para casos puntuales donde
+genuinamente quieres dirección física — e.g. un ícono que siempre tiene que estar a la izquierda
+visual sin importar el writing direction.
 
 ```jsonc
 { "tailwindcss/enforce-logical": ["error", { "allowlist": ["^ml-icon$", "^rounded-tl-special$"] }] }
@@ -94,9 +94,9 @@ regla funciona sin él.
   va a autofixear en loop. Elige una según si tu app soporta RTL (usa `enforce-logical`) o es
   LTR-only (usa `enforce-physical`).
 - **`enforce-canonical`**: tiene opinión sobre los insets lógicos. Esta regla sugiere `start-2` (lo
-  que usan los docs de Tailwind); el design system reporta `inset-s-2` como el spelling canónico,
-  así que con las dos activas terminas ahí en dos pasadas. El CSS es el mismo en ambos casos, y
-  `enforce-physical` convierte los dos spellings de vuelta.
+  que usan los docs de Tailwind); el design system reporta `inset-s-2` como la grafía canónica, así
+  que con las dos activas terminas ahí en dos pasadas. El CSS es el mismo en ambos casos, y
+  `enforce-physical` convierte las dos grafías de vuelta.
 - **`enforce-shorthand`**: corre sobre shorthands `m-*` / `p-*` que ya son direction-neutral, así
   que las dos no se solapan.
 

--- a/packages/docs/es/rules/_extras/enforce-negative-arbitrary-values.md
+++ b/packages/docs/es/rules/_extras/enforce-negative-arbitrary-values.md
@@ -3,7 +3,7 @@
 Detecta utilities escritas con un prefijo negativo afuera de un bracket de valor arbitrario —
 `-top-[5px]`, `-translate-x-[10px]`, `-mt-[8px]` — y mueve el signo negativo adentro del bracket:
 `top-[-5px]`, `translate-x-[-10px]`, `mt-[-8px]`. El `-` exterior es redundante una vez que tienes
-un valor arbitrario, y meterlo adentro hace explícita la intención y matchea cómo
+un valor arbitrario, y meterlo adentro hace explícita la intención y coincide con cómo
 `@tailwindcss/node` canonicaliza la misma shape. El auto-fix corrige el primer hit, las sugerencias
 cubren el resto en el mismo string. Los variants (`hover:-mt-[8px]`) y el `!` (important, prefix o
 suffix) se preservan.

--- a/packages/docs/es/rules/_extras/enforce-physical.md
+++ b/packages/docs/es/rules/_extras/enforce-physical.md
@@ -41,8 +41,8 @@ eje block.
 `string[]`, default `[]`.
 
 Patrones regex (compilados lazy, los inválidos se saltean en silencio). Las clases cuyo string
-completo matchee algún patrón bypassean el rewrite. Útil cuando una utility lógica específica es
-intencional incluso en un codebase mayormente-LTR (e.g. un componente que sí tiene que soportar
+completo coincida con algún patrón bypassean el rewrite. Útil cuando una utility lógica específica
+es intencional incluso en un codebase mayormente-LTR (e.g. un componente que sí tiene que soportar
 RTL).
 
 ```jsonc

--- a/packages/docs/es/rules/_extras/enforce-shorthand.md
+++ b/packages/docs/es/rules/_extras/enforce-shorthand.md
@@ -17,10 +17,10 @@ Un diagnóstico por grupo colapsable: los cuatro lados reportan `m-2` una vez, n
 mitades `my-2`/`mx-2`.
 
 `scale-x-*`+`scale-y-*` deliberadamente **no** es una familia. `scale-110` además escribe
-`--tw-scale-z`, que `scale-3d` lee, así que mergear cambiaría cómo renderiza
+`--tw-scale-z`, que `scale-3d` lee, así que fusionar cambiaría cómo renderiza
 `scale-x-110 scale-y-110 scale-3d`.
 
-### Con un `entryPoint`, el merge se comprueba contra el CSS
+### Con un `entryPoint`, la fusión se comprueba contra el CSS
 
 Tailwind v4 tiene namespaces de tema por eje: `w-*` lee `--width-*` (y `--container-*`), `h-*` lee
 `--height-*`, `size-*` lee `--size-*`. Con este tema
@@ -35,15 +35,15 @@ Tailwind v4 tiene namespaces de tema por eje: `w-*` lee `--width-*` (y `--contai
 `w-brand h-brand` → `size-brand` es destructivo: `size-brand` no existe, y el elemento pierde el
 ancho y el alto. Si configuras `settings.tailwindcss.entryPoint` (o el `entryPoint` propio de la
 regla), la regla compara las declaraciones que Tailwind emite — las partes tienen que resolver al
-mismo valor y el reemplazo tiene que reproducirlo — así que ese merge no se ofrece.
+mismo valor y el reemplazo tiene que reproducirlo — así que esa fusión no se ofrece.
 
-Los tokens de tema con nombre en la familia de sizing solo se mergean cuando los valores son
+Los tokens de tema con nombre en la familia de sizing solo se fusionan cuando los valores son
 literalmente idénticos. `w-card h-card` se deja como está incluso si los tres namespaces definen
 `card` como `30rem`, porque cada lado lee una variable distinta y un override en `:root` de una de
 ellas las separa — el mismo razonamiento que [`enforce-canonical`](./enforce-canonical) aplica a
 `rounded-[0.5rem]` → `rounded-lg`.
 
-Sin entry point la regla mantiene los merges que son seguros diga lo que diga el tema: números y
+Sin entry point la regla mantiene las fusiones que son seguras diga lo que diga el tema: números y
 fracciones (la escala de spacing compartida), valores arbitrarios (el mismo literal a los dos
 lados), las keywords del core (`full`, `auto`, `min`, `max`, `fit`, `px` y las unidades de
 viewport), y todas las familias que no son sizing — esas beben de un único namespace.
@@ -53,7 +53,7 @@ viewport), y todas las familias que no son sizing — esas beben de un único na
 ### `entryPoint`
 
 `string`, opcional. Un entry point CSS solo para esta regla, que pisa
-`settings.tailwindcss.entryPoint`. Se usa únicamente para verificar los merges contra el CSS
+`settings.tailwindcss.entryPoint`. Se usa únicamente para verificar las fusiones contra el CSS
 emitido; la regla funciona sin él.
 
 ## Ejemplos
@@ -112,7 +112,7 @@ emitido; la regla funciona sin él.
 // Dos lados adyacentes no son un eje
 <div className="top-0 right-0" />
 
-// Variants distintas — la regla no mergea cruzando cadenas de variants
+// Variants distintas — la regla no fusiona cruzando cadenas de variants
 <div className="hover:mt-2 focus:mb-2" />
 ```
 
@@ -126,7 +126,7 @@ emitido; la regla funciona sin él.
   `border-s-*`+`border-e-*` → `border-x-*`, `start-*`+`end-*` → `inset-x-*`) caen en utilities de
   eje que ninguna regla direccional convierte, así que las dos nunca se pelean.
 - **`enforce-consistent-important-position`**: el shorthand respeta la convención de posición del
-  `!` de las clases mergeadas. Si las cuatro usan prefijo, el shorthand queda con prefijo; lo mismo
+  `!` de las clases fusionadas. Si las cuatro usan prefijo, el shorthand queda con prefijo; lo mismo
   para sufijo.
 
 ## Cuándo desactivarla

--- a/packages/docs/es/rules/_extras/enforce-sort-order.md
+++ b/packages/docs/es/rules/_extras/enforce-sort-order.md
@@ -1,8 +1,9 @@
 ## Qué hace esta regla
 
-Ordena cada string de clases Tailwind en tu código para que matchee el orden oficial de Tailwind —
-el mismo orden que Tailwind usa al generar CSS, y el mismo que aplican `prettier-plugin-tailwindcss`
-y `oxfmt`. La regla tiene autofix: correr `oxlint --fix` reescribe el string in-place.
+Ordena cada string de clases Tailwind en tu código para que coincida con el orden oficial de
+Tailwind — el mismo orden que Tailwind usa al generar CSS, y el mismo que aplican
+`prettier-plugin-tailwindcss` y `oxfmt`. La regla tiene autofix: correr `oxlint --fix` reescribe el
+string in-place.
 
 DS-dependiente — requiere `settings.tailwindcss.entryPoint`. El sort exacto lo computa la API de
 class-order de `@tailwindcss/node` contra tu stylesheet, así que tokens de theme, plugins y
@@ -39,8 +40,8 @@ la que está construido el modo — `'default'` le pide al worker la respuesta r
 `string`, opcional.
 
 Override por regla de `settings.tailwindcss.entryPoint`. Útil en el caso raro donde esta regla
-necesita leer un stylesheet distinto al del resto del plugin (e.g. aplicas scope a el sort a una
-sub-app). Casi nadie lo necesita — define el entry point una vez en `settings` y olvídate.
+necesita leer un stylesheet distinto al del resto del plugin (e.g. acotas el sort a una sub-app).
+Casi nadie lo necesita — define el entry point una vez en `settings` y olvídate.
 
 ## Ejemplos
 
@@ -92,8 +93,8 @@ sub-app). Casi nadie lo necesita — define el entry point una vez en `settings`
   rule budget reducido — el formatter ya hace este trabajo byte-por-byte. Dejar ambas activadas está
   bien (no hay conflictos), es solo trabajo redundante.
 - **Trabajando en un codebase que ordena clases a propósito por intent de autoría** (e.g.
-  agrupamiento visual que no matchea la prioridad de Tailwind). Desactívala localmente en vez de
-  globalmente si es una preferencia por componente.
+  agrupamiento visual que no coincide con la prioridad de Tailwind). Desactívala localmente en vez
+  de globalmente si es una preferencia por componente.
 
 > **Caveat de `tailwind-merge`.** `tailwind-merge` resuelve un grupo de conflicto conservando la
 > _última_ aparición en el string. Si un mismo string de clases contiene dos clases del mismo grupo

--- a/packages/docs/es/rules/_extras/max-class-count.md
+++ b/packages/docs/es/rules/_extras/max-class-count.md
@@ -12,7 +12,7 @@ reconstruidos por `enforce-consistent-line-wrapping` se cuentan como el set de c
 por líneas visuales.
 
 DS-independiente — no necesita `entryPoint`. Sin autofix: extraer un componente requiere criterio
-que la regla no puede tomar por tú.
+que la regla no puede tomar por ti.
 
 ## Opciones
 
@@ -22,7 +22,7 @@ que la regla no puede tomar por tú.
 
 El máximo de clases permitidas en un solo elemento / llamada. La regla reporta cuando
 `classes.length > max` (es decir, el límite es inclusivo: `max: 20` permite _exactamente_ 20).
-Ajustalo al umbral de tu equipo para "esto ya es un componente".
+Ajústalo al umbral de tu equipo para "esto ya es un componente".
 
 ```jsonc
 { "tailwindcss/max-class-count": ["warn", { "max": 15 }] }
@@ -74,7 +74,7 @@ cn("flex items-center", "p-4 m-2 gap-2")
 ## Interacciones con otras reglas
 
 - **`no-duplicate-classes`**: si una clase está repetida, ambas reglas ven el conteo inflado.
-  Arreglá el duplicado primero — el conteo baja y esta regla puede dejar de disparar sola.
+  Arregla el duplicado primero — el conteo baja y esta regla puede dejar de disparar sola.
 - **`enforce-sort-order`** / **`enforce-consistent-line-wrapping`**: primas cosméticas. El contador
   es insensible al whitespace, así que el line-wrapping no cambia el veredicto.
 - **`enforce-canonical`**: colapsa pares redundantes (`-m-0` → `m-0`) antes de que esta regla corra,

--- a/packages/docs/es/rules/_extras/no-arbitrary-value.md
+++ b/packages/docs/es/rules/_extras/no-arbitrary-value.md
@@ -90,8 +90,8 @@ legítimos a `allow` en vez de desactivar la regla entera.
   nombrado exacto (`w-[100%]` → `w-full`). Pueden coexistir: la suave autofixea los casos triviales
   y esta atrapa lo que queda.
 - **`prefer-theme-tokens`**: misma intención, pero DS-dependiente. `prefer-theme-tokens` consulta tu
-  `@theme` y sugiere el token que matchea. Combínalas: esta regla es tu freno de mano cuando todavía
-  no existe el token.
+  `@theme` y sugiere el token que coincide. Combínalas: esta regla es tu freno de mano cuando
+  todavía no existe el token.
 - **`enforce-consistent-variable-syntax`**: convierte entre `bg-[var(--x)]` y `bg-(--x)`. Como las
   dos formas se reportan acá, correrla — en cualquier dirección — no puede sacar una clase del
   alcance de esta regla.
@@ -99,7 +99,7 @@ legítimos a `allow` en vez de desactivar la regla entera.
 ## Cuándo desactivarla
 
 - **Prototipos / branches de spike** donde la velocidad le gana a la disciplina. Reactívala antes de
-  mergear.
+  integrar.
 - **Archivos que genuinamente necesitan un arbitrary value** (landing pages one-off, shims de
   CSS-in-JS dinámico). Prefiere `allow` con una lista corta de prefijos, o desactiva por línea con
   `// oxlint-disable-next-line tailwindcss/no-arbitrary-value`.

--- a/packages/docs/es/rules/_extras/no-conflicting-classes.md
+++ b/packages/docs/es/rules/_extras/no-conflicting-classes.md
@@ -12,14 +12,14 @@ tratado a mano:
 - **el mismo valor en ambos lados** — `mask-b-from-50% mask-b-from-black` comparten cuatro
   declaraciones byte a byte idénticas, así que gane quien gane el resultado es el mismo;
 - **un reenviador `var()` y la clase que suministra la variable** — `outline-2` declara
-  `outline-style: var(--tw-outline-style)` y no aporta valor propio; el match es por el nombre real
-  de la variable, así que el `--scrollbar-*` de un plugin se comporta igual que el `--tw-*` de
-  Tailwind;
+  `outline-style: var(--tw-outline-style)` y no aporta valor propio; la coincidencia es por el
+  nombre real de la variable, así que el `--scrollbar-*` de un plugin se comporta igual que el
+  `--tw-*` de Tailwind;
 - **una ganadora que sigue arrastrando a la perdedora** — `drop-shadow-indigo-500` lee el
   `--tw-drop-shadow-size` que escribe `drop-shadow-xl`, y la cadena se sigue transitivamente (así
   compone `from-*` / `via-*` / `to-*`);
-- **una custom property reseteada a `initial`** — `animate-in` inicializa cada `--tw-enter-*` para
-  que sus modificadores la sobrescriban;
+- **una custom property restablecida a `initial`** — `animate-in` inicializa cada `--tw-enter-*`
+  para que sus modificadores la sobrescriban;
 - **declaraciones en cajas distintas** — `placeholder-*` estila `::placeholder`, `space-x-*` estila
   los hijos, y ninguna estila el elemento.
 
@@ -41,11 +41,11 @@ pasar en silencio.
 
 ## Opciones
 
-| Opción            | Tipo                             | Por defecto | Descripción                                                                                                                                                                                                                                                 |
-| ----------------- | -------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `reportRedundant` | `boolean`                        | `true`      | Reporta como `redundant` dos clases que declaran la misma propiedad con el mismo valor.                                                                                                                                                                     |
-| `allow`           | `(string \| [string, string])[]` | `[]`        | Patrones a silenciar, comparados con la clase **tal como está escrita** (prefijo de variante y `!` incluidos). Uno simple silencia cualquier par que involucre una clase que haga match; uno de dos elementos silencia esa combinación, en cualquier orden. |
-| `entryPoint`      | `string`                         | —           | Override por regla de `settings.tailwindcss.entryPoint`.                                                                                                                                                                                                    |
+| Opción            | Tipo                             | Por defecto | Descripción                                                                                                                                                                                                                                               |
+| ----------------- | -------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `reportRedundant` | `boolean`                        | `true`      | Reporta como `redundant` dos clases que declaran la misma propiedad con el mismo valor.                                                                                                                                                                   |
+| `allow`           | `(string \| [string, string])[]` | `[]`        | Patrones a silenciar, comparados con la clase **tal como está escrita** (prefijo de variante y `!` incluidos). Uno simple silencia cualquier par que involucre una clase que coincida; uno de dos elementos silencia esa combinación, en cualquier orden. |
+| `entryPoint`      | `string`                         | —           | Override por regla de `settings.tailwindcss.entryPoint`.                                                                                                                                                                                                  |
 
 ```jsonc
 {

--- a/packages/docs/es/rules/_extras/no-contradicting-variants.md
+++ b/packages/docs/es/rules/_extras/no-contradicting-variants.md
@@ -19,8 +19,8 @@ system genera de verdad para cada variante, así que cubre variantes que define 
 ninguna lista de nombres podría saber. Sin entry point la regla usa los nombres de arriba y se
 comporta igual que antes — nunca reporta que falte el design system.
 
-El match es por identidad exacta de la utility, así que `bg-white hover:bg-blue-500` queda intacto
-(valores distintos), igual que `flex hover:items-center` (utilities distintas).
+La coincidencia es por identidad exacta de la utility, así que `bg-white hover:bg-blue-500` queda
+intacto (valores distintos), igual que `flex hover:items-center` (utilities distintas).
 
 "La base aplica sin condiciones" sólo se sostiene cuando nada más pisa su propiedad. Una clase
 responsive que restablece una propiedad que un breakpoint intermedio le quitó es **load-bearing**,
@@ -96,7 +96,7 @@ es la lista de clases **final y autocontenida** del elemento. En una composició
 `tailwind-merge` — el patrón `cn`/`twMerge` + `cva` que usan los codebases estilo shadcn — un
 `className` suele ser un **fragmento de override** que se fusiona en runtime con clases aportadas en
 otro lado, muchas veces en otro módulo. Ahí la variante suele ser **load-bearing**: existe para
-ganarle a una clase del mismo grupo que el componente mergea desde su propio `cva`.
+ganarle a una clase del mismo grupo que el componente fusiona desde su propio `cva`.
 
 Toma `<Button className="bg-transparent hover:bg-transparent" />`, donde `Button` hace
 `twMerge(buttonVariants(), className)` y `buttonVariants()` aporta `hover:bg-accent`.
@@ -113,8 +113,8 @@ string que puede asegurar que es la lista final: un literal (o template) usado d
 que sean:
 
 - argumentos de una llamada merge-aware — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
-- el `className`/`class` de un **componente custom** (`<Button …>`, `<Field.Root …>`), que es opaco
-  — el componente puede volver a fusionarlo internamente;
+- el `className`/`class` de un **componente personalizado** (`<Button …>`, `<Field.Root …>`), que es
+  opaco — el componente puede volver a fusionarlo internamente;
 - asignados a una variable, o emitidos desde un tagged template.
 
 El trade-off es deliberado: acepta algunos falsos negativos (un par genuinamente redundante
@@ -125,5 +125,5 @@ como obviamente correctos e invitan a una regresión de render.
 
 - **Generadores de código / class-name builders** en un elemento nativo que a propósito emiten una
   base y una variante con la misma utility. (Los fragmentos de override que pasan por `cn`/`twMerge`
-  o por un componente custom ya se omiten — mira la sección de arriba.)
+  o por un componente personalizado ya se omiten — mira la sección de arriba.)
 - **Snapshots / fixtures** que necesitan el par redundante para ejercitar tooling downstream.

--- a/packages/docs/es/rules/_extras/no-dark-without-light.md
+++ b/packages/docs/es/rules/_extras/no-dark-without-light.md
@@ -21,15 +21,16 @@ Una clase cuenta como base de dos maneras:
   `visible dark:invisible`, `uppercase dark:normal-case`, `truncate dark:text-clip` y
   `sr-only dark:not-sr-only`, que antes se reportaban todos.
 
-El chequeo por propiedad es **aditivo**: todo lo que ya matcheaba por prefijo sigue matcheando, así
-que configurar un entry point solo puede hacer que esta regla reporte menos, nunca más. Sin él cae
-al chequeo por prefijo más una tabla interna pequeña para `display` y `position` (para que
+El chequeo por propiedad es **aditivo**: todo lo que ya coincidía por prefijo sigue coincidiendo,
+así que configurar un entry point solo puede hacer que esta regla reporte menos, nunca más. Sin él
+cae al chequeo por prefijo más una tabla interna pequeña para `display` y `position` (para que
 `block dark:hidden` funcione), y por eso los pares de arriba siguen reportándose cuando no hay CSS
 configurado.
 
 El conjunto de "variantes observadas" es configurable. Por defecto es sólo `dark`, pero el mismo
 shape aplica a cualquier otra variante estilo scheme (`contrast-more`, `motion-reduce`, `print`,
-variantes custom de data-attribute que tengas registradas, etc.) — mira la opción `variants` abajo.
+variantes personalizadas de data-attribute que tengas registradas, etc.) — mira la opción `variants`
+abajo.
 
 ## Opciones
 
@@ -39,13 +40,13 @@ variantes custom de data-attribute que tengas registradas, etc.) — mira la opc
 
 Lista de variantes que requieren una base sin variante en el mismo prefijo de utility.
 Sobreescríbelo cuando tu app usa otro mecanismo para cambiar de theme (e.g. `contrast-more:` para un
-tema de alto contraste, o una variante custom `theme-foo:` definida en tu CSS).
+tema de alto contraste, o una variante personalizada `theme-foo:` definida en tu CSS).
 
 ```jsonc
 { "tailwindcss/no-dark-without-light": ["error", { "variants": ["dark", "contrast-more"] }] }
 ```
 
-Si seteas `variants` a un array vacío la regla se convierte en un no-op — prefiere desactivarla
+Si estableces `variants` a un array vacío la regla se convierte en un no-op — prefiere desactivarla
 directamente en ese caso.
 
 ### `entryPoint`
@@ -83,13 +84,13 @@ la regla funciona sin él.
 // No hay variante observada → la regla no se mete con la cobertura de base
 <div className="hover:bg-blue-500" />
 
-// Variante custom + base correspondiente
+// Variante personalizada + base correspondiente
 <div
   className="bg-white contrast-more:bg-black"
   // con options: [{ variants: ["contrast-more"] }]
 />
 
-// Un string sólo-dark dentro de un helper de merge o en un componente custom es
+// Un string sólo-dark dentro de un helper de merge o en un componente personalizado es
 // un fragmento de override — la base light vive en otro lado, así que NO se
 // reporta. Mira "Composición y helpers de merge" abajo.
 cn("dark:bg-gray-900")
@@ -125,8 +126,8 @@ la lista final: un literal (o template) usado directamente como `class`/`classNa
 host nativo** (`<div>`, `<input>`, …). **No** reporta strings que sean:
 
 - argumentos de una llamada merge-aware — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
-- el `className`/`class` de un **componente custom** (`<Field …>`, `<Card.Body …>`), que es opaco —
-  el componente puede volver a fusionarlo internamente;
+- el `className`/`class` de un **componente personalizado** (`<Field …>`, `<Card.Body …>`), que es
+  opaco — el componente puede volver a fusionarlo internamente;
 - asignados a una variable, o emitidos desde un tagged template.
 
 El trade-off es deliberado: acepta algunos falsos negativos (una clase genuinamente sólo-dark
@@ -140,4 +141,4 @@ como obviamente correctos e invitan a una regresión de render.
   sacar `dark`) antes que desactivarla.
 - **Strings de clases servidas desde el server** en un elemento nativo donde la base vive en CSS y
   sólo el override dark se emite desde JS. (Los fragmentos de override que pasan por `cn`/`twMerge`
-  o por un componente custom ya se omiten — mira la sección de arriba.)
+  o por un componente personalizado ya se omiten — mira la sección de arriba.)

--- a/packages/docs/es/rules/_extras/no-deprecated-classes.md
+++ b/packages/docs/es/rules/_extras/no-deprecated-classes.md
@@ -10,9 +10,9 @@ preservan en ambos lados de la reescritura.
 
 Con `settings.tailwindcss.entryPoint` (o el `entryPoint` propio de la regla) configurado, la lista
 se **deriva de tu design system**: se le pregunta al `canonicalizeCandidates` de Tailwind a qué
-mapea cada spelling de v3, y solo se reportan los que todavía compila Y todavía renombra. Eso cubre
+mapea cada grafía de v3, y solo se reportan los que todavía compila Y todavía renombra. Eso cubre
 renombres que una tabla hardcodeada no tenía — `break-words` → `wrap-break-word`, `order-none` →
-`order-0`, los spellings de posición reordenados `bg-left-top` → `bg-top-left` y `object-left-top` →
+`order-0`, las grafías de posición reordenadas `bg-left-top` → `bg-top-left` y `object-left-top` →
 `object-top-left` — y, más importante, una entrada desaparece sola cuando un Tailwind futuro deje de
 compilarla, en vez de sugerir un reemplazo para una clase que ya no existe.
 
@@ -49,7 +49,7 @@ sigue funcionando sin nada configurado y nunca emite un diagnóstico `designSyst
 ### ✓ Correcto
 
 ```tsx
-// Spellings post-migración
+// Grafías post-migración
 <div className="grow shrink-0" />
 
 <div className="bg-linear-to-r from-blue-500 to-purple-500" />
@@ -62,7 +62,7 @@ sigue funcionando sin nada configurado y nunca emite un diagnóstico `designSyst
 
 ## Interacciones con otras reglas
 
-- **`no-unknown-classes`**: omite silenciosamente cualquier spelling renombrado, preguntándole al
+- **`no-unknown-classes`**: omite silenciosamente cualquier grafía renombrada, preguntándole al
   design system en vez de a una lista propia, así que las dos reglas no pueden discrepar. No vas a
   recibir "unknown class" más "deprecated class" para `flex-grow` — solo la deprecación. Mantén
   ambas activas.
@@ -71,14 +71,14 @@ sigue funcionando sin nada configurado y nunca emite un diagnóstico `designSyst
   canonicalización), así que antes las dos reglas reportaban la misma clase con el mismo fix.
   `enforce-canonical` ahora se calla con todo lo que esté en la lista de renombres y mantiene el
   resto: formas válidas-pero-no-canónicas como `-m-0` → `m-0` y `start-2` → `inset-s-2` (`start-*`
-  es Tailwind actual, solo que no es el spelling canónico). Mantén ambas activas — con solo
+  es Tailwind actual, solo que no es la grafía canónica). Mantén ambas activas — con solo
   `enforce-canonical` los renombres quedan sin reportar.
 - **`no-restricted-classes`**: ortogonal. Esa la usas para bloquear clases válidas; esta solo se
-  dispara con la lista fija de renames v3→v4.
+  dispara con la lista fija de renombres v3→v4.
 
 ## Cuándo desactivarla
 
-- **Sigues en Tailwind v3** y quieres mantener los spellings de v3. Desactiva esta regla hasta que
+- **Sigues en Tailwind v3** y quieres mantener las grafías de v3. Desactiva esta regla hasta que
   migres.
 - **Mantienes a propósito una capa de clases v3-compatibles** al lado de v4 (por ejemplo, una
   librería compartida que apunta a ambos). En ese caso prefiere un `eslint-disable` puntual en el

--- a/packages/docs/es/rules/_extras/no-duplicate-classes.md
+++ b/packages/docs/es/rules/_extras/no-duplicate-classes.md
@@ -12,9 +12,9 @@ territorio de `no-contradicting-variants`). El fix preserva el whitespace que in
 La regla recorre la misma superficie de extracción que cualquier otra: atributos `className` /
 `class`, los 14 callees por defecto (`cn`, `clsx`, `cva`, `twMerge`, `tv`, `cx`, `classnames`,
 `ctl`, `twJoin`, `cc`, `clb`, `cnb`, `objstr`, `classed`), tagged templates como `` tw`...` ``,
-valores objeto en JSX (`classNames={ { root: "..." } }`) y variables que matchean los patrones de
-nombre por defecto (`className`, `classNames`, `classes`, `style`, `styles`). La extracción profunda
-para `cva` / `tv` / `classed` cubre `base`, `slots`, `variants`, `compoundVariants` y
+valores objeto en JSX (`classNames={ { root: "..." } }`) y variables que coinciden con los patrones
+de nombre por defecto (`className`, `classNames`, `classes`, `style`, `styles`). La extracción
+profunda para `cva` / `tv` / `classed` cubre `base`, `slots`, `variants`, `compoundVariants` y
 `compoundSlots`.
 
 ## Opciones

--- a/packages/docs/es/rules/_extras/no-hardcoded-colors.md
+++ b/packages/docs/es/rules/_extras/no-hardcoded-colors.md
@@ -6,14 +6,14 @@ que escribirías con un paint chip en la mano: hex (`bg-[#ff5733]`, `text-[#000]
 `hwb()`, y `color()`. La intención es la misma que `no-arbitrary-value` pero acotada exclusivamente
 al color, que es donde suele empezar el drift del design system.
 
-El valor se **escanea**, no se matchea desde su primer carácter, y la utility de la que cuelga es
+El valor se **escanea**, no se compara desde su primer carácter, y la utility de la que cuelga es
 irrelevante. Eso importa más de lo que parece:
 
 - un color en medio de un shorthand cuenta — `shadow-[0_1px_2px_#000]` es un negro hardcodeado;
 - también las utilities que ninguna lista de prefijos mantuvo al día — `inset-ring-[#000]`,
   `inset-shadow-[#000]`;
-- y también las propiedades arbitrarias, que ningún prefijo podría matchear — `[color:#f00]`,
-  `[--brand:#f00]`.
+- y también las propiedades arbitrarias, con las que ningún prefijo podría coincidir —
+  `[color:#f00]`, `[--brand:#f00]`.
 
 Hay dos exclusiones deliberadas, y son la razón de que esto sea un escáner y no un regex: un `#`
 dentro de un **string entre comillas** es texto (`content-['#fff']`), y un `#` dentro de **`url()`**
@@ -40,9 +40,9 @@ decisión humana.
 
 `string[]`, default `[]`.
 
-Strings exactos de clases para whitelistear. Los matches son literales (no hay prefix match ni
-regex), así que puedes permitir escapes puntuales sin abrir más la puerta. Útil para el hex
-ocasional mandado por brand en un único componente de assets.
+Strings exactos de clases para incluir en la allowlist. Las coincidencias son literales (no hay
+coincidencia por prefijo ni regex), así que puedes permitir escapes puntuales sin abrir más la
+puerta. Útil para el hex ocasional mandado por brand en un único componente de assets.
 
 ```jsonc
 {
@@ -105,7 +105,7 @@ ocasional mandado por brand en un único componente de assets.
   Usa `no-hardcoded-colors` sola cuando quieres el mensaje específico de color y toleras otros
   arbitrary values; usa ambas para un diagnóstico más claro sobre el drift de color.
 - **`prefer-theme-tokens`**: complementaria. `prefer-theme-tokens` le pregunta al design system si
-  existe un color `@theme` que matchee y lo sugiere; esta regla dispara igual exista o no el token,
+  existe un color `@theme` que coincida y lo sugiere; esta regla dispara igual exista o no el token,
   así que atrapa el drift más temprano (antes de definir el token).
 - **`no-unknown-classes`**: ortogonal. Los arbitrary hardcodeados son sintaxis _válida_ de Tailwind,
   así que `no-unknown-classes` no los va a marcar. Deberían estar ambas activas.

--- a/packages/docs/es/rules/_extras/no-restricted-classes.md
+++ b/packages/docs/es/rules/_extras/no-restricted-classes.md
@@ -2,7 +2,7 @@
 
 El veto manual. Te deja bloquear clases específicas de Tailwind — por nombre exacto o por patrón
 regex — y mostrar un mensaje configurable explicando por qué. Sin design system, sin heurísticas: si
-la clase matchea, la regla dispara.
+la clase coincide, la regla dispara.
 
 Usos típicos: dejar atrás utilities legacy que un refactor quiere sacar (`float-*` en codebases
 solo-flexbox), mantener un color de brand deprecado fuera del código nuevo, prohibir hacks de
@@ -20,9 +20,10 @@ Sin opciones, la regla es no-op. Configura al menos una de `classes` o `patterns
 
 `string[]`, default `[]`.
 
-Nombres exactos de clases a prohibir. Los matches son literales — `"hidden"` matchea la clase bare
-`hidden` y la misma clase en cualquier parte de un class string (`"flex hidden items-center"`), pero
-_no_ matchea `"sr-hidden"` ni `"hover:hidden"`. Úsalo para una ban list chica y explícita.
+Nombres exactos de clases a prohibir. Las coincidencias son literales — `"hidden"` coincide con la
+clase bare `hidden` y la misma clase en cualquier parte de un class string
+(`"flex hidden items-center"`), pero _no_ coincide con `"sr-hidden"` ni `"hover:hidden"`. Úsalo para
+una ban list chica y explícita.
 
 ```jsonc
 {
@@ -39,8 +40,8 @@ _no_ matchea `"sr-hidden"` ni `"hover:hidden"`. Úsalo para una ban list chica y
 Una lista de patrones regex (pasados como strings, compilados con `new RegExp`) con un mensaje
 opcional. Úsalo cuando quieres prohibir una familia entera (`^float-`, `^text-(red|orange)-`) o
 cuando una lista literal explotaría. Los patrones se testean contra la clase completa incluyendo
-variants, así que `^hover:bg-red-` matchea `hover:bg-red-500`. Los mensajes custom aparecen después
-del nombre de la clase y hacen que el diagnóstico sea accionable.
+variants, así que `^hover:bg-red-` coincide con `hover:bg-red-500`. Los mensajes personalizados
+aparecen después del nombre de la clase y hacen que el diagnóstico sea accionable.
 
 ```jsonc
 {
@@ -53,8 +54,8 @@ del nombre de la clase y hacen que el diagnóstico sea accionable.
 }
 ```
 
-Si una clase matchea tanto `classes` como un pattern, gana el match exacto y la regla reporta una
-sola vez. Si no, gana el primer pattern que matchea.
+Si una clase coincide tanto con `classes` como con un pattern, gana la coincidencia exacta y la
+regla reporta una sola vez. Si no, gana el primer pattern que coincide.
 
 ## Ejemplos
 
@@ -68,7 +69,7 @@ sola vez. Si no, gana el primer pattern que matchea.
 // Prohibida en el medio de un class string
 <div className="flex hidden items-center" />
 
-// Prohibida vía pattern con mensaje custom
+// Prohibida vía pattern con mensaje personalizado
 <div className="float-left" />
 // con patterns: [{ pattern: "^float-", message: "Usa flexbox" }]
 // → '"float-left" is restricted: Usa flexbox'
@@ -86,7 +87,7 @@ cn("float-right")
 // Clase fuera de la ban list
 <div className="flex items-center" />
 
-// El variant cambia la clase — `hover:hidden` no matchea `hidden`
+// El variant cambia la clase — `hover:hidden` no coincide con `hidden`
 <div className="hover:hidden" />
 ```
 

--- a/packages/docs/es/rules/_extras/no-unknown-classes.md
+++ b/packages/docs/es/rules/_extras/no-unknown-classes.md
@@ -8,7 +8,7 @@ incluye una sugerencia y un quick-fix de editor para reemplazarla.
 El design system aquí significa **todo lo que Tailwind generaría para tu stylesheet**: las utilities
 core (`flex`, `bg-red-500`, `hover:underline`), cualquier token `@theme` que definiste (`bg-card`,
 `text-brand-foreground`), cualquier clase registrada por plugins (`prose`, `animate-in`, etc.), y
-cualquier CSS custom que escribiste inline.
+cualquier CSS personalizado que escribiste inline.
 
 DS-dependiente — requiere `settings.tailwindcss.entryPoint`. Cuando el design system no puede
 cargar, la regla emite un único diagnóstico fatal `designSystemUnavailable` por archivo en vez de
@@ -125,10 +125,10 @@ El prefijo se detecta automáticamente desde tu `entryPoint`; no hay nada extra 
 
 `string[]`, default `[]`.
 
-Nombres exactos de clases para whitelistear. Usa esto cuando la clase se genera en runtime (template
-strings que el plugin no puede resolver estáticamente) o cuando deliberadamente no es parte de tu
-design system pero quieres que sobreviva al linting. Los matches son literales — `"my-special"` no
-matchea `"hover:my-special"`.
+Nombres exactos de clases para incluir en la allowlist. Usa esto cuando la clase se genera en
+runtime (template strings que el plugin no puede resolver estáticamente) o cuando deliberadamente no
+es parte de tu design system pero quieres que sobreviva al linting. Las coincidencias son literales
+— `"my-special"` no coincide con `"hover:my-special"`.
 
 ```jsonc
 { "tailwindcss/no-unknown-classes": ["error", { "allowlist": ["my-runtime-class", "legacy-button"] }] }

--- a/packages/docs/es/rules/_extras/no-unnecessary-arbitrary-value.md
+++ b/packages/docs/es/rules/_extras/no-unnecessary-arbitrary-value.md
@@ -10,8 +10,8 @@ primer hit, las sugerencias cubren el resto en el mismo string. Variants e `!` (
 preservan.
 
 El chequeo se dispara solo cuando hay un valor arbitrario en la utility (`hasArbitraryValue(cls)` es
-true) Y el cache devuelve un match en `getNamedEquivalent`. Eso mantiene la regla barata y enfocada
-— sin resolución fuzzy, sin round-trip al DS por cada clase.
+true) Y el cache devuelve una coincidencia en `getNamedEquivalent`. Eso mantiene la regla barata y
+enfocada — sin resolución fuzzy, sin round-trip al DS por cada clase.
 
 DS-dependiente — requiere `settings.tailwindcss.entryPoint`. Si el design system no puede cargar, la
 regla emite un único diagnóstico fatal `designSystemUnavailable` por archivo en vez de pasar en
@@ -19,9 +19,9 @@ silencio.
 
 ## Opciones
 
-Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, defaultea
-a `settings.tailwindcss.entryPoint`). Configura el entry point en `settings.tailwindcss.entryPoint`
-para todo el proyecto en vez de por-regla cuando puedas.
+Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, por
+defecto es `settings.tailwindcss.entryPoint`). Configura el entry point en
+`settings.tailwindcss.entryPoint` para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Ejemplos
 
@@ -55,10 +55,12 @@ para todo el proyecto en vez de por-regla cuando puedas.
 ## Interacciones con otras reglas
 
 - **`enforce-canonical`**: complementaria, no hay doble-fire. Las dos actúan solo cuando la forma
-  arbitraria y su reemplazo nombrado emiten CSS **idéntico**; se reparten por forma. Esta regla es
-  dueña del caso directo arbitrario→nombrado (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` →
-  `bg-red-500`); `enforce-canonical` es dueña de los renombres canónicos y la normalización de
-  sintaxis de variables CSS. Las dos parten el espacio arbitrario→nombrado de forma limpia.
+  arbitraria y su reemplazo nombrado emiten CSS **idéntico**. Esta regla es dueña del caso directo
+  arbitrario→nombrado (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`);
+  `enforce-canonical` es dueña de las canonicalizaciones donde el arbitrario mapea a una utility con
+  otro nombre (`rounded-[var(--radius-sm)]` → `rounded-sm`). Las dos parten el espacio
+  arbitrario→nombrado de forma limpia — y el swap simple `[var(--x)]` ↔ `(--x)` es de
+  `enforce-consistent-variable-syntax`, no de ninguna de las dos.
 - **`prefer-scale-token`**: dueña de lo que ninguna de las anteriores toca — un valor que solo es
   _numéricamente_ igual a un paso de la escala o a un token de tema (`p-[2px]` → `p-0.5`), cuyo
   texto CSS difiere (`calc(var(--spacing) * 0.5)` vs `2px`). Solo-reporte, apagada por defecto.
@@ -74,5 +76,5 @@ para todo el proyecto en vez de por-regla cuando puedas.
 - **A propósito mantienes valores arbitrarios por legibilidad** — algunos equipos prefieren
   `w-[200px]` a un alias de token cuando el valor es one-off o pixel-precise. Desactiva la regla y
   apóyate en `prefer-theme-tokens` + `enforce-canonical` para los casos que sí quieres marcar.
-- **Migrando desde otro toolchain** que generaba valores arbitrarios para todo — corrila como `warn`
-  hasta terminar el cleanup, después súbela a `error`.
+- **Migrando desde otro toolchain** que generaba valores arbitrarios para todo — ejecútala como
+  `warn` hasta terminar el cleanup, después súbela a `error`.

--- a/packages/docs/es/rules/_extras/prefer-theme-tokens.md
+++ b/packages/docs/es/rules/_extras/prefer-theme-tokens.md
@@ -9,11 +9,15 @@ como la forma bracket (`prefix-[var(--name)]`) se reconocen, y los modificadores
 (`/80`), variants y `!` (important) se preservan.
 
 El candidato `${prefix}-${varName}` tiene que ser una utility real en tu DS — la regla consulta
-`cache.isValid(candidate)`. Después omite explícitamente cualquier candidato que
+`cache.isValid(candidate)`. Pero existir por nombre no alcanza: el token con nombre tiene que
+SIGNIFICAR lo mismo. `@theme inline { --color-primary: var(--primary) }` hace que `bg-primary` y
+`bg-(--primary)` sean la misma declaración, mientras que un `--color-primary` literal junto a un
+`--primary` no relacionado los vuelve colores distintos — y esta regla autofixea. Así que el
+reemplazo solo se propone cuando la declaración del token resuelve de vuelta a la variable que
+escribiste, o cuando esa variable no está definida en ningún lado (en cuyo caso la declaración
+actual es CSS muerto y el token solo puede ser una mejora). Después omite cualquier candidato que
 `cache.getNamedEquivalent` también resolvería, porque ese caso es propiedad de
-`no-unnecessary-arbitrary-value` (mismo CSS, sin doble-fire). Lo que queda es exactamente el espacio
-solo-heurístico: la utility con nombre existe en tu theme pero no comparte una shape bracket-
-equivalente con el original.
+`no-unnecessary-arbitrary-value` (mismo CSS, sin doble-fire).
 
 DS-dependiente — requiere `settings.tailwindcss.entryPoint`. Si el design system no puede cargar, la
 regla emite un único diagnóstico fatal `designSystemUnavailable` por archivo en vez de pasar en
@@ -21,9 +25,9 @@ silencio.
 
 ## Opciones
 
-Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, defaultea
-a `settings.tailwindcss.entryPoint`). Configura el entry point en `settings.tailwindcss.entryPoint`
-para todo el proyecto en vez de por-regla cuando puedas.
+Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, por
+defecto es `settings.tailwindcss.entryPoint`). Configura el entry point en
+`settings.tailwindcss.entryPoint` para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Ejemplos
 
@@ -56,7 +60,7 @@ Asumiendo un theme estilo shadcn con tokens como `--border`, `--primary`, `--bac
 
 <div className="border-l-border" />
 
-// Variable sin utility nombrada que matchee — déjala
+// Variable sin utility nombrada que coincida — déjala
 <div className="border-(--no-such-token)" />
 ```
 

--- a/packages/docs/es/rules/consistent-variant-order.md
+++ b/packages/docs/es/rules/consistent-variant-order.md
@@ -7,17 +7,24 @@
 Reordena los prefijos de variants dentro de una sola clase para que la cadena se escriba siempre
 igual. `hover:dark:bg-red` y `dark:hover:bg-red` producen el mismo CSS en Tailwind v4, pero un orden
 inconsistente ensucia grep, code reviews y diffs. Esta regla elige un orden canónico y reescribe
-todo para que matchee, con autofix sobre el primer ofensor y sugerencias de editor sobre el resto.
+todo para que coincida, con autofix sobre el primer ofensor y sugerencias de editor sobre el resto.
 
 Los pseudo-elements (`before`, `after`, `file`, `placeholder`, `selection`, `marker`, `backdrop`,
 `first-line`, `first-letter`, `details-content`) quedan siempre pinneados innermost — lo más cerca
 posible de la utility — porque en Tailwind v4 un pseudo-element puesto antes de una variant que
 selecciona elemento produce CSS roto del estilo `&::before { &>svg { … } }`.
 
+Con un entry point configurado, qué variants son esas surge de los selectores que genera el design
+system en lugar de esa lista fija, así que una variant que define tu proyecto también se maneja:
+`@custom-variant thumb (&::-webkit-slider-thumb)` queda pinneada innermost como `before:`, y
+`@custom-variant child (& > *)` se vuelve una barrera de reordenamiento porque mover una variant de
+estado a través de un combinador cambia qué elemento se selecciona.
+
 DS-opcional — cuando `settings.tailwindcss.entryPoint` está configurado, la regla usa la tabla de
-prioridad de variants del design system. Cuando no, cae a un orden estático built-in. Ambos
-fallbacks son determinísticos; esta es la única regla DS-dependiente que tolera silenciosamente un
-entry point faltante.
+prioridad de variants del design system y el comportamiento derivado de variants de arriba. Cuando
+no, cae a un orden estático built-in y la lista fija. Ambos caminos son determinísticos, y un entry
+point faltante se tolera silenciosamente (`no-contradicting-variants` es la otra regla que hace
+esto).
 
 ## Opciones
 
@@ -25,10 +32,10 @@ entry point faltante.
 
 `string[]`, opcional.
 
-Lista de prioridad custom. Los variants aparecen en el orden que listas; lo que no listas ordena
-después, en su posición original. Úsalo cuando tu team tiene un house style distinto al default de
-Tailwind (e.g. prefieres `dark:` outermost en toda cadena). El pin de pseudo-elements sigue
-aplicando sin importar dónde los pongas en tu lista.
+Lista de prioridad personalizada. Los variants aparecen en el orden que listas; lo que no listas
+ordena después, en su posición original. Úsalo cuando tu team tiene un house style distinto al
+default de Tailwind (e.g. prefieres `dark:` outermost en toda cadena). El pin de pseudo-elements
+sigue aplicando sin importar dónde los pongas en tu lista.
 
 ```jsonc
 {
@@ -91,7 +98,7 @@ proyecto; casi nunca se necesita.
 
 - **Confías en `prettier-plugin-tailwindcss` también para ordenar variants**: el formatter lo hace,
   la regla es redundante. Dejar ambas activadas es seguro pero es trabajo extra.
-- **Orden custom de variants que es difícil de expresar como una lista plana** (e.g. el orden
+- **Orden personalizado de variants que es difícil de expresar como una lista plana** (e.g. el orden
   depende de la utility): desactívala y confía en el review.
 - **Código generado** donde el orden de variants codifica un significado que no quieres que se
   reescriba.

--- a/packages/docs/es/rules/enforce-canonical.md
+++ b/packages/docs/es/rules/enforce-canonical.md
@@ -7,11 +7,12 @@
 Le pregunta al design system cuál es la forma canónica de cada utility en tu código y reescribe las
 que no lo son. "Canónico" es lo que devuelve `canonicalizeCandidates()` de `@tailwindcss/node` — la
 misma fuente de verdad que usan prettier-plugin-tailwindcss, oxfmt y las herramientas oficiales de
-Tailwind. Ejemplos: `-m-0` → `m-0` (no necesitas el negativo para un cero), `bg-gradient-to-r` →
-`bg-linear-to-r`, `break-words` → `wrap-break-word`, `start-2` → `inset-s-2`, `flex-grow-1` →
-`grow`, `flex-grow-[2]` → `grow-2` (un valor arbitrario cuya forma nombrada emite el mismo CSS),
+Tailwind. Ejemplos: `-m-0` → `m-0` (no necesitas el negativo para un cero), `start-2` → `inset-s-2`,
+`flex-grow-[2]` → `grow-2` (un valor arbitrario cuya forma nombrada emite el mismo CSS),
 `text-[var(--color-text)]/90` → `text-(--color-text)/90`. El auto-fix corrige el primer hit, las
-sugerencias cubren el resto en el mismo string.
+sugerencias cubren el resto en el mismo string. Los renombres de v3 (`bg-gradient-to-r` →
+`bg-linear-to-r`, `break-words` → `wrap-break-word`) son propiedad de `no-deprecated-classes`, no de
+esta regla — ver Interacciones.
 
 Las clases con nombre resuelven contra un `canonicalMap` precomputado en memoria (sub-microsegundo).
 Los valores arbitrarios (`p-[2px]`, `bg-(--c)`) pasan por el worker `canonicalize-service` porque
@@ -24,9 +25,9 @@ silencio.
 
 ## Opciones
 
-Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, defaultea
-a `settings.tailwindcss.entryPoint`). Configura el entry point en `settings.tailwindcss.entryPoint`
-para todo el proyecto en vez de por-regla cuando puedas.
+Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, por
+defecto es `settings.tailwindcss.entryPoint`). Configura el entry point en
+`settings.tailwindcss.entryPoint` para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Ejemplos
 
@@ -36,9 +37,6 @@ para todo el proyecto en vez de por-regla cuando puedas.
 // El negativo-de-cero es simplemente cero
 <div className="-m-0 -mt-0" />
 
-// Spellings v3 que el canonicalize oficial reescribe
-<div className="bg-gradient-to-r break-words" />
-
 // Shorthand de inset lógico → canónico inset-s-* / inset-e-*
 <div className="start-2 end-4" />
 
@@ -46,7 +44,7 @@ para todo el proyecto en vez de por-regla cuando puedas.
 <div className="flex-grow-[2]" />
 
 // Variants e important se preservan
-<div className="hover:!break-words" />
+<div className="hover:!flex-grow-[2]" />
 ```
 
 ### ✓ Correcto
@@ -54,13 +52,11 @@ para todo el proyecto en vez de por-regla cuando puedas.
 ```tsx
 <div className="m-0 mt-0" />
 
-<div className="bg-linear-to-r wrap-break-word" />
-
 <div className="inset-s-2 inset-e-4" />
 
 <div className="grow-2" />
 
-<div className="hover:!wrap-break-word" />
+<div className="hover:!grow-2" />
 ```
 
 ## Interacciones con otras reglas
@@ -80,7 +76,7 @@ para todo el proyecto en vez de por-regla cuando puedas.
   reportaba dos veces con el mismo fix; el mensaje de la otra regla ("deprecada en v4") es el más
   accionable de los dos. Acá queda todo lo que es actual-pero-no-canónico: `-m-0` → `m-0`, `start-2`
   → `inset-s-2`, y las formas con valor arbitrario como `flex-grow-[2]` → `grow-2` (la lista de
-  renombres tiene spellings, no valores). Mantén ambas activas — con solo esta los renombres quedan
+  renombres tiene grafías, no valores). Mantén ambas activas — con solo esta los renombres quedan
   sin reportar.
 - **`prefer-scale-token`**: la mitad solo-reporte de lo que esta regla cedió en #78. Una reescritura
   cuyo CSS emitido difiere textualmente (`p-[10px]` → `p-2.5`, donde el token llega por

--- a/packages/docs/es/rules/enforce-consistent-important-position.md
+++ b/packages/docs/es/rules/enforce-consistent-important-position.md
@@ -1,14 +1,15 @@
 # enforce-consistent-important-position
 
 > Enforce consistent position of the important (!) modifier. Default: suffix (Tailwind v4 canonical
-> form). Note: using "prefix" may conflict with enforce-canonical which normalizes to suffix.
+> form). This rule is the single source of truth for ! placement — enforce-canonical preserves the
+> position you wrote, so the two never conflict.
 
 ## Qué hace esta regla
 
 Tailwind v4 soporta dos sintaxis para el modificador `!important`: prefijo (`!flex`, la forma de la
 era v3) y sufijo (`flex!`, la forma canónica de v4). Las dos producen el mismo CSS, pero mezclarlas
 dentro de un proyecto deja el codebase inconsistente y rompe el copy-paste entre archivos. Esta
-regla elige una posición y reescribe cada ofensor para que matchee. Autofix sobre el primer hit por
+regla elige una posición y reescribe cada ofensor para que coincida. Autofix sobre el primer hit por
 location, sugerencia de editor sobre los siguientes.
 
 DS-independiente — funciona sin `settings.tailwindcss.entryPoint`. Es una transformación de string
@@ -20,17 +21,17 @@ pura, así que corre en todos lados, incluyendo proyectos que todavía no cablea
 
 `'prefix' | 'suffix'`, default `'suffix'`.
 
-`'suffix'` es la forma canónica de Tailwind v4 (`flex!`, `hover:text-red!`) y matchea lo que
-produciría `enforce-canonical`, así que es la elección recomendada para proyectos nuevos. `'prefix'`
-mantiene la forma de v3 (`!flex`, `hover:!text-red`) — elegila solo si tu codebase todavía está en
-el spelling de v3 y no quieres migrar todavía.
+`'suffix'` es la forma canónica de Tailwind v4 (`flex!`, `hover:text-red!`), así que es la elección
+recomendada para proyectos nuevos. `'prefix'` mantiene la forma de v3 (`!flex`, `hover:!text-red`) —
+elígela solo si tu codebase todavía está en la grafía de v3 y no quieres migrar todavía.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-important-position": ["error", { "position": "suffix" }] }
 ```
 
-Nota: setear `position: 'prefix'` va a entrar en conflicto con `enforce-canonical`, que normaliza a
-sufijo. Usa una o la otra.
+Nota: `enforce-canonical` preserva la posición del `!` que escribiste (no la normaliza), así que
+cualquier valor de `position` compone con él sin problemas. Esta regla es la única fuente de verdad
+para la posición del `!`.
 
 ## Ejemplos
 
@@ -64,9 +65,9 @@ sufijo. Usa una o la otra.
 
 ## Interacciones con otras reglas
 
-- **`enforce-canonical`**: con `position: 'suffix'` (el default) las dos reglas concuerdan. Con
-  `position: 'prefix'` se pelean — canonical reescribe a sufijo en cada pasada del fix. Quedate con
-  sufijo a menos que tengas una razón fuerte.
+- **`enforce-canonical`**: preserva la posición del `!` que escribiste (prefijo, sufijo o ninguno)
+  en vez de normalizarla, así que nunca se pelea con esta regla sin importar el `position` que
+  elijas. Esta regla es la única fuente de verdad para la posición del `!`.
 - **`enforce-sort-order`**: independiente de la posición del important. Tanto la forma prefijo como
   la sufijo ordenan igual.
 - **`no-unknown-classes`**: hace lookup de la utility bare, sacando `!` de cualquier lado, así que
@@ -76,5 +77,6 @@ sufijo. Usa una o la otra.
 
 - **El codebase mezcla las dos formas a propósito** (e.g. archivos legacy de v3 conviviendo con
   archivos frescos de v4 durante una migración). Reactívala cuando termine la migración.
-- **Ya estás corriendo `enforce-canonical`** y confías en que normalice la posición del `!` como
-  parte de la canonicalización — dejar esta regla activada es inocuo pero redundante.
+- **No te importa la consistencia de la posición del `!`.** Ninguna otra regla la impone —
+  `enforce-canonical` preserva la posición que hayas escrito — así que desactivar esta deja la
+  posición del `!` sin chequear.

--- a/packages/docs/es/rules/enforce-consistent-line-wrapping.md
+++ b/packages/docs/es/rules/enforce-consistent-line-wrapping.md
@@ -49,7 +49,7 @@ autofix es opt-in vía `wrapLines`.
 
 ### `wrapLines`
 
-`"overWidth" | "all"`, opcional. Sin default — igual que `classesPerLine`, dejarlo sin setear
+`"overWidth" | "all"`, opcional. Sin default — igual que `classesPerLine`, dejarlo sin establecer
 significa que el fixer está apagado y `printWidth` solo reporta.
 
 Activa el **autofix basado en el width** para template literals. Los dos modos difieren tanto en
@@ -81,7 +81,7 @@ regla, que mide cada fragmento estático por separado. Por eso una sola línea f
 mano con un fragmento corto junto a una interpolación ancha puede exceder `printWidth` sin ser
 reportada.
 
-`wrapLines` solo aplica cuando `classesPerLine` **no** está seteado — si no, `classesPerLine` es
+`wrapLines` solo aplica cuando `classesPerLine` **no** está establecido — si no, `classesPerLine` es
 dueño del layout.
 
 ```jsonc
@@ -128,9 +128,9 @@ Cantidad máxima de clases en una sola línea. Cuando se excede dentro de un tem
 `classesPerLine` por línea. Dentro de string literals (`"…"`) la regla reporta `tooManyPerLine` pero
 no autofixea — los string literals no pueden cruzar líneas con seguridad sin intervención manual.
 
-Setear `classesPerLine` cambia el fixer de template literals a este modo por chunks y apaga el fixer
-basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta, y `wrapLines` se
-ignora.
+Establecer `classesPerLine` cambia el fixer de template literals a este modo por chunks y apaga el
+fixer basado en el width (agrupado por variantes) — `printWidth` entonces solo reporta, y
+`wrapLines` se ignora.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-line-wrapping": ["error", { "classesPerLine": 5 }] }

--- a/packages/docs/es/rules/enforce-consistent-variable-syntax.md
+++ b/packages/docs/es/rules/enforce-consistent-variable-syntax.md
@@ -65,17 +65,27 @@ team prefiere la forma larga por grepability.
 
 ## Interacciones con otras reglas
 
-- **`enforce-canonical`**: no toca la sintaxis de variables. Canonical normaliza nombres de utility;
-  esta regla normaliza la forma de la variable. Las dos corren juntas sin problemas.
-- **`no-unnecessary-arbitrary-value`**: también apunta a valores arbitrarios pero para el caso del
-  equivalente nombrado (`bg-[#ff0000]` → `bg-red-500`). Disjunta de esta regla.
-- **`prefer-theme-tokens`**: cuando una variable CSS matchea un token `@theme`, esa regla swappea a
-  la utility nombrada (`bg-(--primary)` → `bg-primary` si `--primary` está declarado en `@theme`).
-  Ejecuta esa antes que esta si quieres las dos transformaciones.
+- **`enforce-canonical`**: esta regla es la única dueña de la sintaxis de variables. Como `bg-(--x)`
+  es la forma canónica de Tailwind, `enforce-canonical` reportaría el mismo swap `bg-[var(--x)]` →
+  `bg-(--x)`; en cambio, **cede** la conversión pura bracket↔paren a esta regla (igual que cede los
+  renombres de v3 a `no-deprecated-classes`). Eso evita un diagnóstico duplicado y, cuando esta
+  regla está en modo `explicit`, una pelea de autofix. `enforce-canonical` sigue manejando las
+  canonicalizaciones de variables que _no_ son un swap simple: un valor que mapea a un token
+  nombrado (`rounded-[var(--radius-sm)]` → `rounded-sm`) o una forma con modificador de opacidad
+  (`text-[var(--color-text)]/90` → `text-(--color-text)/90`).
+- **`no-unnecessary-arbitrary-value`**: en su mayoría disjunta — convierte un valor arbitrario a su
+  equivalente nombrado (`bg-[#ff0000]` → `bg-red-500`). Solo se solapan cuando el valor de una
+  variable coincide con una utility nombrada: sobre `bg-[var(--color-red-500)]` esa regla dispara (→
+  `bg-red-500`) y esta también (→ `bg-(--color-red-500)`). Proponen destinos distintos, así que
+  activa la que refleje tu política — o ejecuta `no-unnecessary-arbitrary-value` primero si
+  prefieres la utility nombrada.
+- **`prefer-theme-tokens`**: cuando una variable CSS coincide con un token `@theme`, esa regla
+  cambia a la utility nombrada (`bg-(--primary)` → `bg-primary` si `--primary` está declarado en
+  `@theme`). Ejecuta esa antes que esta si quieres las dos transformaciones.
 
 ## Cuándo desactivarla
 
-- **Apuntas a tooling más viejo que Tailwind v4**: la forma shorthand no está soportada. Seteá
+- **Apuntas a tooling más viejo que Tailwind v4**: la forma shorthand no está soportada. Configura
   `syntax: 'explicit'` en vez de desactivarla, así obtienes el rewrite en la dirección segura.
 - **Codebase con sintaxis mixta en plena migración** donde la consistencia todavía no es el
   objetivo.

--- a/packages/docs/es/rules/enforce-logical.md
+++ b/packages/docs/es/rules/enforce-logical.md
@@ -44,9 +44,9 @@ block.
 `string[]`, default `[]`.
 
 Patrones regex (compilados lazy, los inválidos se saltean en silencio). Las clases cuyo string
-completo matchee algún patrón bypassean el rewrite. Úsalo para casos puntuales donde genuinamente
-quieres dirección física — e.g. un ícono que siempre tiene que estar a la izquierda visual sin
-importar el writing direction.
+completo coincida con algún patrón bypassean el rewrite. Úsalo para casos puntuales donde
+genuinamente quieres dirección física — e.g. un ícono que siempre tiene que estar a la izquierda
+visual sin importar el writing direction.
 
 ```jsonc
 { "tailwindcss/enforce-logical": ["error", { "allowlist": ["^ml-icon$", "^rounded-tl-special$"] }] }
@@ -98,9 +98,9 @@ regla funciona sin él.
   va a autofixear en loop. Elige una según si tu app soporta RTL (usa `enforce-logical`) o es
   LTR-only (usa `enforce-physical`).
 - **`enforce-canonical`**: tiene opinión sobre los insets lógicos. Esta regla sugiere `start-2` (lo
-  que usan los docs de Tailwind); el design system reporta `inset-s-2` como el spelling canónico,
-  así que con las dos activas terminas ahí en dos pasadas. El CSS es el mismo en ambos casos, y
-  `enforce-physical` convierte los dos spellings de vuelta.
+  que usan los docs de Tailwind); el design system reporta `inset-s-2` como la grafía canónica, así
+  que con las dos activas terminas ahí en dos pasadas. El CSS es el mismo en ambos casos, y
+  `enforce-physical` convierte las dos grafías de vuelta.
 - **`enforce-shorthand`**: corre sobre shorthands `m-*` / `p-*` que ya son direction-neutral, así
   que las dos no se solapan.
 

--- a/packages/docs/es/rules/enforce-negative-arbitrary-values.md
+++ b/packages/docs/es/rules/enforce-negative-arbitrary-values.md
@@ -7,7 +7,7 @@
 Detecta utilities escritas con un prefijo negativo afuera de un bracket de valor arbitrario —
 `-top-[5px]`, `-translate-x-[10px]`, `-mt-[8px]` — y mueve el signo negativo adentro del bracket:
 `top-[-5px]`, `translate-x-[-10px]`, `mt-[-8px]`. El `-` exterior es redundante una vez que tienes
-un valor arbitrario, y meterlo adentro hace explícita la intención y matchea cómo
+un valor arbitrario, y meterlo adentro hace explícita la intención y coincide con cómo
 `@tailwindcss/node` canonicaliza la misma shape. El auto-fix corrige el primer hit, las sugerencias
 cubren el resto en el mismo string. Los variants (`hover:-mt-[8px]`) y el `!` (important, prefix o
 suffix) se preservan.

--- a/packages/docs/es/rules/enforce-physical.md
+++ b/packages/docs/es/rules/enforce-physical.md
@@ -46,8 +46,8 @@ eje block.
 `string[]`, default `[]`.
 
 Patrones regex (compilados lazy, los inválidos se saltean en silencio). Las clases cuyo string
-completo matchee algún patrón bypassean el rewrite. Útil cuando una utility lógica específica es
-intencional incluso en un codebase mayormente-LTR (e.g. un componente que sí tiene que soportar
+completo coincida con algún patrón bypassean el rewrite. Útil cuando una utility lógica específica
+es intencional incluso en un codebase mayormente-LTR (e.g. un componente que sí tiene que soportar
 RTL).
 
 ```jsonc

--- a/packages/docs/es/rules/enforce-shorthand.md
+++ b/packages/docs/es/rules/enforce-shorthand.md
@@ -21,10 +21,10 @@ Un diagnóstico por grupo colapsable: los cuatro lados reportan `m-2` una vez, n
 mitades `my-2`/`mx-2`.
 
 `scale-x-*`+`scale-y-*` deliberadamente **no** es una familia. `scale-110` además escribe
-`--tw-scale-z`, que `scale-3d` lee, así que mergear cambiaría cómo renderiza
+`--tw-scale-z`, que `scale-3d` lee, así que fusionar cambiaría cómo renderiza
 `scale-x-110 scale-y-110 scale-3d`.
 
-### Con un `entryPoint`, el merge se comprueba contra el CSS
+### Con un `entryPoint`, la fusión se comprueba contra el CSS
 
 Tailwind v4 tiene namespaces de tema por eje: `w-*` lee `--width-*` (y `--container-*`), `h-*` lee
 `--height-*`, `size-*` lee `--size-*`. Con este tema
@@ -39,15 +39,15 @@ Tailwind v4 tiene namespaces de tema por eje: `w-*` lee `--width-*` (y `--contai
 `w-brand h-brand` → `size-brand` es destructivo: `size-brand` no existe, y el elemento pierde el
 ancho y el alto. Si configuras `settings.tailwindcss.entryPoint` (o el `entryPoint` propio de la
 regla), la regla compara las declaraciones que Tailwind emite — las partes tienen que resolver al
-mismo valor y el reemplazo tiene que reproducirlo — así que ese merge no se ofrece.
+mismo valor y el reemplazo tiene que reproducirlo — así que esa fusión no se ofrece.
 
-Los tokens de tema con nombre en la familia de sizing solo se mergean cuando los valores son
+Los tokens de tema con nombre en la familia de sizing solo se fusionan cuando los valores son
 literalmente idénticos. `w-card h-card` se deja como está incluso si los tres namespaces definen
 `card` como `30rem`, porque cada lado lee una variable distinta y un override en `:root` de una de
 ellas las separa — el mismo razonamiento que [`enforce-canonical`](./enforce-canonical) aplica a
 `rounded-[0.5rem]` → `rounded-lg`.
 
-Sin entry point la regla mantiene los merges que son seguros diga lo que diga el tema: números y
+Sin entry point la regla mantiene las fusiones que son seguras diga lo que diga el tema: números y
 fracciones (la escala de spacing compartida), valores arbitrarios (el mismo literal a los dos
 lados), las keywords del core (`full`, `auto`, `min`, `max`, `fit`, `px` y las unidades de
 viewport), y todas las familias que no son sizing — esas beben de un único namespace.
@@ -57,7 +57,7 @@ viewport), y todas las familias que no son sizing — esas beben de un único na
 ### `entryPoint`
 
 `string`, opcional. Un entry point CSS solo para esta regla, que pisa
-`settings.tailwindcss.entryPoint`. Se usa únicamente para verificar los merges contra el CSS
+`settings.tailwindcss.entryPoint`. Se usa únicamente para verificar las fusiones contra el CSS
 emitido; la regla funciona sin él.
 
 ## Ejemplos
@@ -116,7 +116,7 @@ emitido; la regla funciona sin él.
 // Dos lados adyacentes no son un eje
 <div className="top-0 right-0" />
 
-// Variants distintas — la regla no mergea cruzando cadenas de variants
+// Variants distintas — la regla no fusiona cruzando cadenas de variants
 <div className="hover:mt-2 focus:mb-2" />
 ```
 
@@ -130,7 +130,7 @@ emitido; la regla funciona sin él.
   `border-s-*`+`border-e-*` → `border-x-*`, `start-*`+`end-*` → `inset-x-*`) caen en utilities de
   eje que ninguna regla direccional convierte, así que las dos nunca se pelean.
 - **`enforce-consistent-important-position`**: el shorthand respeta la convención de posición del
-  `!` de las clases mergeadas. Si las cuatro usan prefijo, el shorthand queda con prefijo; lo mismo
+  `!` de las clases fusionadas. Si las cuatro usan prefijo, el shorthand queda con prefijo; lo mismo
   para sufijo.
 
 ## Cuándo desactivarla

--- a/packages/docs/es/rules/enforce-sort-order.md
+++ b/packages/docs/es/rules/enforce-sort-order.md
@@ -4,9 +4,10 @@
 
 ## Qué hace esta regla
 
-Ordena cada string de clases Tailwind en tu código para que matchee el orden oficial de Tailwind —
-el mismo orden que Tailwind usa al generar CSS, y el mismo que aplican `prettier-plugin-tailwindcss`
-y `oxfmt`. La regla tiene autofix: correr `oxlint --fix` reescribe el string in-place.
+Ordena cada string de clases Tailwind en tu código para que coincida con el orden oficial de
+Tailwind — el mismo orden que Tailwind usa al generar CSS, y el mismo que aplican
+`prettier-plugin-tailwindcss` y `oxfmt`. La regla tiene autofix: correr `oxlint --fix` reescribe el
+string in-place.
 
 DS-dependiente — requiere `settings.tailwindcss.entryPoint`. El sort exacto lo computa la API de
 class-order de `@tailwindcss/node` contra tu stylesheet, así que tokens de theme, plugins y
@@ -43,8 +44,8 @@ la que está construido el modo — `'default'` le pide al worker la respuesta r
 `string`, opcional.
 
 Override por regla de `settings.tailwindcss.entryPoint`. Útil en el caso raro donde esta regla
-necesita leer un stylesheet distinto al del resto del plugin (e.g. aplicas scope a el sort a una
-sub-app). Casi nadie lo necesita — define el entry point una vez en `settings` y olvídate.
+necesita leer un stylesheet distinto al del resto del plugin (e.g. acotas el sort a una sub-app).
+Casi nadie lo necesita — define el entry point una vez en `settings` y olvídate.
 
 ## Ejemplos
 
@@ -96,8 +97,8 @@ sub-app). Casi nadie lo necesita — define el entry point una vez en `settings`
   rule budget reducido — el formatter ya hace este trabajo byte-por-byte. Dejar ambas activadas está
   bien (no hay conflictos), es solo trabajo redundante.
 - **Trabajando en un codebase que ordena clases a propósito por intent de autoría** (e.g.
-  agrupamiento visual que no matchea la prioridad de Tailwind). Desactívala localmente en vez de
-  globalmente si es una preferencia por componente.
+  agrupamiento visual que no coincide con la prioridad de Tailwind). Desactívala localmente en vez
+  de globalmente si es una preferencia por componente.
 
 > **Caveat de `tailwind-merge`.** `tailwind-merge` resuelve un grupo de conflicto conservando la
 > _última_ aparición en el string. Si un mismo string de clases contiene dos clases del mismo grupo

--- a/packages/docs/es/rules/index.md
+++ b/packages/docs/es/rules/index.md
@@ -20,8 +20,7 @@ Reglas que atrapan problemas que generarían CSS inválido o inesperado.
 ## Modernización
 
 - [no-deprecated-classes](./no-deprecated-classes) — `flex-grow` → `grow`, etc.
-- [enforce-canonical](./enforce-canonical) — `-m-0` → `m-0`, `bg-gradient-to-r` → `bg-linear-to-r`,
-  etc.
+- [enforce-canonical](./enforce-canonical) — `-m-0` → `m-0`, `start-2` → `inset-s-2`, etc.
 - [no-unnecessary-arbitrary-value](./no-unnecessary-arbitrary-value) — `w-[100%]` → `w-full` cuando
   la clase nombrada emite CSS idéntico.
 - [prefer-theme-tokens](./prefer-theme-tokens) — `border-(--border)` → `border-border` cuando un
@@ -90,22 +89,22 @@ Funcionan sin nada configurado — su fallback es determinístico por sí solo �
 cuando hay un `entryPoint` disponible. Ninguna puede emitir `designSystemUnavailable`. Todas aceptan
 además un `entryPoint` propio que pisa el ajuste compartido.
 
-| Regla                       | Opciones por defecto                                | Qué aporta el design system                                     |
-| --------------------------- | --------------------------------------------------- | --------------------------------------------------------------- |
-| `consistent-variant-order`  | `{}` (orden derivado del DS cuando está disponible) | El orden real de variants, y qué hace el selector de cada una   |
-| `enforce-logical`           | `{ allowlist: [], direction: 'both' }`              | Confirma que la clase sugerida exista                           |
-| `enforce-physical`          | `{ allowlist: [], direction: 'both' }`              | Confirma que la clase sugerida exista                           |
-| `enforce-shorthand`         | `{}`                                                | Verifica cada merge contra el CSS emitido                       |
-| `no-contradicting-variants` | `{}`                                                | Qué hace el selector de cada variant                            |
-| `no-dark-without-light`     | `{ variants: ['dark'] }`                            | Agrupa la base por propiedad CSS declarada, no solo por prefijo |
-| `no-deprecated-classes`     | `{}`                                                | Deriva la lista de renombres en vez de usar la tabla interna    |
+| Regla                              | Opciones por defecto                                | Qué aporta el design system                                                                       |
+| ---------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `consistent-variant-order`         | `{}` (orden derivado del DS cuando está disponible) | El orden real de variants, y qué hace el selector de cada una                                     |
+| `enforce-consistent-line-wrapping` | `{ printWidth: 80, group: 'newLine' }`              | El prefix del proyecto, para que el agrupamiento de `wrapLines: 'all'` lo trate como transparente |
+| `enforce-logical`                  | `{ allowlist: [], direction: 'both' }`              | Confirma que la clase sugerida exista                                                             |
+| `enforce-physical`                 | `{ allowlist: [], direction: 'both' }`              | Confirma que la clase sugerida exista                                                             |
+| `enforce-shorthand`                | `{}`                                                | Verifica cada fusión contra el CSS emitido                                                        |
+| `no-contradicting-variants`        | `{}`                                                | Qué hace el selector de cada variant                                                              |
+| `no-dark-without-light`            | `{ variants: ['dark'] }`                            | Agrupa la base por propiedad CSS declarada, no solo por prefijo                                   |
+| `no-deprecated-classes`            | `{}`                                                | Deriva la lista de renombres en vez de usar la tabla interna                                      |
 
 ### Reglas DS-independientes
 
 | Regla                                   | Opciones por defecto            |
 | --------------------------------------- | ------------------------------- |
 | `enforce-consistent-important-position` | `{ position: 'suffix' }`        |
-| `enforce-consistent-line-wrapping`      | `{ printWidth: 80 }`            |
 | `enforce-consistent-variable-syntax`    | `{ syntax: 'shorthand' }`       |
 | `enforce-negative-arbitrary-values`     | (sin opciones)                  |
 | `max-class-count`                       | `{ max: 20 }`                   |

--- a/packages/docs/es/rules/max-class-count.md
+++ b/packages/docs/es/rules/max-class-count.md
@@ -16,7 +16,7 @@ reconstruidos por `enforce-consistent-line-wrapping` se cuentan como el set de c
 por líneas visuales.
 
 DS-independiente — no necesita `entryPoint`. Sin autofix: extraer un componente requiere criterio
-que la regla no puede tomar por tú.
+que la regla no puede tomar por ti.
 
 ## Opciones
 
@@ -26,7 +26,7 @@ que la regla no puede tomar por tú.
 
 El máximo de clases permitidas en un solo elemento / llamada. La regla reporta cuando
 `classes.length > max` (es decir, el límite es inclusivo: `max: 20` permite _exactamente_ 20).
-Ajustalo al umbral de tu equipo para "esto ya es un componente".
+Ajústalo al umbral de tu equipo para "esto ya es un componente".
 
 ```jsonc
 { "tailwindcss/max-class-count": ["warn", { "max": 15 }] }
@@ -78,7 +78,7 @@ cn("flex items-center", "p-4 m-2 gap-2")
 ## Interacciones con otras reglas
 
 - **`no-duplicate-classes`**: si una clase está repetida, ambas reglas ven el conteo inflado.
-  Arreglá el duplicado primero — el conteo baja y esta regla puede dejar de disparar sola.
+  Arregla el duplicado primero — el conteo baja y esta regla puede dejar de disparar sola.
 - **`enforce-sort-order`** / **`enforce-consistent-line-wrapping`**: primas cosméticas. El contador
   es insensible al whitespace, así que el line-wrapping no cambia el veredicto.
 - **`enforce-canonical`**: colapsa pares redundantes (`-m-0` → `m-0`) antes de que esta regla corra,

--- a/packages/docs/es/rules/no-arbitrary-value.md
+++ b/packages/docs/es/rules/no-arbitrary-value.md
@@ -94,8 +94,8 @@ legítimos a `allow` en vez de desactivar la regla entera.
   nombrado exacto (`w-[100%]` → `w-full`). Pueden coexistir: la suave autofixea los casos triviales
   y esta atrapa lo que queda.
 - **`prefer-theme-tokens`**: misma intención, pero DS-dependiente. `prefer-theme-tokens` consulta tu
-  `@theme` y sugiere el token que matchea. Combínalas: esta regla es tu freno de mano cuando todavía
-  no existe el token.
+  `@theme` y sugiere el token que coincide. Combínalas: esta regla es tu freno de mano cuando
+  todavía no existe el token.
 - **`enforce-consistent-variable-syntax`**: convierte entre `bg-[var(--x)]` y `bg-(--x)`. Como las
   dos formas se reportan acá, correrla — en cualquier dirección — no puede sacar una clase del
   alcance de esta regla.
@@ -103,7 +103,7 @@ legítimos a `allow` en vez de desactivar la regla entera.
 ## Cuándo desactivarla
 
 - **Prototipos / branches de spike** donde la velocidad le gana a la disciplina. Reactívala antes de
-  mergear.
+  integrar.
 - **Archivos que genuinamente necesitan un arbitrary value** (landing pages one-off, shims de
   CSS-in-JS dinámico). Prefiere `allow` con una lista corta de prefijos, o desactiva por línea con
   `// oxlint-disable-next-line tailwindcss/no-arbitrary-value`.

--- a/packages/docs/es/rules/no-conflicting-classes.md
+++ b/packages/docs/es/rules/no-conflicting-classes.md
@@ -16,14 +16,14 @@ tratado a mano:
 - **el mismo valor en ambos lados** — `mask-b-from-50% mask-b-from-black` comparten cuatro
   declaraciones byte a byte idénticas, así que gane quien gane el resultado es el mismo;
 - **un reenviador `var()` y la clase que suministra la variable** — `outline-2` declara
-  `outline-style: var(--tw-outline-style)` y no aporta valor propio; el match es por el nombre real
-  de la variable, así que el `--scrollbar-*` de un plugin se comporta igual que el `--tw-*` de
-  Tailwind;
+  `outline-style: var(--tw-outline-style)` y no aporta valor propio; la coincidencia es por el
+  nombre real de la variable, así que el `--scrollbar-*` de un plugin se comporta igual que el
+  `--tw-*` de Tailwind;
 - **una ganadora que sigue arrastrando a la perdedora** — `drop-shadow-indigo-500` lee el
   `--tw-drop-shadow-size` que escribe `drop-shadow-xl`, y la cadena se sigue transitivamente (así
   compone `from-*` / `via-*` / `to-*`);
-- **una custom property reseteada a `initial`** — `animate-in` inicializa cada `--tw-enter-*` para
-  que sus modificadores la sobrescriban;
+- **una custom property restablecida a `initial`** — `animate-in` inicializa cada `--tw-enter-*`
+  para que sus modificadores la sobrescriban;
 - **declaraciones en cajas distintas** — `placeholder-*` estila `::placeholder`, `space-x-*` estila
   los hijos, y ninguna estila el elemento.
 
@@ -45,11 +45,11 @@ pasar en silencio.
 
 ## Opciones
 
-| Opción            | Tipo                             | Por defecto | Descripción                                                                                                                                                                                                                                                 |
-| ----------------- | -------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `reportRedundant` | `boolean`                        | `true`      | Reporta como `redundant` dos clases que declaran la misma propiedad con el mismo valor.                                                                                                                                                                     |
-| `allow`           | `(string \| [string, string])[]` | `[]`        | Patrones a silenciar, comparados con la clase **tal como está escrita** (prefijo de variante y `!` incluidos). Uno simple silencia cualquier par que involucre una clase que haga match; uno de dos elementos silencia esa combinación, en cualquier orden. |
-| `entryPoint`      | `string`                         | —           | Override por regla de `settings.tailwindcss.entryPoint`.                                                                                                                                                                                                    |
+| Opción            | Tipo                             | Por defecto | Descripción                                                                                                                                                                                                                                               |
+| ----------------- | -------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `reportRedundant` | `boolean`                        | `true`      | Reporta como `redundant` dos clases que declaran la misma propiedad con el mismo valor.                                                                                                                                                                   |
+| `allow`           | `(string \| [string, string])[]` | `[]`        | Patrones a silenciar, comparados con la clase **tal como está escrita** (prefijo de variante y `!` incluidos). Uno simple silencia cualquier par que involucre una clase que coincida; uno de dos elementos silencia esa combinación, en cualquier orden. |
+| `entryPoint`      | `string`                         | —           | Override por regla de `settings.tailwindcss.entryPoint`.                                                                                                                                                                                                  |
 
 ```jsonc
 {

--- a/packages/docs/es/rules/no-contradicting-variants.md
+++ b/packages/docs/es/rules/no-contradicting-variants.md
@@ -24,8 +24,8 @@ system genera de verdad para cada variante, así que cubre variantes que define 
 ninguna lista de nombres podría saber. Sin entry point la regla usa los nombres de arriba y se
 comporta igual que antes — nunca reporta que falte el design system.
 
-El match es por identidad exacta de la utility, así que `bg-white hover:bg-blue-500` queda intacto
-(valores distintos), igual que `flex hover:items-center` (utilities distintas).
+La coincidencia es por identidad exacta de la utility, así que `bg-white hover:bg-blue-500` queda
+intacto (valores distintos), igual que `flex hover:items-center` (utilities distintas).
 
 "La base aplica sin condiciones" sólo se sostiene cuando nada más pisa su propiedad. Una clase
 responsive que restablece una propiedad que un breakpoint intermedio le quitó es **load-bearing**,
@@ -101,7 +101,7 @@ es la lista de clases **final y autocontenida** del elemento. En una composició
 `tailwind-merge` — el patrón `cn`/`twMerge` + `cva` que usan los codebases estilo shadcn — un
 `className` suele ser un **fragmento de override** que se fusiona en runtime con clases aportadas en
 otro lado, muchas veces en otro módulo. Ahí la variante suele ser **load-bearing**: existe para
-ganarle a una clase del mismo grupo que el componente mergea desde su propio `cva`.
+ganarle a una clase del mismo grupo que el componente fusiona desde su propio `cva`.
 
 Toma `<Button className="bg-transparent hover:bg-transparent" />`, donde `Button` hace
 `twMerge(buttonVariants(), className)` y `buttonVariants()` aporta `hover:bg-accent`.
@@ -118,8 +118,8 @@ string que puede asegurar que es la lista final: un literal (o template) usado d
 que sean:
 
 - argumentos de una llamada merge-aware — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
-- el `className`/`class` de un **componente custom** (`<Button …>`, `<Field.Root …>`), que es opaco
-  — el componente puede volver a fusionarlo internamente;
+- el `className`/`class` de un **componente personalizado** (`<Button …>`, `<Field.Root …>`), que es
+  opaco — el componente puede volver a fusionarlo internamente;
 - asignados a una variable, o emitidos desde un tagged template.
 
 El trade-off es deliberado: acepta algunos falsos negativos (un par genuinamente redundante
@@ -130,5 +130,5 @@ como obviamente correctos e invitan a una regresión de render.
 
 - **Generadores de código / class-name builders** en un elemento nativo que a propósito emiten una
   base y una variante con la misma utility. (Los fragmentos de override que pasan por `cn`/`twMerge`
-  o por un componente custom ya se omiten — mira la sección de arriba.)
+  o por un componente personalizado ya se omiten — mira la sección de arriba.)
 - **Snapshots / fixtures** que necesitan el par redundante para ejercitar tooling downstream.

--- a/packages/docs/es/rules/no-dark-without-light.md
+++ b/packages/docs/es/rules/no-dark-without-light.md
@@ -25,15 +25,16 @@ Una clase cuenta como base de dos maneras:
   `visible dark:invisible`, `uppercase dark:normal-case`, `truncate dark:text-clip` y
   `sr-only dark:not-sr-only`, que antes se reportaban todos.
 
-El chequeo por propiedad es **aditivo**: todo lo que ya matcheaba por prefijo sigue matcheando, así
-que configurar un entry point solo puede hacer que esta regla reporte menos, nunca más. Sin él cae
-al chequeo por prefijo más una tabla interna pequeña para `display` y `position` (para que
+El chequeo por propiedad es **aditivo**: todo lo que ya coincidía por prefijo sigue coincidiendo,
+así que configurar un entry point solo puede hacer que esta regla reporte menos, nunca más. Sin él
+cae al chequeo por prefijo más una tabla interna pequeña para `display` y `position` (para que
 `block dark:hidden` funcione), y por eso los pares de arriba siguen reportándose cuando no hay CSS
 configurado.
 
 El conjunto de "variantes observadas" es configurable. Por defecto es sólo `dark`, pero el mismo
 shape aplica a cualquier otra variante estilo scheme (`contrast-more`, `motion-reduce`, `print`,
-variantes custom de data-attribute que tengas registradas, etc.) — mira la opción `variants` abajo.
+variantes personalizadas de data-attribute que tengas registradas, etc.) — mira la opción `variants`
+abajo.
 
 ## Opciones
 
@@ -43,13 +44,13 @@ variantes custom de data-attribute que tengas registradas, etc.) — mira la opc
 
 Lista de variantes que requieren una base sin variante en el mismo prefijo de utility.
 Sobreescríbelo cuando tu app usa otro mecanismo para cambiar de theme (e.g. `contrast-more:` para un
-tema de alto contraste, o una variante custom `theme-foo:` definida en tu CSS).
+tema de alto contraste, o una variante personalizada `theme-foo:` definida en tu CSS).
 
 ```jsonc
 { "tailwindcss/no-dark-without-light": ["error", { "variants": ["dark", "contrast-more"] }] }
 ```
 
-Si seteas `variants` a un array vacío la regla se convierte en un no-op — prefiere desactivarla
+Si estableces `variants` a un array vacío la regla se convierte en un no-op — prefiere desactivarla
 directamente en ese caso.
 
 ### `entryPoint`
@@ -87,13 +88,13 @@ la regla funciona sin él.
 // No hay variante observada → la regla no se mete con la cobertura de base
 <div className="hover:bg-blue-500" />
 
-// Variante custom + base correspondiente
+// Variante personalizada + base correspondiente
 <div
   className="bg-white contrast-more:bg-black"
   // con options: [{ variants: ["contrast-more"] }]
 />
 
-// Un string sólo-dark dentro de un helper de merge o en un componente custom es
+// Un string sólo-dark dentro de un helper de merge o en un componente personalizado es
 // un fragmento de override — la base light vive en otro lado, así que NO se
 // reporta. Mira "Composición y helpers de merge" abajo.
 cn("dark:bg-gray-900")
@@ -129,8 +130,8 @@ la lista final: un literal (o template) usado directamente como `class`/`classNa
 host nativo** (`<div>`, `<input>`, …). **No** reporta strings que sean:
 
 - argumentos de una llamada merge-aware — `cn(...)`, `twMerge(...)`, `cva(...)`, `tv(...)`, etc.;
-- el `className`/`class` de un **componente custom** (`<Field …>`, `<Card.Body …>`), que es opaco —
-  el componente puede volver a fusionarlo internamente;
+- el `className`/`class` de un **componente personalizado** (`<Field …>`, `<Card.Body …>`), que es
+  opaco — el componente puede volver a fusionarlo internamente;
 - asignados a una variable, o emitidos desde un tagged template.
 
 El trade-off es deliberado: acepta algunos falsos negativos (una clase genuinamente sólo-dark
@@ -144,4 +145,4 @@ como obviamente correctos e invitan a una regresión de render.
   sacar `dark`) antes que desactivarla.
 - **Strings de clases servidas desde el server** en un elemento nativo donde la base vive en CSS y
   sólo el override dark se emite desde JS. (Los fragmentos de override que pasan por `cn`/`twMerge`
-  o por un componente custom ya se omiten — mira la sección de arriba.)
+  o por un componente personalizado ya se omiten — mira la sección de arriba.)

--- a/packages/docs/es/rules/no-deprecated-classes.md
+++ b/packages/docs/es/rules/no-deprecated-classes.md
@@ -14,9 +14,9 @@ preservan en ambos lados de la reescritura.
 
 Con `settings.tailwindcss.entryPoint` (o el `entryPoint` propio de la regla) configurado, la lista
 se **deriva de tu design system**: se le pregunta al `canonicalizeCandidates` de Tailwind a qué
-mapea cada spelling de v3, y solo se reportan los que todavía compila Y todavía renombra. Eso cubre
+mapea cada grafía de v3, y solo se reportan los que todavía compila Y todavía renombra. Eso cubre
 renombres que una tabla hardcodeada no tenía — `break-words` → `wrap-break-word`, `order-none` →
-`order-0`, los spellings de posición reordenados `bg-left-top` → `bg-top-left` y `object-left-top` →
+`order-0`, las grafías de posición reordenadas `bg-left-top` → `bg-top-left` y `object-left-top` →
 `object-top-left` — y, más importante, una entrada desaparece sola cuando un Tailwind futuro deje de
 compilarla, en vez de sugerir un reemplazo para una clase que ya no existe.
 
@@ -53,7 +53,7 @@ sigue funcionando sin nada configurado y nunca emite un diagnóstico `designSyst
 ### ✓ Correcto
 
 ```tsx
-// Spellings post-migración
+// Grafías post-migración
 <div className="grow shrink-0" />
 
 <div className="bg-linear-to-r from-blue-500 to-purple-500" />
@@ -66,7 +66,7 @@ sigue funcionando sin nada configurado y nunca emite un diagnóstico `designSyst
 
 ## Interacciones con otras reglas
 
-- **`no-unknown-classes`**: omite silenciosamente cualquier spelling renombrado, preguntándole al
+- **`no-unknown-classes`**: omite silenciosamente cualquier grafía renombrada, preguntándole al
   design system en vez de a una lista propia, así que las dos reglas no pueden discrepar. No vas a
   recibir "unknown class" más "deprecated class" para `flex-grow` — solo la deprecación. Mantén
   ambas activas.
@@ -75,14 +75,14 @@ sigue funcionando sin nada configurado y nunca emite un diagnóstico `designSyst
   canonicalización), así que antes las dos reglas reportaban la misma clase con el mismo fix.
   `enforce-canonical` ahora se calla con todo lo que esté en la lista de renombres y mantiene el
   resto: formas válidas-pero-no-canónicas como `-m-0` → `m-0` y `start-2` → `inset-s-2` (`start-*`
-  es Tailwind actual, solo que no es el spelling canónico). Mantén ambas activas — con solo
+  es Tailwind actual, solo que no es la grafía canónica). Mantén ambas activas — con solo
   `enforce-canonical` los renombres quedan sin reportar.
 - **`no-restricted-classes`**: ortogonal. Esa la usas para bloquear clases válidas; esta solo se
-  dispara con la lista fija de renames v3→v4.
+  dispara con la lista fija de renombres v3→v4.
 
 ## Cuándo desactivarla
 
-- **Sigues en Tailwind v3** y quieres mantener los spellings de v3. Desactiva esta regla hasta que
+- **Sigues en Tailwind v3** y quieres mantener las grafías de v3. Desactiva esta regla hasta que
   migres.
 - **Mantienes a propósito una capa de clases v3-compatibles** al lado de v4 (por ejemplo, una
   librería compartida que apunta a ambos). En ese caso prefiere un `eslint-disable` puntual en el

--- a/packages/docs/es/rules/no-duplicate-classes.md
+++ b/packages/docs/es/rules/no-duplicate-classes.md
@@ -16,9 +16,9 @@ territorio de `no-contradicting-variants`). El fix preserva el whitespace que in
 La regla recorre la misma superficie de extracción que cualquier otra: atributos `className` /
 `class`, los 14 callees por defecto (`cn`, `clsx`, `cva`, `twMerge`, `tv`, `cx`, `classnames`,
 `ctl`, `twJoin`, `cc`, `clb`, `cnb`, `objstr`, `classed`), tagged templates como `` tw`...` ``,
-valores objeto en JSX (`classNames={ { root: "..." } }`) y variables que matchean los patrones de
-nombre por defecto (`className`, `classNames`, `classes`, `style`, `styles`). La extracción profunda
-para `cva` / `tv` / `classed` cubre `base`, `slots`, `variants`, `compoundVariants` y
+valores objeto en JSX (`classNames={ { root: "..." } }`) y variables que coinciden con los patrones
+de nombre por defecto (`className`, `classNames`, `classes`, `style`, `styles`). La extracción
+profunda para `cva` / `tv` / `classed` cubre `base`, `slots`, `variants`, `compoundVariants` y
 `compoundSlots`.
 
 ## Opciones

--- a/packages/docs/es/rules/no-hardcoded-colors.md
+++ b/packages/docs/es/rules/no-hardcoded-colors.md
@@ -10,14 +10,14 @@ que escribirías con un paint chip en la mano: hex (`bg-[#ff5733]`, `text-[#000]
 `hwb()`, y `color()`. La intención es la misma que `no-arbitrary-value` pero acotada exclusivamente
 al color, que es donde suele empezar el drift del design system.
 
-El valor se **escanea**, no se matchea desde su primer carácter, y la utility de la que cuelga es
+El valor se **escanea**, no se compara desde su primer carácter, y la utility de la que cuelga es
 irrelevante. Eso importa más de lo que parece:
 
 - un color en medio de un shorthand cuenta — `shadow-[0_1px_2px_#000]` es un negro hardcodeado;
 - también las utilities que ninguna lista de prefijos mantuvo al día — `inset-ring-[#000]`,
   `inset-shadow-[#000]`;
-- y también las propiedades arbitrarias, que ningún prefijo podría matchear — `[color:#f00]`,
-  `[--brand:#f00]`.
+- y también las propiedades arbitrarias, con las que ningún prefijo podría coincidir —
+  `[color:#f00]`, `[--brand:#f00]`.
 
 Hay dos exclusiones deliberadas, y son la razón de que esto sea un escáner y no un regex: un `#`
 dentro de un **string entre comillas** es texto (`content-['#fff']`), y un `#` dentro de **`url()`**
@@ -44,9 +44,9 @@ decisión humana.
 
 `string[]`, default `[]`.
 
-Strings exactos de clases para whitelistear. Los matches son literales (no hay prefix match ni
-regex), así que puedes permitir escapes puntuales sin abrir más la puerta. Útil para el hex
-ocasional mandado por brand en un único componente de assets.
+Strings exactos de clases para incluir en la allowlist. Las coincidencias son literales (no hay
+coincidencia por prefijo ni regex), así que puedes permitir escapes puntuales sin abrir más la
+puerta. Útil para el hex ocasional mandado por brand en un único componente de assets.
 
 ```jsonc
 {
@@ -109,7 +109,7 @@ ocasional mandado por brand en un único componente de assets.
   Usa `no-hardcoded-colors` sola cuando quieres el mensaje específico de color y toleras otros
   arbitrary values; usa ambas para un diagnóstico más claro sobre el drift de color.
 - **`prefer-theme-tokens`**: complementaria. `prefer-theme-tokens` le pregunta al design system si
-  existe un color `@theme` que matchee y lo sugiere; esta regla dispara igual exista o no el token,
+  existe un color `@theme` que coincida y lo sugiere; esta regla dispara igual exista o no el token,
   así que atrapa el drift más temprano (antes de definir el token).
 - **`no-unknown-classes`**: ortogonal. Los arbitrary hardcodeados son sintaxis _válida_ de Tailwind,
   así que `no-unknown-classes` no los va a marcar. Deberían estar ambas activas.

--- a/packages/docs/es/rules/no-restricted-classes.md
+++ b/packages/docs/es/rules/no-restricted-classes.md
@@ -6,7 +6,7 @@
 
 El veto manual. Te deja bloquear clases específicas de Tailwind — por nombre exacto o por patrón
 regex — y mostrar un mensaje configurable explicando por qué. Sin design system, sin heurísticas: si
-la clase matchea, la regla dispara.
+la clase coincide, la regla dispara.
 
 Usos típicos: dejar atrás utilities legacy que un refactor quiere sacar (`float-*` en codebases
 solo-flexbox), mantener un color de brand deprecado fuera del código nuevo, prohibir hacks de
@@ -24,9 +24,10 @@ Sin opciones, la regla es no-op. Configura al menos una de `classes` o `patterns
 
 `string[]`, default `[]`.
 
-Nombres exactos de clases a prohibir. Los matches son literales — `"hidden"` matchea la clase bare
-`hidden` y la misma clase en cualquier parte de un class string (`"flex hidden items-center"`), pero
-_no_ matchea `"sr-hidden"` ni `"hover:hidden"`. Úsalo para una ban list chica y explícita.
+Nombres exactos de clases a prohibir. Las coincidencias son literales — `"hidden"` coincide con la
+clase bare `hidden` y la misma clase en cualquier parte de un class string
+(`"flex hidden items-center"`), pero _no_ coincide con `"sr-hidden"` ni `"hover:hidden"`. Úsalo para
+una ban list chica y explícita.
 
 ```jsonc
 {
@@ -43,8 +44,8 @@ _no_ matchea `"sr-hidden"` ni `"hover:hidden"`. Úsalo para una ban list chica y
 Una lista de patrones regex (pasados como strings, compilados con `new RegExp`) con un mensaje
 opcional. Úsalo cuando quieres prohibir una familia entera (`^float-`, `^text-(red|orange)-`) o
 cuando una lista literal explotaría. Los patrones se testean contra la clase completa incluyendo
-variants, así que `^hover:bg-red-` matchea `hover:bg-red-500`. Los mensajes custom aparecen después
-del nombre de la clase y hacen que el diagnóstico sea accionable.
+variants, así que `^hover:bg-red-` coincide con `hover:bg-red-500`. Los mensajes personalizados
+aparecen después del nombre de la clase y hacen que el diagnóstico sea accionable.
 
 ```jsonc
 {
@@ -57,8 +58,8 @@ del nombre de la clase y hacen que el diagnóstico sea accionable.
 }
 ```
 
-Si una clase matchea tanto `classes` como un pattern, gana el match exacto y la regla reporta una
-sola vez. Si no, gana el primer pattern que matchea.
+Si una clase coincide tanto con `classes` como con un pattern, gana la coincidencia exacta y la
+regla reporta una sola vez. Si no, gana el primer pattern que coincide.
 
 ## Ejemplos
 
@@ -72,7 +73,7 @@ sola vez. Si no, gana el primer pattern que matchea.
 // Prohibida en el medio de un class string
 <div className="flex hidden items-center" />
 
-// Prohibida vía pattern con mensaje custom
+// Prohibida vía pattern con mensaje personalizado
 <div className="float-left" />
 // con patterns: [{ pattern: "^float-", message: "Usa flexbox" }]
 // → '"float-left" is restricted: Usa flexbox'
@@ -90,7 +91,7 @@ cn("float-right")
 // Clase fuera de la ban list
 <div className="flex items-center" />
 
-// El variant cambia la clase — `hover:hidden` no matchea `hidden`
+// El variant cambia la clase — `hover:hidden` no coincide con `hidden`
 <div className="hover:hidden" />
 ```
 

--- a/packages/docs/es/rules/no-unknown-classes.md
+++ b/packages/docs/es/rules/no-unknown-classes.md
@@ -12,7 +12,7 @@ incluye una sugerencia y un quick-fix de editor para reemplazarla.
 El design system aquí significa **todo lo que Tailwind generaría para tu stylesheet**: las utilities
 core (`flex`, `bg-red-500`, `hover:underline`), cualquier token `@theme` que definiste (`bg-card`,
 `text-brand-foreground`), cualquier clase registrada por plugins (`prose`, `animate-in`, etc.), y
-cualquier CSS custom que escribiste inline.
+cualquier CSS personalizado que escribiste inline.
 
 DS-dependiente — requiere `settings.tailwindcss.entryPoint`. Cuando el design system no puede
 cargar, la regla emite un único diagnóstico fatal `designSystemUnavailable` por archivo en vez de
@@ -129,10 +129,10 @@ El prefijo se detecta automáticamente desde tu `entryPoint`; no hay nada extra 
 
 `string[]`, default `[]`.
 
-Nombres exactos de clases para whitelistear. Usa esto cuando la clase se genera en runtime (template
-strings que el plugin no puede resolver estáticamente) o cuando deliberadamente no es parte de tu
-design system pero quieres que sobreviva al linting. Los matches son literales — `"my-special"` no
-matchea `"hover:my-special"`.
+Nombres exactos de clases para incluir en la allowlist. Usa esto cuando la clase se genera en
+runtime (template strings que el plugin no puede resolver estáticamente) o cuando deliberadamente no
+es parte de tu design system pero quieres que sobreviva al linting. Las coincidencias son literales
+— `"my-special"` no coincide con `"hover:my-special"`.
 
 ```jsonc
 { "tailwindcss/no-unknown-classes": ["error", { "allowlist": ["my-runtime-class", "legacy-button"] }] }

--- a/packages/docs/es/rules/no-unnecessary-arbitrary-value.md
+++ b/packages/docs/es/rules/no-unnecessary-arbitrary-value.md
@@ -14,8 +14,8 @@ primer hit, las sugerencias cubren el resto en el mismo string. Variants e `!` (
 preservan.
 
 El chequeo se dispara solo cuando hay un valor arbitrario en la utility (`hasArbitraryValue(cls)` es
-true) Y el cache devuelve un match en `getNamedEquivalent`. Eso mantiene la regla barata y enfocada
-— sin resolución fuzzy, sin round-trip al DS por cada clase.
+true) Y el cache devuelve una coincidencia en `getNamedEquivalent`. Eso mantiene la regla barata y
+enfocada — sin resolución fuzzy, sin round-trip al DS por cada clase.
 
 DS-dependiente — requiere `settings.tailwindcss.entryPoint`. Si el design system no puede cargar, la
 regla emite un único diagnóstico fatal `designSystemUnavailable` por archivo en vez de pasar en
@@ -23,9 +23,9 @@ silencio.
 
 ## Opciones
 
-Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, defaultea
-a `settings.tailwindcss.entryPoint`). Configura el entry point en `settings.tailwindcss.entryPoint`
-para todo el proyecto en vez de por-regla cuando puedas.
+Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, por
+defecto es `settings.tailwindcss.entryPoint`). Configura el entry point en
+`settings.tailwindcss.entryPoint` para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Ejemplos
 
@@ -59,10 +59,12 @@ para todo el proyecto en vez de por-regla cuando puedas.
 ## Interacciones con otras reglas
 
 - **`enforce-canonical`**: complementaria, no hay doble-fire. Las dos actúan solo cuando la forma
-  arbitraria y su reemplazo nombrado emiten CSS **idéntico**; se reparten por forma. Esta regla es
-  dueña del caso directo arbitrario→nombrado (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` →
-  `bg-red-500`); `enforce-canonical` es dueña de los renombres canónicos y la normalización de
-  sintaxis de variables CSS. Las dos parten el espacio arbitrario→nombrado de forma limpia.
+  arbitraria y su reemplazo nombrado emiten CSS **idéntico**. Esta regla es dueña del caso directo
+  arbitrario→nombrado (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`);
+  `enforce-canonical` es dueña de las canonicalizaciones donde el arbitrario mapea a una utility con
+  otro nombre (`rounded-[var(--radius-sm)]` → `rounded-sm`). Las dos parten el espacio
+  arbitrario→nombrado de forma limpia — y el swap simple `[var(--x)]` ↔ `(--x)` es de
+  `enforce-consistent-variable-syntax`, no de ninguna de las dos.
 - **`prefer-scale-token`**: dueña de lo que ninguna de las anteriores toca — un valor que solo es
   _numéricamente_ igual a un paso de la escala o a un token de tema (`p-[2px]` → `p-0.5`), cuyo
   texto CSS difiere (`calc(var(--spacing) * 0.5)` vs `2px`). Solo-reporte, apagada por defecto.
@@ -78,5 +80,5 @@ para todo el proyecto en vez de por-regla cuando puedas.
 - **A propósito mantienes valores arbitrarios por legibilidad** — algunos equipos prefieren
   `w-[200px]` a un alias de token cuando el valor es one-off o pixel-precise. Desactiva la regla y
   apóyate en `prefer-theme-tokens` + `enforce-canonical` para los casos que sí quieres marcar.
-- **Migrando desde otro toolchain** que generaba valores arbitrarios para todo — corrila como `warn`
-  hasta terminar el cleanup, después súbela a `error`.
+- **Migrando desde otro toolchain** que generaba valores arbitrarios para todo — ejecútala como
+  `warn` hasta terminar el cleanup, después súbela a `error`.

--- a/packages/docs/es/rules/prefer-theme-tokens.md
+++ b/packages/docs/es/rules/prefer-theme-tokens.md
@@ -13,11 +13,15 @@ como la forma bracket (`prefix-[var(--name)]`) se reconocen, y los modificadores
 (`/80`), variants y `!` (important) se preservan.
 
 El candidato `${prefix}-${varName}` tiene que ser una utility real en tu DS — la regla consulta
-`cache.isValid(candidate)`. Después omite explícitamente cualquier candidato que
+`cache.isValid(candidate)`. Pero existir por nombre no alcanza: el token con nombre tiene que
+SIGNIFICAR lo mismo. `@theme inline { --color-primary: var(--primary) }` hace que `bg-primary` y
+`bg-(--primary)` sean la misma declaración, mientras que un `--color-primary` literal junto a un
+`--primary` no relacionado los vuelve colores distintos — y esta regla autofixea. Así que el
+reemplazo solo se propone cuando la declaración del token resuelve de vuelta a la variable que
+escribiste, o cuando esa variable no está definida en ningún lado (en cuyo caso la declaración
+actual es CSS muerto y el token solo puede ser una mejora). Después omite cualquier candidato que
 `cache.getNamedEquivalent` también resolvería, porque ese caso es propiedad de
-`no-unnecessary-arbitrary-value` (mismo CSS, sin doble-fire). Lo que queda es exactamente el espacio
-solo-heurístico: la utility con nombre existe en tu theme pero no comparte una shape bracket-
-equivalente con el original.
+`no-unnecessary-arbitrary-value` (mismo CSS, sin doble-fire).
 
 DS-dependiente — requiere `settings.tailwindcss.entryPoint`. Si el design system no puede cargar, la
 regla emite un único diagnóstico fatal `designSystemUnavailable` por archivo en vez de pasar en
@@ -25,9 +29,9 @@ silencio.
 
 ## Opciones
 
-Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, defaultea
-a `settings.tailwindcss.entryPoint`). Configura el entry point en `settings.tailwindcss.entryPoint`
-para todo el proyecto en vez de por-regla cuando puedas.
+Esta regla no tiene opciones propias más allá del override estándar `entryPoint` (string, por
+defecto es `settings.tailwindcss.entryPoint`). Configura el entry point en
+`settings.tailwindcss.entryPoint` para todo el proyecto en vez de por-regla cuando puedas.
 
 ## Ejemplos
 
@@ -60,7 +64,7 @@ Asumiendo un theme estilo shadcn con tokens como `--border`, `--primary`, `--bac
 
 <div className="border-l-border" />
 
-// Variable sin utility nombrada que matchee — déjala
+// Variable sin utility nombrada que coincida — déjala
 <div className="border-(--no-such-token)" />
 ```
 

--- a/packages/docs/es/settings.md
+++ b/packages/docs/es/settings.md
@@ -4,13 +4,13 @@ Cada setting vive bajo `settings.tailwindcss` en tu `.oxlintrc.json`.
 
 ## `entryPoint` (obligatorio)
 
-Ruta al archivo CSS que tiene `@import "tailwindcss";` y (opcionalmente) tus customizaciones de
+Ruta al archivo CSS que tiene `@import "tailwindcss";` y (opcionalmente) tus personalizaciones de
 `@theme { ... }`. El plugin lee este archivo para construir el design system que cada regla
 consulta.
 
 Es obligatorio para las reglas DS-dependientes, que fallan ruidosamente sin él. Hay un segundo grupo
 **DS-opcional**: esas funcionan sin nada configurado y ganan precisión cuando está —
-`enforce-shorthand` verifica cada merge contra el CSS emitido, `no-dark-without-light` agrupa la
+`enforce-shorthand` verifica cada fusión contra el CSS emitido, `no-dark-without-light` agrupa la
 base por propiedad declarada, `no-deprecated-classes` deriva su lista de renombres, y las reglas
 direccionales confirman que la clase que sugieren exista. Mira la
 [referencia de defaults](./rules/#referencia-de-defaults) para saber qué regla está en qué grupo.
@@ -42,10 +42,10 @@ desde la raíz del workspace (editor). Ver [Monorepos](/es/monorepo).
 
 Los globs (la forma de mapping) se evalúan contra el path del archivo lintado relativo al directorio
 donde corre oxlint. Sintaxis soportada: `*` (cualquier caracter excepto `/`), `**` (cualquier
-profundidad), segmentos literales. El orden importa — el primer entry que matchea gana. Se
+profundidad), segmentos literales. El orden importa — el primer entry que coincide gana. Se
 recomienda agregar un fallback `"**"` para archivos fuera de los globs explícitos.
 
-`files` también acepta un arreglo de globs (`string[]`): el entry matchea si el archivo lintado
+`files` también acepta un arreglo de globs (`string[]`): el entry coincide si el archivo lintado
 coincide con cualquiera de ellos.
 
 **v0.x → v1.0.0**: la forma legacy `string[]` se removió. Pasarla en v1 lanza
@@ -84,7 +84,7 @@ el resto del run falla rápido, y el estado se auto-sana cuando la máquina se r
 
 `boolean`, default `false`. También se activa con la variable de entorno `DEBUG=oxlint-tailwindcss`.
 
-Cuando está activo, el plugin loguea a stderr:
+Cuando está activo, el plugin registra en stderr:
 
 - Qué entry point CSS resolvió para cada archivo lintado.
 - Carga exitosa del DS y cache hits.
@@ -132,14 +132,14 @@ El plugin escanea estas ubicaciones por defecto:
 | Tags                 | `` tw`...` `` (tagged template literals)                                                                           |
 | Patrones de variable | `/^classNames?$/`, `/^classes$/`, `/^styles?$/`                                                                    |
 
-`attributes`, `callees` y `tags` matchean por **nombre exacto**. Dos ejes matchean por **regex**, y
-su alcance difiere — fíjate cuál necesitas:
+`attributes`, `callees` y `tags` coinciden por **nombre exacto**. Dos ejes coinciden por **regex**,
+y su alcance difiere — fíjate cuál necesitas:
 
-- **`attributePatterns`** matchea **nombres de atributos JSX**. Úsalo para convenciones `*ClassName`
-  sin listar cada prop — p. ej. `["ClassName$"]` captura `contentContainerClassName` y
+- **`attributePatterns`** coincide con **nombres de atributos JSX**. Úsalo para convenciones
+  `*ClassName` sin listar cada prop — p. ej. `["ClassName$"]` captura `contentContainerClassName` y
   `tintColorClassName` en componentes de React Native / Uniwind. Es aditivo a la lista exacta de
   `attributes`; vacío por defecto, así que el match exacto sigue siendo el default.
-- **`variablePatterns`** matchea **solo nombres de declaración de variables**
+- **`variablePatterns`** coincide con **solo nombres de declaración de variables**
   (`const fooClassName = "..."`), **no** atributos JSX. Su default `/^classNames?$/` coincide en
   escritura con el atributo `className`, pero son cosas distintas — una entrada de
   `variablePatterns` nunca afecta props JSX.
@@ -175,7 +175,7 @@ O quita de los defaults:
 }
 ```
 
-Las exclusiones de `variablePatterns` matchean contra `RegExp.source` literal.
+Las exclusiones de `variablePatterns` coinciden con `RegExp.source` literal.
 
 ## Cheat sheet
 

--- a/packages/docs/es/setup.md
+++ b/packages/docs/es/setup.md
@@ -93,8 +93,8 @@ Si quieres un set "bendecido" que detecte problemas reales sin ser ruidoso, acti
 Agrega reglas extra a medida que las necesites:
 
 - `enforce-logical` / `enforce-physical` si tienes una preferencia de dirección.
-- `no-arbitrary-value`, `no-hardcoded-colors`, `no-restricted-classes` si quieres enforcement de
-  design-system.
+- `no-arbitrary-value`, `no-hardcoded-colors`, `no-restricted-classes` si quieres imponer la
+  disciplina del design system.
 - `prefer-theme-tokens` para preferir utilidades nombradas sobre referencias `var()`.
 
 El catálogo completo está en [Reglas](/es/rules/). Cada página documenta el comportamiento exacto,
@@ -168,14 +168,14 @@ y plugins como `@tailwindcss/typography`.
 ## 7. Yendo más allá
 
 - **Ajustar extractors**: por defecto el plugin escanea `className` / `class`, ~14 callees (`cn`,
-  `clsx`, `cva`, `twMerge`, …), templates con `tw`, y variables que matchean `/^classNames?$/`,
+  `clsx`, `cva`, `twMerge`, …), templates con `tw`, y variables que coinciden con `/^classNames?$/`,
   `/^classes$/`, `/^styles?$/`. Agrega `attributes`, `attributePatterns` (regex para props tipo
   `*ClassName`), `callees`, `tags`, `variablePatterns`, o quita defaults vía `exclude`. Mira la
   [referencia de settings](/es/settings).
 - **Ajustar timeouts**: `settings.tailwindcss.timeout` (ms, default 60000) limita cuánto espera el
   plugin al worker (hilo) que precomputa el design system. CI lento puede necesitar subirlo.
-- **Logging de debug**: `settings.tailwindcss.debug: true` (o `DEBUG=oxlint-tailwindcss`) loguea qué
-  CSS entry point resolvió por cada archivo lintado.
+- **Registro de depuración**: `settings.tailwindcss.debug: true` (o `DEBUG=oxlint-tailwindcss`)
+  registra qué CSS entry point resolvió por cada archivo lintado.
 - **Qué Tailwind se usa**: el plugin carga el motor de Tailwind de _tu_ proyecto, resuelto por entry
   point, así el linter y tu build coinciden. Si el motor resuelto es un major más nuevo que el
   plugin (un futuro Tailwind 5) o tiene un drift de major respecto de tu build, falla fuerte;

--- a/packages/docs/rules/_extras/enforce-canonical.md
+++ b/packages/docs/rules/_extras/enforce-canonical.md
@@ -4,10 +4,11 @@ Asks the design system for the canonical form of every utility in your code and 
 that aren't already canonical. "Canonical" is whatever `canonicalizeCandidates()` from
 `@tailwindcss/node` returns — the same source of truth used by prettier-plugin-tailwindcss, oxfmt,
 and the official Tailwind tooling. Examples: `-m-0` → `m-0` (no negative is needed for a zero),
-`bg-gradient-to-r` → `bg-linear-to-r`, `break-words` → `wrap-break-word`, `start-2` → `inset-s-2`,
-`flex-grow-1` → `grow`, `flex-grow-[2]` → `grow-2` (an arbitrary value whose named form emits
-identical CSS), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. Auto- fix lands the first
-hit, suggestions cover the rest in the same string.
+`start-2` → `inset-s-2`, `flex-grow-[2]` → `grow-2` (an arbitrary value whose named form emits
+identical CSS), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. Auto-fix lands the first
+hit, suggestions cover the rest in the same string. The v3 renames (`bg-gradient-to-r` →
+`bg-linear-to-r`, `break-words` → `wrap-break-word`) are owned by `no-deprecated-classes`, not this
+rule — see Interactions.
 
 Named classes resolve through a precomputed in-memory `canonicalMap` (sub-microsecond). Arbitrary
 values (`p-[2px]`, `bg-(--c)`) go through the `canonicalize-service` worker because they need a live
@@ -31,9 +32,6 @@ for the whole project instead of per-rule whenever possible.
 // Negative-of-zero is just zero
 <div className="-m-0 -mt-0" />
 
-// v3 spellings the official canonicalize step rewrites
-<div className="bg-gradient-to-r break-words" />
-
 // Logical inset shorthand → canonical inset-s-* / inset-e-*
 <div className="start-2 end-4" />
 
@@ -41,7 +39,7 @@ for the whole project instead of per-rule whenever possible.
 <div className="flex-grow-[2]" />
 
 // Variants and important are preserved
-<div className="hover:!break-words" />
+<div className="hover:!flex-grow-[2]" />
 ```
 
 ### ✓ Correct
@@ -49,13 +47,11 @@ for the whole project instead of per-rule whenever possible.
 ```tsx
 <div className="m-0 mt-0" />
 
-<div className="bg-linear-to-r wrap-break-word" />
-
 <div className="inset-s-2 inset-e-4" />
 
 <div className="grow-2" />
 
-<div className="hover:!wrap-break-word" />
+<div className="hover:!grow-2" />
 ```
 
 ## Interactions with other rules

--- a/packages/docs/rules/_extras/enforce-consistent-important-position.md
+++ b/packages/docs/rules/_extras/enforce-consistent-important-position.md
@@ -15,17 +15,17 @@ it runs everywhere, including in projects that haven't wired up the design syste
 
 `'prefix' | 'suffix'`, default `'suffix'`.
 
-`'suffix'` is the Tailwind v4 canonical form (`flex!`, `hover:text-red!`) and matches what
-`enforce-canonical` would produce, so it's the recommended choice for new projects. `'prefix'` keeps
-the v3 form (`!flex`, `hover:!text-red`) — pick it only if your codebase is still on the v3 spelling
-and you don't want to migrate yet.
+`'suffix'` is the Tailwind v4 canonical form (`flex!`, `hover:text-red!`), so it's the recommended
+choice for new projects. `'prefix'` keeps the v3 form (`!flex`, `hover:!text-red`) — pick it only if
+your codebase is still on the v3 spelling and you don't want to migrate yet.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-important-position": ["error", { "position": "suffix" }] }
 ```
 
-Note: setting `position: 'prefix'` will conflict with `enforce-canonical`, which normalizes to
-suffix. Use one or the other.
+Note: `enforce-canonical` preserves whichever `!` position you write (it does not normalize it), so
+either `position` value composes with it cleanly. This rule is the single source of truth for `!`
+placement.
 
 ## Examples
 
@@ -59,9 +59,9 @@ suffix. Use one or the other.
 
 ## Interactions with other rules
 
-- **`enforce-canonical`**: with `position: 'suffix'` (the default) the two rules agree. With
-  `position: 'prefix'` they fight — canonical rewrites suffix to its preferred form on every fix
-  pass. Stick with suffix unless you have a strong reason.
+- **`enforce-canonical`**: preserves the `!` position you write (prefix, suffix, or none) rather
+  than normalizing it, so it never fights this rule no matter which `position` you pick. This rule
+  is the single source of truth for `!` placement.
 - **`enforce-sort-order`**: order-independent of important position. Both prefix and suffix forms
   sort identically.
 - **`no-unknown-classes`**: looks up the bare utility, stripping `!` on either side, so neither form
@@ -71,5 +71,5 @@ suffix. Use one or the other.
 
 - **The codebase deliberately mixes both forms** (e.g. legacy v3 files alongside fresh v4 ones
   during a migration). Re-enable once the migration is done.
-- **You're already running `enforce-canonical`** and trust it to normalize `!` position as part of
-  canonicalization — leaving this rule on is harmless but redundant.
+- **You don't care about `!` position consistency.** No other rule enforces it — `enforce-canonical`
+  preserves whatever position you wrote — so disabling this one means `!` placement goes unchecked.

--- a/packages/docs/rules/_extras/enforce-consistent-variable-syntax.md
+++ b/packages/docs/rules/_extras/enforce-consistent-variable-syntax.md
@@ -61,10 +61,20 @@ prefers the longer form for grepability.
 
 ## Interactions with other rules
 
-- **`enforce-canonical`**: doesn't touch variable syntax. Canonical normalizes utility names; this
-  rule normalizes the variable form. Both run together cleanly.
-- **`no-unnecessary-arbitrary-value`**: also targets arbitrary values but for the named-equivalent
-  case (`bg-[#ff0000]` → `bg-red-500`). Disjoint from this rule.
+- **`enforce-canonical`**: this rule is the single owner of variable syntax. Because `bg-(--x)` is
+  Tailwind's canonical form, `enforce-canonical` would otherwise report the same `bg-[var(--x)]` →
+  `bg-(--x)` swap; instead it **cedes** the plain bracket↔paren conversion to this rule (the same
+  way it cedes v3 renames to `no-deprecated-classes`). That prevents a duplicate diagnostic and,
+  when this rule is set to `explicit`, an autofix fight. `enforce-canonical` still handles variable
+  canonicalizations that _aren't_ a plain swap — a value that maps to a named token
+  (`rounded-[var(--radius-sm)]` → `rounded-sm`) or an opacity-modifier form
+  (`text-[var(--color-text)]/90` → `text-(--color-text)/90`).
+- **`no-unnecessary-arbitrary-value`**: mostly disjoint — it converts an arbitrary value to its
+  named equivalent (`bg-[#ff0000]` → `bg-red-500`). They overlap only when a variable's value
+  matches a named utility: on `bg-[var(--color-red-500)]` that rule fires (→ `bg-red-500`) and this
+  one fires too (→ `bg-(--color-red-500)`). The two propose different targets, so enable the one
+  whose policy you want — or run `no-unnecessary-arbitrary-value` first if you prefer the named
+  utility.
 - **`prefer-theme-tokens`**: when a CSS variable matches a `@theme` token, that rule swaps to the
   named utility (`bg-(--primary)` → `bg-primary` if `--primary` is declared in `@theme`). Run that
   one before this one if you want both transforms.

--- a/packages/docs/rules/_extras/no-unnecessary-arbitrary-value.md
+++ b/packages/docs/rules/_extras/no-unnecessary-arbitrary-value.md
@@ -54,9 +54,11 @@ for the whole project instead of per-rule whenever possible.
 
 - **`enforce-canonical`**: complementary, no double-fire. Both act only when the arbitrary form and
   its named replacement emit **identical** CSS. This rule owns the direct arbitrary→named case
-  (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`); `enforce-canonical` owns
-  canonical renames and CSS-var syntax normalization. The two carve up the arbitrary→named space
-  cleanly.
+  (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`); `enforce-canonical` owns the
+  canonicalizations where the arbitrary maps to a differently-named utility
+  (`rounded-[var(--radius-sm)]` → `rounded-sm`). The two carve up the arbitrary→named space cleanly
+  — and the plain `[var(--x)]` ↔ `(--x)` syntax swap is `enforce-consistent-variable-syntax`'s, not
+  either of theirs.
 - **`prefer-scale-token`**: owns what neither of the above touches — a value that is only
   _numerically_ equal to a scale step or theme token (`p-[2px]` → `p-0.5`), whose CSS text differs
   (`calc(var(--spacing) * 0.5)` vs `2px`). Report-only, off by default.

--- a/packages/docs/rules/enforce-canonical.md
+++ b/packages/docs/rules/enforce-canonical.md
@@ -8,10 +8,11 @@ Asks the design system for the canonical form of every utility in your code and 
 that aren't already canonical. "Canonical" is whatever `canonicalizeCandidates()` from
 `@tailwindcss/node` returns — the same source of truth used by prettier-plugin-tailwindcss, oxfmt,
 and the official Tailwind tooling. Examples: `-m-0` → `m-0` (no negative is needed for a zero),
-`bg-gradient-to-r` → `bg-linear-to-r`, `break-words` → `wrap-break-word`, `start-2` → `inset-s-2`,
-`flex-grow-1` → `grow`, `flex-grow-[2]` → `grow-2` (an arbitrary value whose named form emits
-identical CSS), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. Auto- fix lands the first
-hit, suggestions cover the rest in the same string.
+`start-2` → `inset-s-2`, `flex-grow-[2]` → `grow-2` (an arbitrary value whose named form emits
+identical CSS), `text-[var(--color-text)]/90` → `text-(--color-text)/90`. Auto-fix lands the first
+hit, suggestions cover the rest in the same string. The v3 renames (`bg-gradient-to-r` →
+`bg-linear-to-r`, `break-words` → `wrap-break-word`) are owned by `no-deprecated-classes`, not this
+rule — see Interactions.
 
 Named classes resolve through a precomputed in-memory `canonicalMap` (sub-microsecond). Arbitrary
 values (`p-[2px]`, `bg-(--c)`) go through the `canonicalize-service` worker because they need a live
@@ -35,9 +36,6 @@ for the whole project instead of per-rule whenever possible.
 // Negative-of-zero is just zero
 <div className="-m-0 -mt-0" />
 
-// v3 spellings the official canonicalize step rewrites
-<div className="bg-gradient-to-r break-words" />
-
 // Logical inset shorthand → canonical inset-s-* / inset-e-*
 <div className="start-2 end-4" />
 
@@ -45,7 +43,7 @@ for the whole project instead of per-rule whenever possible.
 <div className="flex-grow-[2]" />
 
 // Variants and important are preserved
-<div className="hover:!break-words" />
+<div className="hover:!flex-grow-[2]" />
 ```
 
 ### ✓ Correct
@@ -53,13 +51,11 @@ for the whole project instead of per-rule whenever possible.
 ```tsx
 <div className="m-0 mt-0" />
 
-<div className="bg-linear-to-r wrap-break-word" />
-
 <div className="inset-s-2 inset-e-4" />
 
 <div className="grow-2" />
 
-<div className="hover:!wrap-break-word" />
+<div className="hover:!grow-2" />
 ```
 
 ## Interactions with other rules

--- a/packages/docs/rules/enforce-consistent-important-position.md
+++ b/packages/docs/rules/enforce-consistent-important-position.md
@@ -1,7 +1,8 @@
 # enforce-consistent-important-position
 
 > Enforce consistent position of the important (!) modifier. Default: suffix (Tailwind v4 canonical
-> form). Note: using "prefix" may conflict with enforce-canonical which normalizes to suffix.
+> form). This rule is the single source of truth for ! placement — enforce-canonical preserves the
+> position you wrote, so the two never conflict.
 
 ## What this rule does
 
@@ -20,17 +21,17 @@ it runs everywhere, including in projects that haven't wired up the design syste
 
 `'prefix' | 'suffix'`, default `'suffix'`.
 
-`'suffix'` is the Tailwind v4 canonical form (`flex!`, `hover:text-red!`) and matches what
-`enforce-canonical` would produce, so it's the recommended choice for new projects. `'prefix'` keeps
-the v3 form (`!flex`, `hover:!text-red`) — pick it only if your codebase is still on the v3 spelling
-and you don't want to migrate yet.
+`'suffix'` is the Tailwind v4 canonical form (`flex!`, `hover:text-red!`), so it's the recommended
+choice for new projects. `'prefix'` keeps the v3 form (`!flex`, `hover:!text-red`) — pick it only if
+your codebase is still on the v3 spelling and you don't want to migrate yet.
 
 ```jsonc
 { "tailwindcss/enforce-consistent-important-position": ["error", { "position": "suffix" }] }
 ```
 
-Note: setting `position: 'prefix'` will conflict with `enforce-canonical`, which normalizes to
-suffix. Use one or the other.
+Note: `enforce-canonical` preserves whichever `!` position you write (it does not normalize it), so
+either `position` value composes with it cleanly. This rule is the single source of truth for `!`
+placement.
 
 ## Examples
 
@@ -64,9 +65,9 @@ suffix. Use one or the other.
 
 ## Interactions with other rules
 
-- **`enforce-canonical`**: with `position: 'suffix'` (the default) the two rules agree. With
-  `position: 'prefix'` they fight — canonical rewrites suffix to its preferred form on every fix
-  pass. Stick with suffix unless you have a strong reason.
+- **`enforce-canonical`**: preserves the `!` position you write (prefix, suffix, or none) rather
+  than normalizing it, so it never fights this rule no matter which `position` you pick. This rule
+  is the single source of truth for `!` placement.
 - **`enforce-sort-order`**: order-independent of important position. Both prefix and suffix forms
   sort identically.
 - **`no-unknown-classes`**: looks up the bare utility, stripping `!` on either side, so neither form
@@ -76,5 +77,5 @@ suffix. Use one or the other.
 
 - **The codebase deliberately mixes both forms** (e.g. legacy v3 files alongside fresh v4 ones
   during a migration). Re-enable once the migration is done.
-- **You're already running `enforce-canonical`** and trust it to normalize `!` position as part of
-  canonicalization — leaving this rule on is harmless but redundant.
+- **You don't care about `!` position consistency.** No other rule enforces it — `enforce-canonical`
+  preserves whatever position you wrote — so disabling this one means `!` placement goes unchecked.

--- a/packages/docs/rules/enforce-consistent-variable-syntax.md
+++ b/packages/docs/rules/enforce-consistent-variable-syntax.md
@@ -65,10 +65,20 @@ prefers the longer form for grepability.
 
 ## Interactions with other rules
 
-- **`enforce-canonical`**: doesn't touch variable syntax. Canonical normalizes utility names; this
-  rule normalizes the variable form. Both run together cleanly.
-- **`no-unnecessary-arbitrary-value`**: also targets arbitrary values but for the named-equivalent
-  case (`bg-[#ff0000]` → `bg-red-500`). Disjoint from this rule.
+- **`enforce-canonical`**: this rule is the single owner of variable syntax. Because `bg-(--x)` is
+  Tailwind's canonical form, `enforce-canonical` would otherwise report the same `bg-[var(--x)]` →
+  `bg-(--x)` swap; instead it **cedes** the plain bracket↔paren conversion to this rule (the same
+  way it cedes v3 renames to `no-deprecated-classes`). That prevents a duplicate diagnostic and,
+  when this rule is set to `explicit`, an autofix fight. `enforce-canonical` still handles variable
+  canonicalizations that _aren't_ a plain swap — a value that maps to a named token
+  (`rounded-[var(--radius-sm)]` → `rounded-sm`) or an opacity-modifier form
+  (`text-[var(--color-text)]/90` → `text-(--color-text)/90`).
+- **`no-unnecessary-arbitrary-value`**: mostly disjoint — it converts an arbitrary value to its
+  named equivalent (`bg-[#ff0000]` → `bg-red-500`). They overlap only when a variable's value
+  matches a named utility: on `bg-[var(--color-red-500)]` that rule fires (→ `bg-red-500`) and this
+  one fires too (→ `bg-(--color-red-500)`). The two propose different targets, so enable the one
+  whose policy you want — or run `no-unnecessary-arbitrary-value` first if you prefer the named
+  utility.
 - **`prefer-theme-tokens`**: when a CSS variable matches a `@theme` token, that rule swaps to the
   named utility (`bg-(--primary)` → `bg-primary` if `--primary` is declared in `@theme`). Run that
   one before this one if you want both transforms.

--- a/packages/docs/rules/index.md
+++ b/packages/docs/rules/index.md
@@ -20,8 +20,7 @@ These rules catch problems that would generate invalid or unexpected CSS.
 ## Modernization
 
 - [no-deprecated-classes](./no-deprecated-classes) — `flex-grow` → `grow`, etc.
-- [enforce-canonical](./enforce-canonical) — `-m-0` → `m-0`, `bg-gradient-to-r` → `bg-linear-to-r`,
-  etc.
+- [enforce-canonical](./enforce-canonical) — `-m-0` → `m-0`, `start-2` → `inset-s-2`, etc.
 - [no-unnecessary-arbitrary-value](./no-unnecessary-arbitrary-value) — `w-[100%]` → `w-full` when
   the named class emits identical CSS.
 - [prefer-theme-tokens](./prefer-theme-tokens) — `border-(--border)` → `border-border` when a named
@@ -90,22 +89,22 @@ These work with nothing configured — their fallback is deterministic on its ow
 accurate when an `entryPoint` is available. None of them can emit `designSystemUnavailable`. Each
 also accepts a rule-level `entryPoint` that overrides the shared setting.
 
-| Rule                        | Default options                        | What the design system adds                                  |
-| --------------------------- | -------------------------------------- | ------------------------------------------------------------ |
-| `consistent-variant-order`  | `{}` (DS-derived order when available) | Real variant order, and what each variant's selector does    |
-| `enforce-logical`           | `{ allowlist: [], direction: 'both' }` | Confirms the suggested class exists                          |
-| `enforce-physical`          | `{ allowlist: [], direction: 'both' }` | Confirms the suggested class exists                          |
-| `enforce-shorthand`         | `{}`                                   | Verifies each merge against the emitted CSS                  |
-| `no-contradicting-variants` | `{}`                                   | What each variant's selector does                            |
-| `no-dark-without-light`     | `{ variants: ['dark'] }`               | Groups the base by declared CSS property, not just by prefix |
-| `no-deprecated-classes`     | `{}`                                   | Derives the rename list instead of using the built-in table  |
+| Rule                               | Default options                        | What the design system adds                                                 |
+| ---------------------------------- | -------------------------------------- | --------------------------------------------------------------------------- |
+| `consistent-variant-order`         | `{}` (DS-derived order when available) | Real variant order, and what each variant's selector does                   |
+| `enforce-consistent-line-wrapping` | `{ printWidth: 80, group: 'newLine' }` | The project prefix, so `wrapLines: 'all'` grouping treats it as transparent |
+| `enforce-logical`                  | `{ allowlist: [], direction: 'both' }` | Confirms the suggested class exists                                         |
+| `enforce-physical`                 | `{ allowlist: [], direction: 'both' }` | Confirms the suggested class exists                                         |
+| `enforce-shorthand`                | `{}`                                   | Verifies each merge against the emitted CSS                                 |
+| `no-contradicting-variants`        | `{}`                                   | What each variant's selector does                                           |
+| `no-dark-without-light`            | `{ variants: ['dark'] }`               | Groups the base by declared CSS property, not just by prefix                |
+| `no-deprecated-classes`            | `{}`                                   | Derives the rename list instead of using the built-in table                 |
 
 ### DS-independent rules
 
 | Rule                                    | Default options                 |
 | --------------------------------------- | ------------------------------- |
 | `enforce-consistent-important-position` | `{ position: 'suffix' }`        |
-| `enforce-consistent-line-wrapping`      | `{ printWidth: 80 }`            |
 | `enforce-consistent-variable-syntax`    | `{ syntax: 'shorthand' }`       |
 | `enforce-negative-arbitrary-values`     | (no options)                    |
 | `max-class-count`                       | `{ max: 20 }`                   |

--- a/packages/docs/rules/no-unnecessary-arbitrary-value.md
+++ b/packages/docs/rules/no-unnecessary-arbitrary-value.md
@@ -58,9 +58,11 @@ for the whole project instead of per-rule whenever possible.
 
 - **`enforce-canonical`**: complementary, no double-fire. Both act only when the arbitrary form and
   its named replacement emit **identical** CSS. This rule owns the direct arbitrary→named case
-  (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`); `enforce-canonical` owns
-  canonical renames and CSS-var syntax normalization. The two carve up the arbitrary→named space
-  cleanly.
+  (`h-[auto]` → `h-auto`, `bg-[var(--color-red-500)]` → `bg-red-500`); `enforce-canonical` owns the
+  canonicalizations where the arbitrary maps to a differently-named utility
+  (`rounded-[var(--radius-sm)]` → `rounded-sm`). The two carve up the arbitrary→named space cleanly
+  — and the plain `[var(--x)]` ↔ `(--x)` syntax swap is `enforce-consistent-variable-syntax`'s, not
+  either of theirs.
 - **`prefer-scale-token`**: owns what neither of the above touches — a value that is only
   _numerically_ equal to a scale step or theme token (`p-[2px]` → `p-0.5`), whose CSS text differs
   (`calc(var(--spacing) * 0.5)` vs `2px`). Report-only, off by default.

--- a/packages/oxlint-tailwindcss/CHANGELOG.md
+++ b/packages/oxlint-tailwindcss/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 1.12.0
+
+`enforce-canonical` and `enforce-consistent-variable-syntax` both rewrote the CSS-variable shorthand
+(`bg-[var(--x)]` → `bg-(--x)`, Tailwind's canonical form). With both rules enabled the same class
+produced two identical diagnostics, and under `enforce-consistent-variable-syntax`'s `explicit`
+setting the two autofixes fought each other. Their docs also claimed the rules didn't overlap. This
+release makes `enforce-canonical` cede the plain variable-syntax swap to the dedicated rule — the
+way it already cedes v3 renames to `no-deprecated-classes` — and corrects the documentation across
+the board ([#152](https://github.com/sergioazoc/oxlint-tailwindcss/issues/152), reported by @ftzi).
+
+### Bug fixes
+
+- **`enforce-canonical` no longer reports the pure CSS-variable shorthand swap.** When the only
+  canonicalization of a class would be `x-[var(--v)]` → `x-(--v)`, `enforce-canonical` now stays
+  silent and leaves it to `enforce-consistent-variable-syntax`, the single owner of variable-syntax
+  policy. This removes the duplicate diagnostic when both rules are on, and the autofix oscillation
+  under the dedicated rule's `explicit` mode. `enforce-canonical` still handles variable
+  canonicalizations that aren't a plain swap — a value that maps to a named token
+  (`rounded-[var(--radius-sm)]` → `rounded-sm`) or an opacity-modifier form
+  (`text-[var(--color-text)]/90` → `text-(--color-text)/90`).
+
+### Documentation
+
+- Corrected rule-page and README claims that had drifted from the code: the `enforce-canonical` ↔
+  `enforce-consistent-variable-syntax` overlap (#152); `enforce-canonical` examples that showed v3
+  renames it actually cedes to `no-deprecated-classes`; a false "conflict" between
+  `enforce-consistent-important-position` and `enforce-canonical` (canonical preserves the `!`
+  position you write); `no-deprecated-classes` described as needing no design system (it is
+  DS-optional); the DS-dependent / DS-optional rule lists; and the
+  `enforce-consistent-line-wrapping` default options.
+
 ## 1.11.1
 
 `no-contradicting-variants` flags a variant class as redundant when the same utility already applies

--- a/packages/oxlint-tailwindcss/README.md
+++ b/packages/oxlint-tailwindcss/README.md
@@ -3,7 +3,7 @@
 24 Tailwind CSS linting rules for [oxlint](https://oxc.rs/docs/guide/usage/linter). Built for
 Tailwind CSS v4 with deterministic config, typo suggestions, and autofixes.
 
-> **v1.0.0** — Upgrading from v0.x? See the
+> **v1** — Upgrading from v0.x? See the
 > **[migration guide](https://oxlint-tailwindcss.pages.dev/migration/v0-to-v1)**. The headline
 > change: `settings.tailwindcss.entryPoint` is now required.
 
@@ -222,17 +222,18 @@ Output:
 
 If no entry point is configured, the DS-dependent rules (`no-unknown-classes`,
 `no-conflicting-classes`, `enforce-canonical`, `enforce-sort-order`,
-`no-unnecessary-arbitrary-value`, `prefer-theme-tokens`) emit a single `designSystemUnavailable`
-diagnostic per file with an actionable hint — no more silent skips. `consistent-variant-order`
-tolerates a missing entryPoint (its static fallback is itself deterministic), and
-`no-deprecated-classes` needs no design system at all (it only consults a hardcoded v3→v4 rename
-map). All non-DS rules work without an entry point.
+`no-unnecessary-arbitrary-value`, `prefer-scale-token`, `prefer-theme-tokens`) emit a single
+`designSystemUnavailable` diagnostic per file with an actionable hint — no more silent skips.
+`consistent-variant-order` tolerates a missing entryPoint (its static fallback is itself
+deterministic), and `no-deprecated-classes` tolerates one too — it falls back to a hardcoded v3→v4
+rename map, and derives a richer map from the design system when an entry point is configured. All
+non-DS rules work without an entry point.
 
 ## Custom class detection
 
 By default the plugin detects Tailwind classes in `className`/`class` attributes, 14 utility
-functions (`cn`, `clsx`, `cva`, `tv`, `classed`, etc.), `tw` tagged templates, and variables named
-`className`/`classes`/`style`.
+functions (`cn`, `clsx`, `cva`, `tv`, `classed`, etc.), `tw` tagged templates, and variables whose
+names match `className`/`classNames`/`classes`/`style`/`styles`.
 
 You can extend these defaults via `settings.tailwindcss`. All values are **additive** — your custom
 entries are appended to the built-in defaults:
@@ -715,8 +716,9 @@ Handles variants correctly — the `!` is placed on the utility, not the variant
 | `position` | `"prefix"` \| `"suffix"` | `"suffix"` | Where to place the `!` modifier |
 
 > **Note:** The default is `"suffix"` to match Tailwind CSS v4's canonical form. The prefix form
-> (`!flex`) is deprecated in v4. Using `"prefix"` may conflict with `enforce-canonical`, which also
-> normalizes `!` to the suffix position.
+> (`!flex`) is the v3 spelling. `enforce-canonical` preserves whatever `!` position you write (it
+> does not normalize it), so this rule is the single source of truth for `!` placement and the two
+> never conflict.
 
 **Autofix:** Moves `!` to the correct position.
 
@@ -837,12 +839,14 @@ Warns when a class string exceeds the configured print width or classes-per-line
 
 **Options:**
 
-| Option           | Type     | Default | Description             |
-| ---------------- | -------- | ------- | ----------------------- |
-| `printWidth`     | `number` | `80`    | Max class string length |
-| `classesPerLine` | `number` |         | Max classes per line    |
+| Option           | Type                                  | Default     | Description                                                         |
+| ---------------- | ------------------------------------- | ----------- | ------------------------------------------------------------------- |
+| `printWidth`     | `number`                              | `80`        | Max class string length                                             |
+| `classesPerLine` | `number`                              |             | Max classes per line                                                |
+| `wrapLines`      | `'overWidth' \| 'all'`                |             | Re-wrap lines: only over-width, or always into the canonical layout |
+| `group`          | `'newLine' \| 'emptyLine' \| 'never'` | `'newLine'` | How the `wrapLines: 'all'` layout separates variant groups          |
 
-**Autofix:** Only for `classesPerLine` with template literals.
+**Autofix:** `classesPerLine` and `wrapLines` re-wrap template literals; `printWidth` is warn-only.
 
 ---
 

--- a/packages/oxlint-tailwindcss/package.json
+++ b/packages/oxlint-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-tailwindcss",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Tailwind CSS linting rules for oxlint",
   "keywords": [
     "css",

--- a/packages/oxlint-tailwindcss/src/rules/enforce-canonical.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-canonical.ts
@@ -3,6 +3,7 @@ import { createExtractorVisitors, type ClassLocation } from '../utils/extractors
 import { splitClassesWithSeparators } from '../utils/class-splitter'
 import { reportClassReplacements } from '../utils/report'
 import {
+  convertVarSyntax,
   reattachImportant,
   splitImportant,
   splitUtilityAndVariant,
@@ -123,6 +124,7 @@ export const enforceCanonical = defineRule({
           if (!dynamic) return // worker fatal already reported; stop the check
           for (let k = 0; k < arbitrary.length; k++) {
             const { canonical, safe } = dynamic[k]
+            const idx = arbitraryIdx[k]
             // #78: only rewrite when the canonical form is CSS-value-equivalent.
             // `canonicalizeCandidates` matches an arbitrary literal (e.g.
             // `rounded-[4px]` = `4px`) against the compile-time theme, so it
@@ -130,9 +132,23 @@ export const enforceCanonical = defineRule({
             // `var(--radius-lg)`) that a `:root` override makes NON-equivalent —
             // autofixing that silently corrupts the design. When the emitted CSS
             // isn't byte-identical the conversion is left as the user wrote it.
-            canonicals[arbitraryIdx[k]] = safe
-              ? preserveImportantPosition(arbitrary[k], canonical)
-              : arbitrary[k]
+            if (!safe) {
+              canonicals[idx] = arbitrary[k]
+              continue
+            }
+            const preserved = preserveImportantPosition(arbitrary[k], canonical)
+            // #152: when the ONLY change is the CSS-variable shorthand swap
+            // (`x-[var(--v)]` → `x-(--v)`), cede it to
+            // `enforce-consistent-variable-syntax` — the single owner of
+            // variable-syntax policy — exactly as the deprecated renames above
+            // are ceded to `no-deprecated-classes`. Otherwise both rules report
+            // the same fix, and under that rule's `explicit` mode they fight over
+            // it (autofix oscillation). Value-changing var canonicalizations
+            // (`rounded-[var(--radius-sm)]` → `rounded-sm`) and opacity-modifier
+            // forms (`text-[var(--c)]/90`) are NOT a shorthand swap — the helper
+            // returns null for them — so they stay this rule's business.
+            canonicals[idx] =
+              convertVarSyntax(arbitrary[k], 'shorthand') === preserved ? arbitrary[k] : preserved
           }
         }
 

--- a/packages/oxlint-tailwindcss/src/rules/enforce-consistent-important-position.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-consistent-important-position.ts
@@ -14,7 +14,7 @@ export const enforceConsistentImportantPosition = defineRule({
     type: 'suggestion',
     docs: {
       description:
-        'Enforce consistent position of the important (!) modifier. Default: suffix (Tailwind v4 canonical form). Note: using "prefix" may conflict with enforce-canonical which normalizes to suffix.',
+        'Enforce consistent position of the important (!) modifier. Default: suffix (Tailwind v4 canonical form). This rule is the single source of truth for ! placement — enforce-canonical preserves the position you wrote, so the two never conflict.',
     },
     fixable: 'code',
     schema: [

--- a/packages/oxlint-tailwindcss/src/rules/enforce-consistent-variable-syntax.ts
+++ b/packages/oxlint-tailwindcss/src/rules/enforce-consistent-variable-syntax.ts
@@ -2,36 +2,11 @@ import { defineRule } from '@oxlint/plugins'
 import { createExtractorVisitors, type ClassLocation } from '../utils/extractors'
 import { splitClassesWithSeparators } from '../utils/class-splitter'
 import { reportClassReplacements } from '../utils/report'
-import { reattachImportant, splitImportant, splitUtilityAndVariant } from '../utils/class-parser'
+import { convertVarSyntax } from '../utils/class-parser'
 import { createLazyOptions } from '../utils/context'
 
 interface Options {
   syntax?: 'shorthand' | 'explicit'
-}
-
-// Match bg-[var(--something)] — simple var() wrapping a single CSS variable
-const EXPLICIT_VAR_RE = /^([a-z][a-z0-9-]*(?:-[a-z0-9]+)*)-\[var\((--[a-zA-Z0-9-]+)\)\]$/
-// Match bg-(--something) — shorthand v4 syntax
-const SHORTHAND_VAR_RE = /^([a-z][a-z0-9-]*(?:-[a-z0-9]+)*)-\((--[a-zA-Z0-9-]+)\)$/
-
-function convertClass(cls: string, syntax: 'shorthand' | 'explicit'): string | null {
-  const { utility, variant } = splitUtilityAndVariant(cls)
-  const { bare: bareUtility, position } = splitImportant(utility)
-
-  if (syntax === 'shorthand') {
-    const match = EXPLICIT_VAR_RE.exec(bareUtility)
-    if (match) {
-      const [, prefix, varName] = match
-      return `${variant}${reattachImportant(`${prefix}-(${varName})`, position)}`
-    }
-  } else {
-    const match = SHORTHAND_VAR_RE.exec(bareUtility)
-    if (match) {
-      const [, prefix, varName] = match
-      return `${variant}${reattachImportant(`${prefix}-[var(${varName})]`, position)}`
-    }
-  }
-  return null
 }
 
 export const enforceConsistentVariableSyntax = defineRule({
@@ -72,7 +47,7 @@ export const enforceConsistentVariableSyntax = defineRule({
       for (const loc of locations) {
         const split = splitClassesWithSeparators(loc.value)
         const offending = split.classes.flatMap((cls) => {
-          const converted = convertClass(cls, syntax)
+          const converted = convertVarSyntax(cls, syntax)
           return converted ? [{ cls, replacement: converted }] : []
         })
         reportClassReplacements(context, loc, split, split.classes, offending, { messageId })

--- a/packages/oxlint-tailwindcss/src/utils/class-parser.ts
+++ b/packages/oxlint-tailwindcss/src/utils/class-parser.ts
@@ -221,6 +221,44 @@ export function reattachImportant(bare: string, position: ImportantPosition): st
   return bare
 }
 
+// Match `bg-[var(--something)]` — explicit var() wrapping a single CSS variable.
+const EXPLICIT_VAR_RE = /^([a-z][a-z0-9-]*(?:-[a-z0-9]+)*)-\[var\((--[a-zA-Z0-9-]+)\)\]$/
+// Match `bg-(--something)` — the Tailwind v4 shorthand.
+const SHORTHAND_VAR_RE = /^([a-z][a-z0-9-]*(?:-[a-z0-9]+)*)-\((--[a-zA-Z0-9-]+)\)$/
+
+/**
+ * Convert a class between the two CSS-variable syntaxes:
+ * `bg-[var(--x)]` (explicit) ↔ `bg-(--x)` (shorthand). Returns the converted
+ * class, or `null` when it isn't a simple single-variable utility.
+ *
+ * Deliberately narrow — it matches ONLY the bare-bracket form, so compound
+ * expressions (`bg-[color-mix(...)]`) and opacity-modifier forms
+ * (`text-[var(--c)]/90`, whose trailing `/90` fails the `$` anchor) return
+ * `null`. Variants and `!` position round-trip via `splitUtilityAndVariant` /
+ * `splitImportant`. This is the single set of classes over which
+ * `enforce-consistent-variable-syntax` (which owns the policy) and
+ * `enforce-canonical` (which cedes it) overlap, so both consume this one helper.
+ */
+export function convertVarSyntax(cls: string, syntax: 'shorthand' | 'explicit'): string | null {
+  const { utility, variant } = splitUtilityAndVariant(cls)
+  const { bare: bareUtility, position } = splitImportant(utility)
+
+  if (syntax === 'shorthand') {
+    const match = EXPLICIT_VAR_RE.exec(bareUtility)
+    if (match) {
+      const [, prefix, varName] = match
+      return `${variant}${reattachImportant(`${prefix}-(${varName})`, position)}`
+    }
+  } else {
+    const match = SHORTHAND_VAR_RE.exec(bareUtility)
+    if (match) {
+      const [, prefix, varName] = match
+      return `${variant}${reattachImportant(`${prefix}-[var(${varName})]`, position)}`
+    }
+  }
+  return null
+}
+
 /**
  * What a variant does to the selector, as reported by the design system.
  *

--- a/packages/oxlint-tailwindcss/tests/integration/enforce-canonical-variable-syntax-coexistence.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/enforce-canonical-variable-syntax-coexistence.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `enforce-canonical` vs `enforce-consistent-variable-syntax` (#152).
+ *
+ * `bg-[var(--x)]` is sugar for `bg-(--x)`. `canonicalizeCandidates` returns the
+ * shorthand as the canonical form, so `enforce-canonical` used to report that
+ * swap too — the exact fix `enforce-consistent-variable-syntax` produces. Both
+ * fired on the same class (a duplicate diagnostic), and under the dedicated
+ * rule's `explicit` setting the two autofixes fought each other (oscillation).
+ *
+ * #152 makes `enforce-canonical` CEDE the pure bracket↔paren swap to
+ * `enforce-consistent-variable-syntax` — the single owner of variable-syntax
+ * policy — the same way it already cedes the v3 renames to `no-deprecated-classes`.
+ *
+ * What canonical KEEPS (the dedicated rule's regex doesn't match these, so there
+ * is no overlap to cede): value-changing canonicalizations
+ * (`rounded-[var(--radius-sm)]` → `rounded-sm`) and opacity-modifier forms
+ * (`text-[var(--color-text)]/90` → `text-(--color-text)/90`).
+ */
+
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe } from 'vitest'
+import { makeFixtureRunner } from '../utils/with-fixture'
+import { enforceCanonical } from '../../src/rules/enforce-canonical'
+import { enforceConsistentVariableSyntax } from '../../src/rules/enforce-consistent-variable-syntax'
+import { getLoadedDesignSystem, resetDesignSystem } from '../../src/design-system/loader'
+import { resetCanonicalizeService } from '../../src/design-system/canonicalize-service'
+
+const DEFAULT_FIXTURE = resolve(__dirname, '../fixtures/default.css')
+const SHADCN_FIXTURE = resolve(__dirname, '../fixtures/shadcn.css')
+
+describe('enforce-canonical ↔ enforce-consistent-variable-syntax (#152)', () => {
+  const run = makeFixtureRunner(DEFAULT_FIXTURE)
+  beforeAll(() => {
+    resetDesignSystem()
+    resetCanonicalizeService()
+    getLoadedDesignSystem(DEFAULT_FIXTURE)
+  })
+  afterAll(() => {
+    resetDesignSystem()
+    resetCanonicalizeService()
+  })
+
+  // enforce-canonical CEDES the pure syntax swap, but KEEPS token/opacity cases.
+  run('enforce-canonical cedes the var-syntax swap', enforceCanonical, {
+    valid: [
+      // The #152 inputs — canonical is now silent (dedicated rule owns them).
+      { code: '<div className="bg-[var(--custom-color)]" />', filename: 'test.tsx' },
+      { code: '<div className="w-[var(--custom-width)]" />', filename: 'test.tsx' },
+      {
+        code: '<div className="bg-[var(--custom-color)] w-[var(--custom-width)]" />',
+        filename: 'test.tsx',
+      },
+      // Already shorthand — nothing to do either way.
+      { code: '<div className="bg-(--custom-color)" />', filename: 'test.tsx' },
+    ],
+    invalid: [
+      // Opacity-modifier form is NOT a plain swap (the dedicated rule's regex
+      // won't match `/90`), so canonical still owns it.
+      {
+        code: '<div className="text-[var(--color-text)]/90" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'nonCanonical' }],
+        output: '<div className="text-(--color-text)/90" />',
+      },
+    ],
+  })
+
+  // The dedicated rule OWNS the swap, in both directions.
+  run('variable-syntax owns the swap (shorthand)', enforceConsistentVariableSyntax, {
+    valid: [{ code: '<div className="bg-(--custom-color)" />', filename: 'test.tsx' }],
+    invalid: [
+      {
+        code: '<div className="bg-[var(--custom-color)]" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'useShorthand' }],
+        output: '<div className="bg-(--custom-color)" />',
+      },
+    ],
+  })
+
+  // `explicit` mode: no oscillation. The dedicated rule pushes shorthand →
+  // explicit; enforce-canonical no longer pushes the other way, so `bg-[var()]`
+  // is a stable fixed point instead of a fight.
+  run('variable-syntax owns the swap (explicit)', enforceConsistentVariableSyntax, {
+    valid: [
+      {
+        code: '<div className="bg-[var(--custom-color)]" />',
+        filename: 'test.tsx',
+        options: [{ syntax: 'explicit' }],
+      },
+    ],
+    invalid: [
+      {
+        code: '<div className="bg-(--custom-color)" />',
+        filename: 'test.tsx',
+        options: [{ syntax: 'explicit' }],
+        errors: [{ messageId: 'useExplicit' }],
+        output: '<div className="bg-[var(--custom-color)]" />',
+      },
+    ],
+  })
+})
+
+// Value-changing canonicalization (bracket → named TOKEN) is not a syntax swap,
+// so canonical keeps owning it even when the value is a var reference.
+describe('enforce-canonical keeps var→token (#152, shadcn theme)', () => {
+  const run = makeFixtureRunner(SHADCN_FIXTURE)
+  beforeAll(() => {
+    resetDesignSystem()
+    resetCanonicalizeService()
+    getLoadedDesignSystem(SHADCN_FIXTURE)
+  })
+  afterAll(() => {
+    resetDesignSystem()
+    resetCanonicalizeService()
+  })
+
+  run('enforce-canonical (shadcn theme)', enforceCanonical, {
+    valid: [
+      // Pure syntax swap is ceded here too.
+      { code: '<div className="border-[var(--border)]" />', filename: 'test.tsx' },
+    ],
+    invalid: [
+      // Named-token change (different utility name) stays with canonical.
+      {
+        code: '<div className="rounded-[var(--radius-sm)]" />',
+        filename: 'test.tsx',
+        errors: [{ messageId: 'nonCanonical' }],
+        output: '<div className="rounded-sm" />',
+      },
+    ],
+  })
+})

--- a/packages/oxlint-tailwindcss/tests/integration/prefer-theme-tokens-coexistence.test.ts
+++ b/packages/oxlint-tailwindcss/tests/integration/prefer-theme-tokens-coexistence.test.ts
@@ -14,9 +14,8 @@
  *   │ rounded-[var(--radius-sm)] │ fires    │ fires       │ silent     │ (a)
  *   │ rounded-(--radius-sm)      │ fires    │ silent      │ silent     │ (b)
  *   │ bg-(--red-500)             │ silent   │ silent      │ fires      │ (c)
- *   │ bg-[var(--red-500)]        │ fires*   │ silent      │ fires      │ (d)
+ *   │ bg-[var(--red-500)]        │ silent   │ silent      │ fires      │ (d)
  *   └────────────────────────────┴──────────┴─────────────┴────────────┘
- *   *enforce-canonical only changes the bracket→paren syntax.
  *
  *   (a) Bracket form CSS-equivalent to the named utility — both canon and
  *       no-unnec produce `rounded-sm`. prefer-theme-tokens stays silent
@@ -26,8 +25,9 @@
  *       the same reason as (a).
  *   (c) Raw variable matching utility suffix — only prefer-theme-tokens catches
  *       it (canonicalizeCandidates only resolves theme-token names).
- *   (d) Bracket form of (c) — canonicalizeCandidates rewrites the syntax,
- *       prefer-theme-tokens rewrites to the named utility directly.
+ *   (d) Bracket form of (c) — canon's only change would be the bracket→paren
+ *       syntax, which #152 CEDES to enforce-consistent-variable-syntax, so canon
+ *       is silent; prefer-theme-tokens rewrites to the named utility directly.
  *
  * Theme-token matrix where `--color-X` exposes the raw variable directly
  * (e.g. `@theme inline { --color-border: var(--border); }`, no wrapping
@@ -37,13 +37,14 @@
  *   │ input                      │ canon    │ no-unnec    │ prefer-tt  │
  *   ├────────────────────────────┼──────────┼─────────────┼────────────┤
  *   │ border-(--border)          │ silent   │ silent      │ fires      │
- *   │ border-[var(--border)]     │ fires*   │ fires       │ silent     │
+ *   │ border-[var(--border)]     │ silent   │ fires       │ silent     │
  *   │ border-(--no-such-var)     │ silent   │ silent      │ silent     │
  *   └────────────────────────────┴──────────┴─────────────┴────────────┘
- *   *Only the bracket→paren syntax change. no-unnec fires because the
- *   bracket form is CSS-equivalent to border-border (both compile to
- *   `border-color: var(--border)`). prefer-tt stays silent on the bracket
- *   form thanks to its getNamedEquivalent guard — no-unnec owns it.
+ *   canon's only change would be the bracket→paren syntax, which #152 CEDES to
+ *   enforce-consistent-variable-syntax, so canon is silent here. no-unnec fires
+ *   because the bracket form is CSS-equivalent to border-border (both compile to
+ *   `border-color: var(--border)`). prefer-tt stays silent on the bracket form
+ *   thanks to its getNamedEquivalent guard — no-unnec owns it.
  */
 
 import { resolve } from 'node:path'
@@ -79,6 +80,10 @@ describe('prefer-theme-tokens coexistence (default theme)', () => {
       { code: '<div className="bg-red-500" />', filename: 'test.tsx' },
       // Variable name does not match a theme token — left as-is
       { code: '<div className="bg-(--red-500)" />', filename: 'test.tsx' },
+      // #152: bracket form whose only canonicalization is the syntax swap
+      // (`bg-[var(--red-500)]` → `bg-(--red-500)`) is CEDED to
+      // enforce-consistent-variable-syntax — enforce-canonical stays silent (d).
+      { code: '<div className="bg-[var(--red-500)]" />', filename: 'test.tsx' },
     ],
     invalid: [
       // Theme-token bracket → named (a)
@@ -94,13 +99,6 @@ describe('prefer-theme-tokens coexistence (default theme)', () => {
         filename: 'test.tsx',
         errors: [{ messageId: 'nonCanonical' }],
         output: '<div className="rounded-sm" />',
-      },
-      // Non-theme-token bracket → only the syntax canonicalizes (d)
-      {
-        code: '<div className="bg-[var(--red-500)]" />',
-        filename: 'test.tsx',
-        errors: [{ messageId: 'nonCanonical' }],
-        output: '<div className="bg-(--red-500)" />',
       },
     ],
   })
@@ -166,20 +164,16 @@ describe('prefer-theme-tokens coexistence (shadcn-style theme)', () => {
   // ── enforce-canonical ────────────────────────────────────────────
   // With this fixture, `--border` is NOT itself a theme token (`--color-border`
   // is, and it points to `--border`). canonicalizeCandidates therefore only
-  // changes the bracket→paren syntax — it does not produce border-border.
+  // changes the bracket→paren syntax — it does not produce border-border. #152:
+  // that pure syntax swap is CEDED to enforce-consistent-variable-syntax, so
+  // enforce-canonical stays silent on every form here.
   run('enforce-canonical (shadcn theme)', enforceCanonical, {
     valid: [
       { code: '<div className="border-(--border)" />', filename: 'test.tsx' },
       { code: '<div className="border-border" />', filename: 'test.tsx' },
+      { code: '<div className="border-[var(--border)]" />', filename: 'test.tsx' },
     ],
-    invalid: [
-      {
-        code: '<div className="border-[var(--border)]" />',
-        filename: 'test.tsx',
-        errors: [{ messageId: 'nonCanonical' }],
-        output: '<div className="border-(--border)" />',
-      },
-    ],
+    invalid: [],
   })
 
   // ── no-unnecessary-arbitrary-value ──────────────────────────────
@@ -219,17 +213,19 @@ describe('prefer-theme-tokens coexistence (shadcn-style theme)', () => {
 
 // Convergence property
 // ─────────────────────
-// Both rules + enforce-canonical converge on `border-border` regardless of
-// which fix oxlint applies first:
+// The rules still converge on `border-border` regardless of which fix oxlint
+// applies first:
 //
 //   border-[var(--border)]
 //     → no-unnec → border-border  (single step)
-//     → enforce-canonical → border-(--border) → prefer-tt → border-border
+//     → enforce-consistent-variable-syntax → border-(--border) → prefer-tt → border-border
 //
-// The valid/invalid blocks above lock down each rule's behavior on both the
-// intermediate (`border-(--border)`) and the input (`border-[var(--border)]`)
-// shapes, so any future regression that breaks convergence will fail one of
-// those test cases.
+// #152: enforce-canonical no longer produces the intermediate `border-(--border)`
+// (it cedes the bracket→paren syntax to enforce-consistent-variable-syntax), so
+// that step now belongs to the dedicated rule. The valid/invalid blocks above
+// lock down each rule's behavior on both the intermediate (`border-(--border)`)
+// and the input (`border-[var(--border)]`) shapes, so any future regression that
+// breaks convergence will fail one of those test cases.
 
 /**
  * The fourth rule joins on a premise none of the other three can host.


### PR DESCRIPTION
Closes #152.

## Behavior change (minor → 1.12.0)

`enforce-canonical` and `enforce-consistent-variable-syntax` both rewrote the CSS-variable shorthand (`bg-[var(--x)]` → `bg-(--x)`, Tailwind's canonical form). With both rules on, the same class produced **two identical diagnostics**, and under the dedicated rule's `explicit` mode the two autofixes **contradicted each other** (oscillation). Their docs also claimed the rules didn't overlap.

`enforce-canonical` now **cedes** the plain `[var(--x)]` ↔ `(--x)` swap to `enforce-consistent-variable-syntax` — the single owner of variable-syntax policy — the same way it already cedes v3 renames to `no-deprecated-classes`. It still handles the var canonicalizations that aren't a plain swap: value→token (`rounded-[var(--radius-sm)]` → `rounded-sm`) and opacity-modifier forms (`text-[var(--color-text)]/90`).

- Shared helper `convertVarSyntax` extracted to `utils/class-parser.ts` (consumed by both rules).
- New coexistence test locks the cede + the `explicit`-mode no-conflict; updated the `prefer-theme-tokens` coexistence matrix.

## Documentation truthfulness sweep

Audited README, CLAUDE.md and all 24 rule pages (EN/ES) against the code and fixed every claim that had drifted:

- The #152 overlap claim; `enforce-canonical` examples showing v3 renames it actually cedes; a false "conflict" between `enforce-consistent-important-position` and `enforce-canonical` (canonical preserves the `!` position); `no-deprecated-classes` described as needing no design system (it's DS-optional); DS-dependent/DS-optional rule lists (now 7/8/9, code-accurate); missing `group`/`wrapLines` options; `Tailwind v4` → `v4.1+`.

## Spanish docs neutralized

Removed all voseo and marked Spanglish (`matchea`→`coincide con`, `setea`→`configura`, `mergear`→`fusionar`, `custom`→`personalizado`, …), keeping standard technical terms (`default`, `entry point`, `override`, `linter`, `opt-in`, `prefix`). Verified EN↔ES parity — fixed real content divergences (ES pages that described older rule versions or omitted paragraphs).

## Verification

typecheck ✓ · lint ✓ · format:check ✓ · **1941 tests pass** ✓ · docs `generate` idempotent ✓ · EN↔ES structural parity 24/24 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)